### PR TITLE
Make private URL distribution e-mails customisable

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -34,6 +34,10 @@ Getting started with development
 
     $ pip install -r 'requirements_development.txt'
 
+- The email backend should be changed in ``local_settings.py`` to display sent messages in ``STDOUT``, not by real email. Insert::
+
+    EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+
 Style guide
 ===========
 

--- a/tabbycat/privateurls/forms.py
+++ b/tabbycat/privateurls/forms.py
@@ -1,0 +1,32 @@
+from django import forms
+
+from django.utils.translation import gettext as _
+
+
+class EmailBodyField(forms.CharField):
+
+    label = _("Message")
+    required = True
+    widget = forms.Textarea
+    help_text = _(
+        "Use '%name' and '%url' as placeholders for the judge's name and their private URL"
+        ", respectively in the message body.")
+
+    def validate(self, value):
+        super(EmailBodyField, self).validate(value)
+
+        # Check if includes URL variable
+        if '%url' not in value:
+            raise forms.ValidationError(_("'%url' must be present in the email body"))
+
+
+class MassBallotEmailForm(forms.Form):
+    subject_line = forms.CharField(label=_("Subject"), required=True, max_length=78)
+    message_body = EmailBodyField()
+
+
+class MassFeedbackEmailForm(forms.Form):
+    team_subject = forms.CharField(label=_("Subject for team emails"), required=True, max_length=78)
+    team_message = EmailBodyField()
+    judge_subject = forms.CharField(label=_("Subject for judge emails"), required=True, max_length=78)
+    judge_message = EmailBodyField()

--- a/tabbycat/privateurls/templates/ballot_urls_email_list.html
+++ b/tabbycat/privateurls/templates/ballot_urls_email_list.html
@@ -44,11 +44,40 @@
 
   {{ block.super }}
 
-  <form action="{% tournamenturl 'privateurls-email-ballot-send' %}" method="POST" class="mb-3">
-    {% csrf_token %}
-    <button class="btn btn-success btn-block" type="submit">
-      {% trans "Send emails with private ballot URLs to adjudicators" %}
-    </button>
-  </form>
+  <div class="card">
+    <div class="card-body">
+      <h4 class="card-title">{% trans "Email message" %}</h4>
+    </div>
+    <div class="list-group list-group-flush">
+      <form action="{% tournamenturl 'privateurls-email-ballot-send' %}" method="POST" class="mb-3">
+        {% csrf_token %}
+        <div class="list-group-item">
+          <div class="form-group">
+            <label for="id_subject">{% trans "Subject line" %}</label>
+            <input type="text" name="subject" id="id_subject" class="form-control" value="{% blocktrans trimmed %}Your personal ballot submission URL for {{ tournament }}{% endblocktrans %}">
+          </div>
+          <div class="form-group">
+            <label for="id_message">{% trans "Message content" %}</label>
+            <textarea id="id_message" name="message" cols="40" rows="10" class="form-control">
+{% blocktrans %}Hi %name,
+
+At {{ tournament }}, we are using an online ballot system. You can submit your ballots at the following URL. This URL is unique to you — do not share it with anyone, as anyone who knows it can submit ballots on your behalf. This URL will not change throughout this tournament, so we suggest bookmarking it.
+
+Your personal private ballot submission URL is:
+%url{% endblocktrans %}
+            </textarea>
+            <div class="text-center small text-muted">
+              {% blocktrans trimmed %}Use '%name' and '%url' as placeholders for the judge's name and their private URL, respectively in the message body.{% endblocktrans %}
+            </div>
+          </div>
+        </div>
+        <div class="list-group-item">
+          <button class="btn btn-success btn-block" type="submit">
+            {% trans "Send emails with private ballot URLs to adjudicators" %}
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
 
 {% endblock content %}

--- a/tabbycat/privateurls/templates/ballot_urls_email_list.html
+++ b/tabbycat/privateurls/templates/ballot_urls_email_list.html
@@ -49,27 +49,15 @@
       <h4 class="card-title">{% trans "Email message" %}</h4>
     </div>
     <div class="list-group list-group-flush">
-      <form action="{% tournamenturl 'privateurls-email-ballot-send' %}" method="POST" class="mb-3">
+      <form method="POST" class="mb-3">
         {% csrf_token %}
         <div class="list-group-item">
