### PR TITLE
Fix caching problem in personalized landing pages

### DIFF
--- a/tabbycat/options/preferences.py
+++ b/tabbycat/options/preferences.py
@@ -800,7 +800,7 @@ class AssistantAccess(ChoicePreference):
 
 @tournament_preferences_registry.register
 class CheckInParticipantSubmit(BooleanPreference):
-    help_text = _("Whether participants can check themselves in/out through their private URl.")
+    help_text = _("Whether participants can check themselves in/out through their private URL.")
     verbose_name = _("Participant self-checkin")
     section = data_entry
     name = 'public_checkins_submit'

--- a/tabbycat/privateurls/templates/public_url_landing.html
+++ b/tabbycat/privateurls/templates/public_url_landing.html
@@ -18,7 +18,7 @@
 
   {% blocktrans trimmed with name=person.name asvar p1 %}
     The URL of this page is personalised to you, {{ name }}. <strong>Do not
-    share it with anyone:</strong> anyone who knows this URL can submit results and/or
+    share it with anyone;</strong> anyone who knows this URL can submit results and/or
     feedback for your debates. You may bookmark this page and return here after each
     debate for the available actions.
   {% endblocktrans %}

--- a/tabbycat/privateurls/templates/urls_email_list.html
+++ b/tabbycat/privateurls/templates/urls_email_list.html
@@ -18,7 +18,7 @@
   {% endif %}
 
   {% blocktrans trimmed asvar p1 %}
-    Review the list of participants who are due to be sent an email with their private ballot URL, then click the button at the bottom of the page to send the emails.
+    Review the list of participants who are due to be sent an email with their private URL, then click the button at the bottom of the page to send the emails.
   {% endblocktrans %}
   {% include 'components/explainer-card.html' with type='info' %}
 
@@ -34,10 +34,10 @@
 
   {% if nparticipants_already_sent %}
     {% blocktrans trimmed count npeople=nparticipants_already_sent asvar message %}
-      {{ npeople }} participant who has already had their ballot URL sent to them is excluded from the below list.
+      {{ npeople }} participant who has already had their URL sent to them is excluded from the below list.
       You can review the sent mail records in the <a href="{{ sent_mail_records_url }}">Edit Database area</a>.
     {% plural %}
-      {{ npeople }} participants who have already had their ballot URLs sent to them are excluded from the below list. You can review the sent mail records in the <a href="{{ sent_mail_records_url }}">Edit Database area</a>.
+      {{ npeople }} participants who have already had their URLs sent to them are excluded from the below list. You can review the sent mail records in the <a href="{{ sent_mail_records_url }}">Edit Database area</a>.
     {% endblocktrans %}
     {% include 'components/alert.html' with type='info' %}
   {% endif %}
@@ -59,7 +59,7 @@
         </div>
         <div class="list-group-item">
           <button class="btn btn-success btn-block" type="submit">
-            {% trans "Send emails with private ballot URLs to participants" %}
+            {% trans "Send emails with private URLs to participants" %}
           </button>
         </div>
       </form>

--- a/tabbycat/privateurls/views.py
+++ b/tabbycat/privateurls/views.py
@@ -15,7 +15,7 @@ from checkins.models import PersonIdentifier
 from checkins.utils import get_unexpired_checkins
 from notifications.models import MessageSentRecord
 from participants.models import Adjudicator, Person, Speaker
-from tournaments.mixins import PublicTournamentPageMixin, TournamentMixin
+from tournaments.mixins import PersonalizablePublicTournamentPageMixin, TournamentMixin
 from utils.misc import reverse_tournament
 from utils.mixins import AdministratorMixin
 from utils.tables import TabbycatTableBuilder
@@ -218,7 +218,7 @@ class EmailUrlsView(BaseEmailRandomisedUrlsView, FormView):
         return super().form_valid(form)
 
 
-class PersonIndexView(PublicTournamentPageMixin, TemplateView):
+class PersonIndexView(PersonalizablePublicTournamentPageMixin, TemplateView):
     slug_field = 'url_key'
     slug_url_kwarg = 'url_key'
 

--- a/tabbycat/tournaments/mixins.py
+++ b/tabbycat/tournaments/mixins.py
@@ -218,9 +218,24 @@ class TournamentAccessControlledPageMixin(TournamentMixin):
             return self.render_page_disabled_error_page()
 
 
-class PublicTournamentPageMixin(TournamentAccessControlledPageMixin, CacheMixin):
-    """Mixin for views that show public tournament pages that can be enabled and
-    disabled by a tournament preference.
+class PersonalizablePublicTournamentPageMixin(TournamentAccessControlledPageMixin):
+    """Mixin for views that show personalizable public tournament pages which may be
+    enabled for disabled by tournament preferences. Caching is inappropriate for these
+    pages."""
+
+    public_page_preference = None
+    template_403_name = "errors/public_403.html"
+    _user_role = "public"
+
+    def is_page_enabled(self, tournament):
+        if self.public_page_preference is None:
+            raise ImproperlyConfigured("public_page_preference isn't set on this view.")
+        return tournament.pref(self.public_page_preference)
+
+
+class PublicTournamentPageMixin(PersonalizablePublicTournamentPageMixin, CacheMixin):
+    """Mixin for views that show non-personalized public tournament pages that can
+    be enabled and disabled by a tournament preference.
 
     Views using this mixin should set the `public_page_preference` class
     attribute to the name of the preference that controls whether the page is
@@ -234,14 +249,7 @@ class PublicTournamentPageMixin(TournamentAccessControlledPageMixin, CacheMixin)
     `get_disabled_message()` method.
     """
 
-    public_page_preference = None
-    template_403_name = "errors/public_403.html"
-    _user_role = "public"
-
-    def is_page_enabled(self, tournament):
-        if self.public_page_preference is None:
-            raise ImproperlyConfigured("public_page_preference isn't set on this view.")
-        return tournament.pref(self.public_page_preference)
+    pass
 
 
 class OptionalAssistantTournamentPageMixin(AssistantMixin, TournamentAccessControlledPageMixin):


### PR DESCRIPTION
The underlying issue was that the page was being cached (as I had thought in #684 [[comment](https://github.com/TabbycatDebate/tabbycat/issues/684#issuecomment-406579786)]). Saw 304s being sent out as the landing page. To fix, I created a new mixin which is like the PublicTournamentPage mixin but without the caching. Caching can't be used well for personalized pages, which PublicTournamentPageMixin wasn't for.

Also fixed a few typos relating to the feature.