### PR TITLE
Send receipt email to judges with their ballot

### DIFF
--- a/tabbycat/options/preferences.py
+++ b/tabbycat/options/preferences.py
@@ -834,27 +834,6 @@ class FeedbackReturnLocation(StringPreference):
     default = 'TBA'
 
 
-@tournament_preferences_registry.register
-class BallotEmailSubjectLine(StringPreference):
-    help_text = _("The subject line for emails sent to adjudicators with their submitted ballot. "
-                  "Use '%debate' as a placeholder for the associated debate")
-    verbose_name = _("Ballot receipt subject line")
-    section = data_entry
-    name = 'ballot_email_subject'
-    default = "Your ballot for %debate has been received"
-
-
-@tournament_preferences_registry.register
-class BallotEmailMessageBody(LongStringPreference):
-    help_text = _("The message body for emails sent to adjudicators with their submitted ballot. "
-                  "Use '%debate' as a placeholder for the associated debate, '%user' for the adjudicator, "
-                  "and '%scores' for the ballot values.")
-    verbose_name = _("Ballot receipt message")
-    section = data_entry
-    name = 'ballot_email_message'
-    default = "Hi %user,\n\nYour ballot for %debate has been successfully received, with these scores:\n\n%scores\n\nIf there are any problems, please contact the tab team."
-
-
 # ==============================================================================
 public_features = Section('public_features', verbose_name=_("Public Features"))
 # ==============================================================================
@@ -1266,7 +1245,7 @@ class DuplicateAdjs(BooleanPreference):
 
 @tournament_preferences_registry.register
 class AdjAllocationConfirmations(BooleanPreference):
-    help_text = 'Allow links to be sent to adjudicators that allow them to confirm shifts'
+    help_text = _("Allow links to be sent to adjudicators that allow them to confirm shifts")
     verbose_name = _("Adjudicator allocation confirmations")
     section = league_options
     name = 'allocation_confirmations'
@@ -1280,3 +1259,38 @@ class EnableCrossTournamentDrawPages(BooleanPreference):
     section = league_options
     name = 'enable_mass_draws'
     default = False
+
+
+# ==============================================================================
+email = Section('email', verbose_name=_("Email Sending"))
+# ==============================================================================
+
+
+@tournament_preferences_registry.register
+class EnableEmailBallotReceipts(BooleanPreference):
+    help_text = _("Enables judges' ballots to be sent to them by email after submission for confirmation")
+    verbose_name = _("Ballot receipts")
+    section = email
+    name = 'enable_ballot_receipts'
+    default = False
+
+
+@tournament_preferences_registry.register
+class BallotEmailSubjectLine(StringPreference):
+    help_text = _("The subject line for emails sent to adjudicators with their submitted ballot. "
+                  "Use '%debate' as a placeholder for the associated debate")
+    verbose_name = _("Ballot receipt subject line")
+    section = email
+    name = 'ballot_email_subject'
+    default = "Your ballot for %debate has been received"
+
+
+@tournament_preferences_registry.register
+class BallotEmailMessageBody(LongStringPreference):
+    help_text = _("The message body for emails sent to adjudicators with their submitted ballot. "
+                  "Use '%debate' as a placeholder for the associated debate, '%user' for the adjudicator, "
+                  "and '%scores' for the ballot values.")
+    verbose_name = _("Ballot receipt message")
+    section = email
+    name = 'ballot_email_message'
+    default = "Hi %user,\n\nYour ballot for %debate has been successfully received, with these scores:\n\n%scores\n\nIf there are any problems, please contact the tab team."

--- a/tabbycat/options/preferences.py
+++ b/tabbycat/options/preferences.py
@@ -833,6 +833,28 @@ class FeedbackReturnLocation(StringPreference):
     name = 'feedback_return_location'
     default = 'TBA'
 
+
+@tournament_preferences_registry.register
+class BallotEmailSubjectLine(StringPreference):
+    help_text = _("The subject line for emails sent to adjudicators with their submitted ballot. "
+                  "Use '%debate' as a placeholder for the associated debate")
+    verbose_name = _("Ballot receipt subject line")
+    section = data_entry
+    name = 'ballot_email_subject'
+    default = "Your ballot for %debate has been received"
+
+
+@tournament_preferences_registry.register
+class BallotEmailMessageBody(LongStringPreference):
+    help_text = _("The message body for emails sent to adjudicators with their submitted ballot. "
+                  "Use '%debate' as a placeholder for the associated debate, '%user' for the adjudicator, "
+                  "and '%scores' for the ballot values.")
+    verbose_name = _("Ballot receipt message")
+    section = data_entry
+    name = 'ballot_email_message'
+    default = "Hi %user,\n\nYour ballot for %debate has been successfully received, with these scores:\n\n%scores\n\nIf there are any problems, please contact the tab team."
+
+
 # ==============================================================================
 public_features = Section('public_features', verbose_name=_("Public Features"))
 # ==============================================================================