+          {{ form.non_field_errors }}
+          {% for field in form.visible_fields %}
           <div class="form-group">
-            <label for="id_subject">{% trans "Subject line" %}</label>
-            <input type="text" name="subject" id="id_subject" class="form-control" value="{% blocktrans trimmed %}Your personal ballot submission URL for {{ tournament }}{% endblocktrans %}">
+            {% include "components/form-field.html" %}
           </div>
-          <div class="form-group">
-            <label for="id_message">{% trans "Message content" %}</label>
-            <textarea id="id_message" name="message" cols="40" rows="10" class="form-control">
-{% blocktrans %}Hi %name,
-
-At {{ tournament }}, we are using an online ballot system. You can submit your ballots at the following URL. This URL is unique to you — do not share it with anyone, as anyone who knows it can submit ballots on your behalf. This URL will not change throughout this tournament, so we suggest bookmarking it.
-
-Your personal private ballot submission URL is:
-%url{% endblocktrans %}
-            </textarea>
-            <div class="text-center small text-muted">
-              {% blocktrans trimmed %}Use '%name' and '%url' as placeholders for the judge's name and their private URL, respectively in the message body.{% endblocktrans %}
-            </div>
-          </div>
+          {% endfor %}
         </div>
         <div class="list-group-item">
           <button class="btn btn-success btn-block" type="submit">

--- a/tabbycat/privateurls/templates/feedback_urls_email_list.html
+++ b/tabbycat/privateurls/templates/feedback_urls_email_list.html
@@ -59,11 +59,60 @@
 
   {{ block.super }}
 
-  <form action="{% tournamenturl 'privateurls-email-feedback-send' %}" method="POST" class="mb-3">
-    {% csrf_token %}
-    <button class="btn btn-success btn-block" type="submit">
-      {% trans "Send emails with private feedback URLs to speakers and adjudicators" %}
-    </button>
-  </form>
+  <div class="card">
+    <div class="card-body">
+      <h4 class="card-title">{% trans "Email message" %}</h4>
+    </div>
+    <div class="list-group list-group-flush">
+      <form action="{% tournamenturl 'privateurls-email-feedback-send' %}" method="POST" class="mb-3">
+        {% csrf_token %}
+        <div class="list-group-item">
+          <div class="form-group">
+            <label for="id_subject_teams">{% trans "Subject line for teams" %}</label>
+            <input type="text" name="subject_teams" id="id_subject_teams" class="form-control" value="{% blocktrans trimmed %}Your team's feedback submission URL for {{ tournament }}{% endblocktrans %}">
+          </div>
+          <div class="form-group">
+            <label for="id_message_teams">{% trans "Message content" %}</label>
+            <textarea id="id_message_teams" name="message_teams" cols="40" rows="10" class="form-control">
+{% blocktrans %}Hi %name,
+
+At {{ tournament }}, we are using an online adjudicator feedback system. As part of %team, you can submit your feedback at the following URL. This URL is unique to you — do not share it with anyone, as anyone who knows it can submit feedback on your team's behalf. This URL will not change throughout this tournament, so we suggest bookmarking it.
+
+Your team's private feedback submission URL is:
+%url{% endblocktrans %}
+            </textarea>
+            <div class="text-center small text-muted">
+              {% blocktrans trimmed %}Use '%name', '%team', and '%url' as placeholders for the debater's name, their team, and their private URL, respectively in the message body.{% endblocktrans %}
+            </div>
+          </div>
+        </div>
+        <div class="list-group-item">
+          <div class="form-group">
+            <label for="id_subject_judges">{% trans "Subject line for judges" %}</label>
+            <input type="text" name="subject_judges" id="id_subject_judges" class="form-control" value="{% blocktrans trimmed %}Your personal feedback submission URL for {{ tournament }}{% endblocktrans %}">
+          </div>
+          <div class="form-group">
+            <label for="id_message_judges">{% trans "Message content" %}</label>
+            <textarea id="id_message_judges" name="message_judges" cols="40" rows="10" class="form-control">
+{% blocktrans %}Hi %name,
+
+At {{ tournament }}, we are using an online adjudicator feedback system. You can submit your feedback at the following URL. This URL is unique to you — do not share it with anyone, as anyone who knows it can submit feedback on your behalf. This URL will not change throughout this tournament, so we suggest bookmarking it.
+
+Your personal private feedback submission URL is:
+%url{% endblocktrans %}
+            </textarea>
+            <div class="text-center small text-muted">
+              {% blocktrans trimmed %}Use '%name' and '%url' as placeholders for the judge's name and their private URL, respectively in the message body.{% endblocktrans %}
+            </div>
+          </div>
+        </div>
+        <div class="list-group-item">
+          <button class="btn btn-success btn-block" type="submit">
+            {% trans "Send emails with private ballot URLs to adjudicators" %}
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
 
 {% endblock content %}

