### PR TITLE
Send message to adjudicators on draw release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Change Log
 - Implemented a new server architecture on Heroku that should significantly improve performance under load. If upgrading an existing Heroku instance this requires a few tweaks:
     - Adding the `https://github.com/heroku/heroku-buildpack-nginx.git` build pack under the Settings area of the Heroku Dashboard and positioning it first
     - If your Heroku Stack is not "heroku-16" (noted under that same Settings page) it will need to be set as such using the Heroku CLI and the `heroku stack:set heroku-16 --app APP_NAME` command
+- Added email notification to adjudicators on round release.
 - Implemented participant self-check-in through the use of their private URLs.
 - Gave all participants to a tournament a private URL key rather than being by team, and added a landing page for the participants using this key.
 - Implemented templated email notifications with ballot submission and round advance with the messages in a new settings panel. Private URL emails are now also customizable.

--- a/tabbycat/draw/templates/draw_display_admin.html
+++ b/tabbycat/draw/templates/draw_display_admin.html
@@ -153,6 +153,7 @@
         {% else %}
 
           {% trans "Release draw to public" as release_text %}
+          {% trans "Emails will be sent to adjudicators announcing their assignments." as email_text %}
           <form id="releaseDrawForm" method="POST" action="{% roundurl 'draw-release' %}">{% csrf_token %}</form>
 
           {% if pref.participant_ballots != 'off' or pref.participant_feedback != 'off' or pref.public_draw %}
@@ -172,12 +173,21 @@
               {% include "components/item-info.html" with type="info" %}
             {% endif %}
 
+            {% if pref.enable_adj_email %}
+              {% include "components/item-info.html" with type="secondary" text=email_text icon="mail" %}
+            {% endif %}
+
             {% include "components/item-action.html" with type="success" id="triggerReleaseDrawForm" text=release_text url="" to_complete=True %}
 
           {% else %}
 
             {% trans "Your configuration doesn't have a public draw page or feedback/ballot submissions. There's no reason to release the draw." as text %}
             {% include "components/item-info.html" with type="secondary" %}
+
+            {% if pref.enable_adj_email %}
+              {% include "components/item-info.html" with type="secondary" text=email_text icon="mail" %}
+            {% endif %}
+
             {% include "components/item-action.html" with type="secondary" id="triggerReleaseDrawForm" text=release_text url="" %}
 
           {% endif %}

--- a/tabbycat/draw/templates/draw_display_admin.html
+++ b/tabbycat/draw/templates/draw_display_admin.html
@@ -153,7 +153,7 @@
         {% else %}
 
           {% trans "Release draw to public" as release_text %}
-          {% trans "Emails will be sent to adjudicators announcing their assignments." as email_text %}
+          {% trans "Your tournament is configured to send emails to adjudicators announcing which debate they were allocated to once the draw is released." as email_text %}
           <form id="releaseDrawForm" method="POST" action="{% roundurl 'draw-release' %}">{% csrf_token %}</form>
 
           {% if pref.participant_ballots != 'off' or pref.participant_feedback != 'off' or pref.public_draw %}
@@ -172,9 +172,8 @@
               {% trans "Your tournament is configured to show the draw publicly. Releasing a draw will allow it to show it on the public page." as text %}
               {% include "components/item-info.html" with type="info" %}
             {% endif %}
-
             {% if pref.enable_adj_email %}
-              {% include "components/item-info.html" with type="secondary" text=email_text icon="mail" %}
+              {% include "components/item-info.html" with text=email_text %}
             {% endif %}
 
             {% include "components/item-action.html" with type="success" id="triggerReleaseDrawForm" text=release_text url="" to_complete=True %}
@@ -185,7 +184,7 @@
             {% include "components/item-info.html" with type="secondary" %}
 
             {% if pref.enable_adj_email %}
-              {% include "components/item-info.html" with type="secondary" text=email_text icon="mail" %}
+              {% include "components/item-info.html" with text=email_text %}
             {% endif %}
 
             {% include "components/item-action.html" with type="secondary" id="triggerReleaseDrawForm" text=release_text url="" %}

--- a/tabbycat/draw/utils.py
+++ b/tabbycat/draw/utils.py
@@ -1,7 +1,18 @@
-from django.db.models import Count, Q
+import logging
+from smtplib import SMTPException
 
+from django.core.mail import get_connection
+from django.db.models import Count, Q
+from django.template import Template
+from django.utils.translation import gettext as _
+
+from adjallocation.allocation import AdjudicatorAllocation
+from notifications.models import SentMessageRecord
+from notifications.utils import TournamentEmailMessage
 from participants.models import Team
 from tournaments.models import Round