--- a/tabbycat/options/preferences.py
+++ b/tabbycat/options/preferences.py
@@ -1278,19 +1278,19 @@ class EnableEmailBallotReceipts(BooleanPreference):
 @tournament_preferences_registry.register
 class BallotEmailSubjectLine(StringPreference):
     help_text = _("The subject line for emails sent to adjudicators with their submitted ballot. "
-                  "Use '%debate' as a placeholder for the associated debate")
+                  "Use '<DEBATE>' as a placeholder for the associated debate")
     verbose_name = _("Ballot receipt subject line")
     section = email
     name = 'ballot_email_subject'
-    default = "Your ballot for %debate has been received"
+    default = "Your ballot for <DEBATE> has been received"
 
 
 @tournament_preferences_registry.register
 class BallotEmailMessageBody(LongStringPreference):
     help_text = _("The message body for emails sent to adjudicators with their submitted ballot. "
-                  "Use '%debate' as a placeholder for the associated debate, '%user' for the adjudicator, "
-                  "and '%scores' for the ballot values.")
+                  "Use '<DEBATE>' as a placeholder for the associated debate, '<USER>' for the adjudicator, "
+                  "and '<SCORES>' for the ballot values.")
     verbose_name = _("Ballot receipt message")
     section = email
     name = 'ballot_email_message'
-    default = "Hi %user,\n\nYour ballot for %debate has been successfully received, with these scores:\n\n%scores\n\nIf there are any problems, please contact the tab team."
+    default = "Hi <USER>,\n\nYour ballot for <DEBATE> has been successfully received, with these scores:\n\n<SCORES>\n\nIf there are any problems, please contact the tab team."

--- a/tabbycat/options/templates/preferences_index.html
+++ b/tabbycat/options/templates/preferences_index.html
@@ -75,6 +75,11 @@
       {% trans "Small tweaks in what information is presented by the interface" as description %}
       {% include "components/item-action.html" with type="primary" emoji="💻" text=title extra=description %}
 
+      {% tournamenturl 'options-tournament-section' section='email' as url %}
+      {% trans "Email Sending" as title %}
+      {% trans "Configures when to send email messages" as description %}
+      {% include "components/item-action.html" with type="primary" emoji="📧" text=title extra=description %}
+
       {% if show_leagues %}
         {% tournamenturl 'options-tournament-section' section='league_options' as url %}
         {% trans "League Options" as title %}

--- a/tabbycat/results/templates/assistant_enter_results.html
+++ b/tabbycat/results/templates/assistant_enter_results.html
@@ -44,6 +44,11 @@
               <input id="incorrect" class="btn btn-danger btn-block" type="button" value="{% trans "Results are incorrect" %}" tabindex="{{ form.nexttabindex|add:1 }}" />
             </div>
           </div>
+          <div class="text-center pt-3 small text-muted">
+            {% if pref.enable_ballot_receipts and not request.user == ballotsub.submitter %}
+              {% trans "Emails will be sent to adjudicators when the ballot is confirmed." %}
+            {% endif %}
+          </div>
         {% endif %}
       </div>
     </div>

--- a/tabbycat/results/templates/enter_results.html
+++ b/tabbycat/results/templates/enter_results.html
@@ -95,6 +95,11 @@
               <a class="btn btn-primary btn-block btn-danger" href="{% roundurl 'results-round-list' debate.round %}" tabindex="{{ form.nexttabindex|add:1 }}">{% trans "Cancel Entry" %}</a>
             </div>
           </div>
+          <div class="text-center pt-3 small text-muted">
+            {% if pref.enable_ballot_receipts %}
+              {% trans "Emails will be sent to adjudicators when the ballot is confirmed." %}
+            {% endif %}
+          </div>
         </div>
 
       </div>

--- a/tabbycat/results/templates/public_enter_results.html
+++ b/tabbycat/results/templates/public_enter_results.html
@@ -69,7 +69,10 @@
         <input class="save btn btn-success btn-block " type="submit" value="Submit Ballot(s)" tabindex="{{ form.nexttabindex }}"/>
         <div class="text-center pt-3 small text-muted">
           {% trans "When submitting this form your IP address will be stored for logging purposes." %}