--- a/tabbycat/privateurls/templates/feedback_urls_email_list.html
+++ b/tabbycat/privateurls/templates/feedback_urls_email_list.html
@@ -64,47 +64,14 @@
       <h4 class="card-title">{% trans "Email message" %}</h4>
     </div>
     <div class="list-group list-group-flush">
-      <form action="{% tournamenturl 'privateurls-email-feedback-send' %}" method="POST" class="mb-3">
-        {% csrf_token %}
-        <div class="list-group-item">
+      <form method="POST" class="mb-3">
+        {% csrf_token %}<div class="list-group-item">
+          {{ form.non_field_errors }}
+          {% for field in form.visible_fields %}
           <div class="form-group">
-            <label for="id_subject_teams">{% trans "Subject line for teams" %}</label>
-            <input type="text" name="subject_teams" id="id_subject_teams" class="form-control" value="{% blocktrans trimmed %}Your team's feedback submission URL for {{ tournament }}{% endblocktrans %}">
+            {% include "components/form-field.html" %}
           </div>
-          <div class="form-group">
-            <label for="id_message_teams">{% trans "Message content" %}</label>
-            <textarea id="id_message_teams" name="message_teams" cols="40" rows="10" class="form-control">
-{% blocktrans %}Hi %name,
-
-At {{ tournament }}, we are using an online adjudicator feedback system. As part of %team, you can submit your feedback at the following URL. This URL is unique to you — do not share it with anyone, as anyone who knows it can submit feedback on your team's behalf. This URL will not change throughout this tournament, so we suggest bookmarking it.
-
-Your team's private feedback submission URL is:
-%url{% endblocktrans %}
-            </textarea>
-            <div class="text-center small text-muted">
-              {% blocktrans trimmed %}Use '%name', '%team', and '%url' as placeholders for the debater's name, their team, and their private URL, respectively in the message body.{% endblocktrans %}
-            </div>
-          </div>
-        </div>
-        <div class="list-group-item">
-          <div class="form-group">
-            <label for="id_subject_judges">{% trans "Subject line for judges" %}</label>
-            <input type="text" name="subject_judges" id="id_subject_judges" class="form-control" value="{% blocktrans trimmed %}Your personal feedback submission URL for {{ tournament }}{% endblocktrans %}">
-          </div>
-          <div class="form-group">
-            <label for="id_message_judges">{% trans "Message content" %}</label>
-            <textarea id="id_message_judges" name="message_judges" cols="40" rows="10" class="form-control">
-{% blocktrans %}Hi %name,
-
-At {{ tournament }}, we are using an online adjudicator feedback system. You can submit your feedback at the following URL. This URL is unique to you — do not share it with anyone, as anyone who knows it can submit feedback on your behalf. This URL will not change throughout this tournament, so we suggest bookmarking it.
-
-Your personal private feedback submission URL is:
-%url{% endblocktrans %}
-            </textarea>
-            <div class="text-center small text-muted">
-              {% blocktrans trimmed %}Use '%name' and '%url' as placeholders for the judge's name and their private URL, respectively in the message body.{% endblocktrans %}
-            </div>
-          </div>
+          {% endfor %}
         </div>
         <div class="list-group-item">
           <button class="btn btn-success btn-block" type="submit">

--- a/tabbycat/privateurls/urls.py
+++ b/tabbycat/privateurls/urls.py
@@ -14,15 +14,9 @@ urlpatterns = [
     path('email/ballot/',
         views.EmailBallotUrlsView.as_view(),
         name='privateurls-email-ballot'),
-    path('email/ballot/confirm/',
-        views.ConfirmEmailBallotUrlsView.as_view(),
-        name='privateurls-email-ballot-send'),
 
     path('email/feedback/',
         views.EmailFeedbackUrlsView.as_view(),
         name='privateurls-email-feedback'),
-    path('email/feedback/confirm/',
-        views.ConfirmEmailFeedbackUrlsView.as_view(),
-        name='privateurls-email-feedback-send'),
 
 ]

