### PR TITLE
Add help_text to URL email fields

### DIFF
--- a/tabbycat/privateurls/forms.py
+++ b/tabbycat/privateurls/forms.py
@@ -8,25 +8,28 @@ class EmailBodyField(forms.CharField):
     label = _("Message")
     required = True
     widget = forms.Textarea
-    help_text = _(
-        "Use '%name' and '%url' as placeholders for the judge's name and their private URL"
-        ", respectively in the message body.")
 
     def validate(self, value):
-        super(EmailBodyField, self).validate(value)
-
         # Check if includes URL variable
-        if '%url' not in value:
-            raise forms.ValidationError(_("'%url' must be present in the email body"))
+        if '<URL>' not in value:
+            raise forms.ValidationError(_("'<URL>' must be present in the email body"))
+
+        super().validate(value)
 
 
 class MassBallotEmailForm(forms.Form):
     subject_line = forms.CharField(label=_("Subject"), required=True, max_length=78)
-    message_body = EmailBodyField()
+    message_body = EmailBodyField(help_text=_(
+        "Use '<NAME>' and '<URL>' as placeholders for the judge's name and their private URL"
+        ", respectively in the message body."))
 
 
 class MassFeedbackEmailForm(forms.Form):
     team_subject = forms.CharField(label=_("Subject for team emails"), required=True, max_length=78)
-    team_message = EmailBodyField()
+    team_message = EmailBodyField(help_text=_(
+        "Use '<NAME>', '<TEAM>', and '<URL>' as placeholders for the judge's name"
+        ", team's name, and their private URL, respectively in the message body."))
     judge_subject = forms.CharField(label=_("Subject for judge emails"), required=True, max_length=78)
-    judge_message = EmailBodyField()
+    judge_message = EmailBodyField(help_text=_(
+        "Use '<NAME>' and '<URL>' as placeholders for the judge's name and their private URL"
+        ", respectively in the message body."))

--- a/tabbycat/privateurls/templates/ballot_urls_email_list.html
+++ b/tabbycat/privateurls/templates/ballot_urls_email_list.html
@@ -54,9 +54,7 @@
         <div class="list-group-item">
           {{ form.non_field_errors }}
           {% for field in form.visible_fields %}
-          <div class="form-group">
             {% include "components/form-field.html" %}
-          </div>
           {% endfor %}
         </div>
         <div class="list-group-item">

--- a/tabbycat/privateurls/utils.py
+++ b/tabbycat/privateurls/utils.py
@@ -55,9 +55,9 @@ def send_randomised_url_emails(request, tournament, queryset, url_name, url_key_
         url = request.build_absolute_uri(path)
 
         formatted_subject = subject
-        formatted_message = message.replace('%name', instance.name).replace('%url', url)
+        formatted_message = message.replace('<NAME>', instance.name).replace('<URL>', url)
         if hasattr(instance, 'team'):
-            formatted_message = formatted_message.replace('%team', instance.team.short_name)
+            formatted_message = formatted_message.replace('<TEAM>', instance.team.short_name)
 
         messages.append((formatted_subject, formatted_message, settings.DEFAULT_FROM_EMAIL, [email]))
 

--- a/tabbycat/privateurls/views.py
+++ b/tabbycat/privateurls/views.py
@@ -194,13 +194,13 @@ class EmailBallotUrlsView(BaseEmailRandomisedUrlsView, FormView):
         default = {}
         default['subject_line'] = _("Your personal ballot submission URL for %(tour)s") % {'tour': self.tournament}
         default['message_body'] = _(
-            "Hi %%name,\n\n"
+            "Hi <NAME>,\n\n"
             "At %(tour)s, we are using an online ballot system. You can submit "
             "your ballots at the following URL. This URL is unique to you — do not share it with "
             "anyone, as anyone who knows it can submit ballots on your behalf. This URL "
             "will not change throughout this tournament, so we suggest bookmarking it.\n\n"
             "Your personal private ballot submission URL is:\n"
-            "%%url"
+            "<URL>"
         ) % {'tour': self.tournament}
         return default
 
@@ -253,25 +253,25 @@ class EmailFeedbackUrlsView(BaseEmailRandomisedUrlsView, FormView):
 
         default['team_subject'] = _("Your team's feedback submission URL for %(tour)s") % {'tour': self.tournament}
         default['team_message'] = _(
-            "Hi %%name,\n\n"
+            "Hi <NAME>,\n\n"
             "At %(tour)s, we are using an online adjudicator feedback system. As part of "
-            "%%team, you can submit your feedback at the following URL. This URL is unique "
+            "<TEAM>, you can submit your feedback at the following URL. This URL is unique "
             "to you — do not share it with anyone, as anyone who knows it can submit feedback on "
             "your team's behalf. This URL will not change throughout this tournament, so we "
             "suggest bookmarking it.\n\n"
             "Your team's private feedback submission URL is:\n"
-            "%%url"
+            "<URL>"
         ) % {'tour': self.tournament}
 
         default['judge_subject'] = _("Your personal feedback submission URL for %(tour)s") % {'tour': self.tournament}
         default['judge_message'] = _(
-            "Hi %%name,\n\n"
+            "Hi <NAME>,\n\n"
             "At %(tour)s, we are using an online adjudicator feedback system. You can submit "
             "your feedback at the following URL. This URL is unique to you — do not share it with "
             "anyone, as anyone who knows it can submit feedback on your behalf. This URL "
             "will not change throughout this tournament, so we suggest bookmarking it.\n\n"
             "Your personal private feedback submission URL is:\n"
-            "%%url"
+            "<URL>"
         ) % {'tour': self.tournament}
 
         return default


### PR DESCRIPTION
Points 1 & 3 of #531.

For some reason, `help_text` would not work from inside the class. Customized the message for which parameters are available. Also reduced the variables to use angle brackets.