-          {% trans "Emails will be sent to adjudicators to validate their responses." %}
+          {% if pref.enable_ballot_receipts %}
+            <br />
+            {% trans "Emails will be sent to adjudicators when the ballot is confirmed." %}
+          {% endif %}
         </div>
       </div>
     </div>

--- a/tabbycat/results/templates/public_enter_results.html
+++ b/tabbycat/results/templates/public_enter_results.html
@@ -69,6 +69,7 @@
         <input class="save btn btn-success btn-block " type="submit" value="Submit Ballot(s)" tabindex="{{ form.nexttabindex }}"/>
         <div class="text-center pt-3 small text-muted">
           {% trans "When submitting this form your IP address will be stored for logging purposes." %}
+          {% trans "Emails will be sent to adjudicators to validate their responses." %}
         </div>
       </div>
     </div>

--- a/tabbycat/results/utils.py
+++ b/tabbycat/results/utils.py
@@ -1,7 +1,10 @@
 import logging
 import datetime
 from itertools import combinations
+from smtplib import SMTPException
 
+from django.core.mail import send_mass_mail
+from django.conf import settings
 from django.db.models import Count
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy
@@ -252,3 +255,40 @@ def side_and_position_names(tournament):
                 else _ORDINALS[pos]
                 for pos in tournament.positions]
             yield side, positions
+
+
+def send_email_to_adjs(ballots, debate):
+
+    messages = []
+    scores = ''
+
+    round_name = _("%(tournament)s %(round)s @ %(room)s") % {'tournament': debate.round.tournament.__str__(),
+                                                             'round': debate.round.name, 'room': debate.venue.name}
+    subject = debate.round.tournament.pref('ballot_email_subject').replace('%debate', round_name)
+    message = debate.round.tournament.pref('ballot_email_message').replace('%debate', round_name)
+
+    for ballot in ballots:
+        judge = ballot['adjudicator'] if 'adjudicator' in ballot else debate.debateadjudicator_set.get(type="C")
+
+        if judge.email is None:
+            continue
+
+        message = message.replace('%user', judge.name).split('%scores')
+
+        for team in ballot['teams']:
+            scores += _("(%(side)s) %(team)s\n") % {'side': team['side'], 'team': team['team'].short_name}
+
+            for speaker in team['speakers']:
+                scores += _("- %(debater)s: %(score)s\n") % {'debater': speaker['speaker'], 'score': speaker['score']}
+
+        messages.append((subject, message[0] + scores + message[1], settings.DEFAULT_FROM_EMAIL, [judge.email]))
+        scores = ''
+
+    try:
+        send_mass_mail(messages, fail_silently=False)
+    except SMTPException:
+        logger.exception("Failed to send ballot reciept e-mails")
+        raise
+    except ConnectionError:
+        logger.exception("Connection error sending ballot reciept e-mails")
+        raise

--- a/tabbycat/results/views.py
+++ b/tabbycat/results/views.py
@@ -28,8 +28,9 @@ from utils.tables import TabbycatTableBuilder
 from .forms import BPEliminationResultForm, PerAdjudicatorBallotSetForm, SingleBallotSetForm
 from .models import BallotSubmission, TeamScore
 from .tables import ResultsTableBuilder
+from .result import DebateResult
 from .prefetch import populate_confirmed_ballots
-from .utils import get_result_status_stats, populate_identical_ballotsub_lists
+from .utils import get_result_status_stats, populate_identical_ballotsub_lists, send_email_to_adjs
 
 logger = logging.getLogger(__name__)
 
@@ -273,6 +274,8 @@ class BaseBallotSetView(LogActionMixin, TournamentMixin, FormView):
             self.ballotsub.save()
         self.add_success_message()
         self.round = self.ballotsub.debate.round  # for LogActionMixin
+
+        send_email_to_adjs(DebateResult(self.ballotsub).as_dicts(), self.ballotsub.debate)
         return super().form_valid(form)
 
     def populate_objects(self):


### PR DESCRIPTION
The commit message has some pertinent information.

This resolves #535 by executing an emailing routine after ballot submission, through the `form_valid()` method of `BaseBallotSetView`. Through that, the new routine takes the `ballotsub` and `DebateResults` separately (as it would give an error otherwise).

Review when you have time; no rush :)