--- a/tabbycat/privateurls/utils.py
+++ b/tabbycat/privateurls/utils.py
@@ -54,13 +54,10 @@ def send_randomised_url_emails(request, tournament, queryset, url_name, url_key_
         path = reverse_tournament(url_name, tournament, kwargs={'url_key': url_key})
         url = request.build_absolute_uri(path)
 
-        formatted_subject = subject % {'tournament': tournament.short_name}
-        formatted_message = message % {
-            'name': instance.name,
-            'tournament': tournament.short_name,
-            'team': instance.team.short_name if hasattr(instance, 'team') else None,
-            'url': url,
-        }
+        formatted_subject = subject
+        formatted_message = message.replace('%name', instance.name).replace('%url', url)
+        if hasattr(instance, 'team'):
+            formatted_message = formatted_message.replace('%team', instance.team.short_name)
 
         messages.append((formatted_subject, formatted_message, settings.DEFAULT_FROM_EMAIL, [email]))
 

--- a/tabbycat/privateurls/views.py
+++ b/tabbycat/privateurls/views.py
@@ -187,6 +187,7 @@ class EmailBallotUrlsView(BaseEmailRandomisedUrlsView):
     def get_context_data(self, **kwargs):
         kwargs['nadjudicators_already_sent'] = self.get_adjudicators_to_email(
             PrivateUrlSentMailRecord.URL_TYPE_BALLOT, already_sent=True).count()
+        kwargs['tournament'] = self.tournament
         return super().get_context_data(**kwargs)
 
     def get_table(self):
@@ -207,6 +208,7 @@ class EmailFeedbackUrlsView(BaseEmailRandomisedUrlsView):
         kwargs['nadjudicators_already_sent'] = self.get_adjudicators_to_email(
             PrivateUrlSentMailRecord.URL_TYPE_FEEDBACK, already_sent=True).count()
         kwargs['nspeakers_already_sent'] = self.get_speakers_to_email(already_sent=True).count()
+        kwargs['tournament'] = self.tournament
         return super().get_context_data(**kwargs)
 
     def get_speakers_table(self):
@@ -252,16 +254,8 @@ class ConfirmEmailBallotUrlsView(BaseConfirmEmailRandomisedUrlsView):
 
         tournament = self.tournament
 
-        subject = _("Your personal ballot submission URL for %(tournament)s")
-        message = _(
-            "Hi %(name)s,\n\n"
-            "At %(tournament)s, we are using an online ballot system. You can submit "
-            "your ballots at the following URL. This URL is unique to you — do not share it with "
-            "anyone, as anyone who knows it can submit ballots on your behalf. This URL "
-            "will not change throughout this tournament, so we suggest bookmarking it.\n\n"
-            "Your personal private ballot submission URL is:\n"
-            "%(url)s"
-        )
+        subject = request.POST['subject']
+        message = request.POST['message']
         adjudicators = self.get_adjudicators_to_email(PrivateUrlSentMailRecord.URL_TYPE_BALLOT)
 
         try:
@@ -295,17 +289,8 @@ class ConfirmEmailFeedbackUrlsView(BaseConfirmEmailRandomisedUrlsView):
         tournament = self.tournament
         success = True
 
-        subject = _("Your team's feedback submission URL for %(tournament)s")
-        message = _(
-            "Hi %(name)s,\n\n"
-            "At %(tournament)s, we are using an online adjudicator feedback system. As part of "
-            "%(team)s, you can submit your feedback at the following URL. This URL is unique "
-            "to you — do not share it with anyone, as anyone who knows it can submit feedback on "
-            "your team's behalf. This URL will not change throughout this tournament, so we "
-            "suggest bookmarking it.\n\n"
-            "Your team's private feedback submission URL is:\n"
-            "%(url)s"
-        )
+        subject = request.POST['subject_teams']
+        message = request.POST['message_teams']
         speakers = self.get_speakers_to_email()
 
         try:
@@ -325,16 +310,8 @@ class ConfirmEmailFeedbackUrlsView(BaseConfirmEmailRandomisedUrlsView):
             ) % {'error': str(e)})
             success = False
 