+
+logger = logging.getLogger(__name__)
 
 
 def annotate_npullups(teams, until):
@@ -22,3 +33,54 @@ def annotate_npullups(teams, until):
 
     for team in teams:
         team.npullups = npullups_by_team_id.get(team.id, 0)
+
+
+def send_mail_to_adjs(round):
+    tournament = round.tournament
+    draw = round.debate_set_with_prefetches(speakers=False, divisions=False).all()
+
+    subject = Template(tournament.pref('adj_email_subject_line'))
+    body = Template(tournament.pref('adj_email_message'))
+    messages = []
+
+    adj_position_names = {
+        AdjudicatorAllocation.POSITION_CHAIR: _("the chair"),
+        AdjudicatorAllocation.POSITION_ONLY: _("the only"),
+        AdjudicatorAllocation.POSITION_PANELLIST: _("a panellist"),
+        AdjudicatorAllocation.POSITION_TRAINEE: _("a trainee"),
+    }
+
+    def _assemble_panel(adjs):
+        adj_string = []
+        for adj, pos in adjs:
+            adj_string.append("%s (%s)" % (adj.name, adj_position_names[pos]))
+
+        return ", ".join(adj_string)
+
+    for debate in draw:
+        context = {
+            'ROUND': round.name,
+            'VENUE': debate.venue.name,
+            'PANEL': _assemble_panel(debate.adjudicators.with_positions()),
+            'DRAW': debate.matchup
+        }
+
+        for adj, pos in debate.adjudicators.with_positions():
+            if adj.email is None:
+                continue
+
+            context['USER'] = adj.name
+            context['POSITION'] = adj_position_names[pos]
+
+            messages.append(TournamentEmailMessage(subject, body, tournament, round, SentMessageRecord.EVENT_TYPE_DRAW, adj, context))
+
+    try:
+        get_connection().send_messages(messages)
+    except SMTPException:
+        logger.exception("Failed to send adjudicator e-mails")
+        raise
+    except ConnectionError:
+        logger.exception("Connection error sending adjudicator e-mails")
+        raise
+    else:
+        SentMessageRecord.objects.bulk_create([message.as_sent_record() for message in messages])

--- a/tabbycat/options/preferences.py
+++ b/tabbycat/options/preferences.py
@@ -1361,3 +1361,35 @@ class PointsEmailLinkText(StringPreference):
     section = email
     name = 'team_points_email_link_text'
     default = "To consult the current team standings, visit:"
+
+
+@tournament_preferences_registry.register
+class EnableAdjudicatorDrawNotification(BooleanPreference):
+    help_text = _("Whether to send a notification informing adjudicators of their assignments when the draw is released.")
+    verbose_name = _("Adjudicator draw notifications")
+    section = email
+    name = 'enable_adj_email'
+    default = False
+
+
+@tournament_preferences_registry.register
+class AdjudicatorDrawNotificationSubject(StringPreference):
+    help_text = _("The subject-line for emails sent to adjudicators with their assignments. "
+        "Use '{{ ROUND }}' as a placeholder for the current round, and '{{ VENUE }}' for their assigned venue.")
+    verbose_name = _("Adjudicator draw subject line")
+    section = email
+    name = 'adj_email_subject_line'
+    default = "Your assigned debate for {{ ROUND }}: {{ VENUE }}"
+
+
+@tournament_preferences_registry.register
+class AdjudicatorDrawNotificationMessage(LongStringPreference):
+    help_text = _("The message body for emails sent to adjudicators with their assignments. "
+        "Use '{{ ROUND }}' as a placeholder for the current round, '{{ VENUE }}' for their venue, "
+        "'{{ USER }}' for the adjudicator's name, '{{ POSITION }}' for their role, '{{ PANEL }}' for the full debate adjudication panel, and "
+        "'{{ DRAW }}' for the debate pairing.")
+    verbose_name = _("Adjudicator draw message")
+    section = email
+    name = 'adj_email_message'
+    default = "Hi {{ USER }}\n\nYou have been assigned as {{ POSITION }} adjudicator for {{ ROUND }} in room {{ VENUE }} with the following panel: {{ PANEL }}\n\n" \
+            + "The debate is between these teams: {{ DRAW }}"


### PR DESCRIPTION
This commit adds the ability to send email notifications to adjudicators informing them of their role and in which venue they are assigned to (but not of the affiliations of others in the panel, nor motions even if released. The notification is customizable, and also includes the debate matchup.

Part of #671.