### PR TITLE
Bug fix: Add switch to save ignored field

### DIFF
--- a/tabbycat/adjfeedback/forms.py
+++ b/tabbycat/adjfeedback/forms.py
@@ -192,7 +192,10 @@ class BaseFeedbackForm(forms.Form):
             af.confirmed = True
 
         af.score = self.cleaned_data['score']
-        af.ignored = self.cleaned_data['ignored']
+
+        if self._ignored_option:
+            af.ignored = self.cleaned_data['ignored']
+
         af.save()
 
         for question in self._tournament.adj_feedback_questions.filter(**self.question_filter):


### PR DESCRIPTION
Didn't notice that my patch broke the public feedback submission form.

If there is no `ignored` field, then it would not be present in the cleaned data, causing an error in the public submission form when attempting to save the feedback.