-        subject = _("Your personal feedback submission URL for %(tournament)s")
-        message = _(
-            "Hi %(name)s,\n\n"
-            "At %(tournament)s, we are using an online adjudicator feedback system. You can submit "
-            "your feedback at the following URL. This URL is unique to you — do not share it with "
-            "anyone, as anyone who knows it can submit feedback on your behalf. This URL "
-            "will not change throughout this tournament, so we suggest bookmarking it.\n\n"
-            "Your personal private feedback submission URL is:\n"
-            "%(url)s"
-        )
+        subject = request.POST['subject_judges']
+        message = request.POST['message_judges']
         adjudicators = self.get_adjudicators_to_email(PrivateUrlSentMailRecord.URL_TYPE_FEEDBACK)
 
         try:

--- a/tabbycat/privateurls/views.py
+++ b/tabbycat/privateurls/views.py
@@ -2,6 +2,7 @@ import logging
 from smtplib import SMTPException
 
 from django.contrib import messages
+from django.views.generic.edit import FormView
 from django.db.models import Exists, OuterRef, Q
 from django.utils.translation import gettext as _
 from django.utils.translation import ngettext
@@ -14,6 +15,7 @@ from utils.mixins import AdministratorMixin
 from utils.tables import TabbycatTableBuilder
 from utils.views import PostOnlyRedirectView, VueTableTemplateView
 
+from .forms import MassBallotEmailForm, MassFeedbackEmailForm
 from .utils import populate_url_keys, send_randomised_url_emails
 
 logger = logging.getLogger(__name__)
@@ -180,24 +182,99 @@ class BaseEmailRandomisedUrlsView(RandomisedUrlsMixin, VueTableTemplateView):
         return table
 
 
-class EmailBallotUrlsView(BaseEmailRandomisedUrlsView):
+class EmailBallotUrlsView(BaseEmailRandomisedUrlsView, FormView):
 
     template_name = 'ballot_urls_email_list.html'
+    form_class = MassBallotEmailForm
+
+    def get_success_url(self):
+        return reverse_tournament('privateurls-email-ballot', self.tournament)
+
+    def get_initial(self):
+        default = {}
+        default['subject_line'] = _("Your personal ballot submission URL for %(tour)s") % {'tour': self.tournament}
+        default['message_body'] = _(
+            "Hi %%name,\n\n"
+            "At %(tour)s, we are using an online ballot system. You can submit "
+            "your ballots at the following URL. This URL is unique to you — do not share it with "
+            "anyone, as anyone who knows it can submit ballots on your behalf. This URL "
+            "will not change throughout this tournament, so we suggest bookmarking it.\n\n"
+            "Your personal private ballot submission URL is:\n"
+            "%%url"
+        ) % {'tour': self.tournament}
+        return default
 
     def get_context_data(self, **kwargs):
         kwargs['nadjudicators_already_sent'] = self.get_adjudicators_to_email(
             PrivateUrlSentMailRecord.URL_TYPE_BALLOT, already_sent=True).count()
-        kwargs['tournament'] = self.tournament
         return super().get_context_data(**kwargs)
 
     def get_table(self):
         return self.get_adjudicators_table(PrivateUrlSentMailRecord.URL_TYPE_BALLOT,
             'results-public-ballotset-new-randomised', _("Ballot URL"))
 
+    def form_valid(self, form):
+        adjudicators = self.get_adjudicators_to_email(PrivateUrlSentMailRecord.URL_TYPE_BALLOT)
 
-class EmailFeedbackUrlsView(BaseEmailRandomisedUrlsView):
+        try:
+            nadjudicators = send_randomised_url_emails(
+                self.request, self.tournament, adjudicators,
+                'results-public-ballotset-new-randomised',
+                lambda adj: adj.url_key, 'adjudicator', PrivateUrlSentMailRecord.URL_TYPE_BALLOT,
+                form.cleaned_data['subject_line'], form.cleaned_data['message_body']
+            )
+        except SMTPException:
+            messages.error(self.request, _("There was a problem sending private ballot URLs to adjudicators."))
+        except ConnectionError as e:
+            messages.error(self.request, _(
+                "There was a problem connecting to the e-mail server when trying to send private "
+                "ballot URLs to adjudicators: %(error)s"
+            ) % {'error': str(e)})
+        else:
+            messages.success(self.request, ngettext(
+                "E-mails with private ballot URLs were sent to %(nadjudicators)d adjudicator.",
+                "E-mails with private ballot URLs were sent to %(nadjudicators)d adjudicators.",
+                nadjudicators
+            ) % {'nadjudicators': nadjudicators})
+
+        return super().form_valid(form)
+
+
+class EmailFeedbackUrlsView(BaseEmailRandomisedUrlsView, FormView):
 
     template_name = 'feedback_urls_email_list.html'
