### PR TITLE
Fix bugs in Notification app

### DIFF
--- a/tabbycat/notifications/utils.py
+++ b/tabbycat/notifications/utils.py
@@ -20,7 +20,6 @@ class TournamentEmailMessage(mail.EmailMessage):
         self.from_email = "%s <%s>" % (self.tournament.short_name, settings.DEFAULT_FROM_EMAIL)
         self.reply_to = None
         if self.tournament.pref('reply_to_address') != "":
-            headers['List-Unsubscribe'] = "<mailto:%s?subject=unsubscribe>" % (self.tournament.pref('reply_to_address'))
             self.reply_to = ["%s <%s>" % (self.tournament.pref('reply_to_name'), self.tournament.pref('reply_to_address'))]
 
         super().__init__(subject, body, self.from_email, self.emails, bcc, connection, attachments,

--- a/tabbycat/notifications/utils.py
+++ b/tabbycat/notifications/utils.py
@@ -15,14 +15,16 @@ class TournamentEmailMessage(mail.EmailMessage):
         self.round = round
 
         self.event = event
-
-        self.reply_to = "%s <%s>" % (self.tournament.pref('reply_to_name'), self.tournament.pref('reply_to_address'))
-        self.from_email = "%s <%s>" % (self.tournament.short_name, settings.DEFAULT_FROM_EMAIL)
-
         self.headers = headers
-        headers['List-Unsubscribe'] = "<mailto:%s?subject=unsubscribe>" % (self.tournament.pref('reply_to_address'))
+
+        self.from_email = "%s <%s>" % (self.tournament.short_name, settings.DEFAULT_FROM_EMAIL)
+        self.reply_to = None
+        if self.tournament.pref('reply_to_address') != "":
+            headers['List-Unsubscribe'] = "<mailto:%s?subject=unsubscribe>" % (self.tournament.pref('reply_to_address'))
+            self.reply_to = ["%s <%s>" % (self.tournament.pref('reply_to_name'), self.tournament.pref('reply_to_address'))]
+
         super().__init__(subject, body, self.from_email, self.emails, bcc, connection, attachments,
-            self.headers, cc, [self.reply_to])
+            self.headers, cc, self.reply_to)
 
     def as_model(self):
         return MessageSentRecord(recepient=self.person, event=self.event, method=MessageSentRecord.METHOD_TYPE_EMAIL, round=self.round, tournament=self.tournament)

--- a/tabbycat/privateurls/templates/feedback_urls_email_list.html
+++ b/tabbycat/privateurls/templates/feedback_urls_email_list.html
@@ -38,7 +38,7 @@
     {% include 'components/alert.html' with type='warning' %}
   {% endif %}
 
-  {% url 'admin:notifications_MessageSentRecord_changelist' as sent_mail_records_url %}
+  {% url 'admin:notifications_messagesentrecord_changelist' as sent_mail_records_url %}
 
   {% if nspeakers_already_sent or nadjudicators_already_sent %}
     {% blocktrans trimmed count nspeakers=nspeakers_already_sent asvar speaker_phrase %}


### PR DESCRIPTION
Two bugs are fixed in this patch:
- The database link in the 'feedback' email form had incorrect capitalization.
- Reply-to and List-Unsubscribe headers had to be optional.

Oddly, in Chrome and Safari, the reply-to fields seem to be mandatory, even though I had not specified that. Is it a browser problem, and could it be overridden without DB editing?