+    form_class = MassFeedbackEmailForm
+
+    def get_success_url(self):
+        return reverse_tournament('privateurls-email-feedback', self.tournament)
+
+    def get_initial(self):
+        default = {}
+
+        default['team_subject'] = _("Your team's feedback submission URL for %(tour)s") % {'tour': self.tournament}
+        default['team_message'] = _(
+            "Hi %%name,\n\n"
+            "At %(tour)s, we are using an online adjudicator feedback system. As part of "
+            "%%team, you can submit your feedback at the following URL. This URL is unique "
+            "to you — do not share it with anyone, as anyone who knows it can submit feedback on "
+            "your team's behalf. This URL will not change throughout this tournament, so we "
+            "suggest bookmarking it.\n\n"
+            "Your team's private feedback submission URL is:\n"
+            "%%url"
+        ) % {'tour': self.tournament}
+
+        default['judge_subject'] = _("Your personal feedback submission URL for %(tour)s") % {'tour': self.tournament}
+        default['judge_message'] = _(
+            "Hi %%name,\n\n"
+            "At %(tour)s, we are using an online adjudicator feedback system. You can submit "
+            "your feedback at the following URL. This URL is unique to you — do not share it with "
+            "anyone, as anyone who knows it can submit feedback on your behalf. This URL "
+            "will not change throughout this tournament, so we suggest bookmarking it.\n\n"
+            "Your personal private feedback submission URL is:\n"
+            "%%url"
+        ) % {'tour': self.tournament}
+
+        return default
 
     def get_context_data(self, **kwargs):
         kwargs['speakers_no_email'] = Speaker.objects.filter(
@@ -208,7 +285,6 @@ class EmailFeedbackUrlsView(BaseEmailRandomisedUrlsView):
         kwargs['nadjudicators_already_sent'] = self.get_adjudicators_to_email(
             PrivateUrlSentMailRecord.URL_TYPE_FEEDBACK, already_sent=True).count()
         kwargs['nspeakers_already_sent'] = self.get_speakers_to_email(already_sent=True).count()
-        kwargs['tournament'] = self.tournament
         return super().get_context_data(**kwargs)
 
     def get_speakers_table(self):
@@ -242,90 +318,41 @@ class EmailFeedbackUrlsView(BaseEmailRandomisedUrlsView):
                 'adjfeedback-public-add-from-adjudicator-randomised', _("Feedback URL"))
         return [speaker_table, adjudicator_table]
 
-
-class BaseConfirmEmailRandomisedUrlsView(RandomisedUrlsMixin, PostOnlyRedirectView):
-
-    tournament_redirect_pattern_name = 'privateurls-list'
-
-
-class ConfirmEmailBallotUrlsView(BaseConfirmEmailRandomisedUrlsView):
-
-    def post(self, request, *args, **kwargs):
-
-        tournament = self.tournament
-
-        subject = request.POST['subject']
-        message = request.POST['message']
-        adjudicators = self.get_adjudicators_to_email(PrivateUrlSentMailRecord.URL_TYPE_BALLOT)
-
-        try:
-            nadjudicators = send_randomised_url_emails(
-                request, tournament, adjudicators,
-                'results-public-ballotset-new-randomised',
-                lambda adj: adj.url_key, 'adjudicator', PrivateUrlSentMailRecord.URL_TYPE_BALLOT,
-                subject, message
-            )
-        except SMTPException:
-            messages.error(request, _("There was a problem sending private ballot URLs to adjudicators."))
-        except ConnectionError as e:
-            messages.error(request, _(
-                "There was a problem connecting to the e-mail server when trying to send private "
-                "ballot URLs to adjudicators: %(error)s"
-            ) % {'error': str(e)})
-        else:
-            messages.success(request, ngettext(
-                "E-mails with private ballot URLs were sent to %(nadjudicators)d adjudicator.",
-                "E-mails with private ballot URLs were sent to %(nadjudicators)d adjudicators.",
-                nadjudicators
-            ) % {'nadjudicators': nadjudicators})
-
-        return super().post(request, *args, **kwargs)
-
-
-class ConfirmEmailFeedbackUrlsView(BaseConfirmEmailRandomisedUrlsView):
-
-    def post(self, request, *args, **kwargs):
-
-        tournament = self.tournament
+    def form_valid(self, form):
         success = True
-
-        subject = request.POST['subject_teams']
-        message = request.POST['message_teams']
         speakers = self.get_speakers_to_email()
 
         try:
             nspeakers = send_randomised_url_emails(
-                request, tournament, speakers,
+                self.request, self.tournament, speakers,
                 'adjfeedback-public-add-from-team-randomised',
                 lambda speaker: speaker.team.url_key, 'speaker', PrivateUrlSentMailRecord.URL_TYPE_FEEDBACK,
-                subject, message
+                form.cleaned_data['team_subject'], form.cleaned_data['team_message']
             )
         except SMTPException:
-            messages.error(request, _("There was a problem sending private feedback URLs to speakers."))
+            messages.error(self.request, _("There was a problem sending private feedback URLs to speakers."))
             success = False
         except ConnectionError as e:
-            messages.error(request, _(
+            messages.error(self.request, _(
                 "There was a problem connecting to the e-mail server when trying to send private "
                 "feedback URLs to speakers: %(error)s"
             ) % {'error': str(e)})
             success = False
 
-        subject = request.POST['subject_judges']
-        message = request.POST['message_judges']
         adjudicators = self.get_adjudicators_to_email(PrivateUrlSentMailRecord.URL_TYPE_FEEDBACK)
 
         try:
             nadjudicators = send_randomised_url_emails(
-                request, tournament, adjudicators,
+                self.request, self.tournament, adjudicators,
                 'adjfeedback-public-add-from-adjudicator-randomised',
                 lambda adj: adj.url_key, 'adjudicator', PrivateUrlSentMailRecord.URL_TYPE_FEEDBACK,
-                subject, message
+                form.cleaned_data['judge_subject'], form.cleaned_data['judge_message']
             )
         except SMTPException:
-            messages.error(request, _("There was a problem sending private feedback URLs to adjudicators."))
+            messages.error(self.request, _("There was a problem sending private feedback URLs to adjudicators."))
             success = False
         except ConnectionError as e:
-            messages.error(request, _(
+            messages.error(self.request, _(
                 "There was a problem connecting to the e-mail server when trying to send private "
                 "feedback URLs to adjudicators: %(error)s"
             ) % {'error': str(e)})
@@ -338,9 +365,9 @@ class ConfirmEmailFeedbackUrlsView(BaseConfirmEmailRandomisedUrlsView):
             # Translators: This goes in the "adjudicators_phrase" variable in "E-mails with private feedback URLs were sent..."
             adjudicators_phrase = ngettext("%(nadjudicators)d adjudicator",
                 "%(nadjudicators)d adjudicators", nadjudicators) % {'nadjudicators': nadjudicators}
-            messages.success(request, _("E-mails with private feedback URLs were sent to "
+            messages.success(self.request, _("E-mails with private feedback URLs were sent to "
                 "%(speakers_phrase)s and %(adjudicators_phrase)s.") % {
                 'speakers_phrase': speakers_phrase, 'adjudicators_phrase': adjudicators_phrase
             })
 
-        return super().post(request, *args, **kwargs)
+        return super().form_valid(form)


### PR DESCRIPTION
This resolves #531, although in a somewhat different direction.

What this change does is adds text fields (and areas) in the forms which were previously just buttons to send the mass emails. Using the cursory CSS I saw being used, the forms are styled (well, I hope). With the messages visible, there is a sense of what the emails will look like. Basic use is just to not touch the message, but a more advanced workflow would allow for that.

Point 3 is not implemented; just trying out Python / Django and haven't quite figured out that yet (or much if anything). If validation is made, it should only take `%url` into account.

I also added a line about email debugging to the Contributors file. However, I did not add anything to the documentation about this (as the only mention to email was in passing, and the instructions are below the textarea), nor added an entry in the changelog.