### PR TITLE
Search for duplicate key notifications

### DIFF
--- a/tabbycat/privateurls/utils.py
+++ b/tabbycat/privateurls/utils.py
@@ -49,7 +49,7 @@ def send_randomised_url_emails(request, tournament, participants, subject, messa
         path = reverse_tournament('privateurls-person-index', tournament, kwargs={'url_key': instance.url_key})
         url = request.build_absolute_uri(path)
 
-        variables = {'NAME': instance.name, 'URL': url}
+        variables = {'NAME': instance.name, 'URL': url, 'key': instance.url_key}
 
         messages.append(TournamentEmailMessage(subject, message, tournament, None, SentMessageRecord.EVENT_TYPE_URL, instance, variables))
     try:

--- a/tabbycat/privateurls/views.py
+++ b/tabbycat/privateurls/views.py
@@ -38,7 +38,8 @@ class RandomisedUrlsMixin(AdministratorMixin, TournamentMixin):
 
     def get_participants_to_email(self, already_sent=False):
         subquery = SentMessageRecord.objects.filter(
-            tournament=self.tournament, recipient=OuterRef('pk'),
+            tournament=self.tournament, email=OuterRef('email'),
+            context__key=OuterRef('url_key'),
             event=SentMessageRecord.EVENT_TYPE_URL
         )
         people = self.tournament.participants.filter(

--- a/tabbycat/tournaments/templates/round_advance_check.html
+++ b/tabbycat/tournaments/templates/round_advance_check.html
@@ -15,13 +15,23 @@
 
   <form action="{% roundurl 'tournament-send-standings-emails' %}" method="POST">
     {% csrf_token %}
-    <button class="btn btn-outline-primary active" id="sendPointsEmails" type="submit">
-      {% if pref.teams_in_debate == "two" %}
-        {% trans "Email Team Wins/Losses" %}
-      {% else %}
-        {% trans "Email Team Points" %}
-      {% endif %}
-    </button>
+    {% if emails_sent %}
+      <button class="btn btn-outline-secondary" id="sendPointsEmails" type="submit" data-toggle="tooltip" title="{% trans "Emails have already been sent." %}">
+        {% if pref.teams_in_debate == "two" %}
+          {% trans "Email Team Wins/Losses" %}
+        {% else %}
+          {% trans "Email Team Points" %}
+        {% endif %}
+      </button>
+    {% else %}
+      <button class="btn btn-outline-primary active" id="sendPointsEmails" type="submit">
+        {% if pref.teams_in_debate == "two" %}
+          {% trans "Email Team Wins/Losses" %}
+        {% else %}
+          {% trans "Email Team Points" %}
+        {% endif %}
+      </button>
+    {% endif %}
   </form>
 
   <form action="{% roundurl 'tournament-advance-round' %}" method="POST">

--- a/tabbycat/tournaments/utils.py
+++ b/tabbycat/tournaments/utils.py
@@ -189,14 +189,13 @@ def send_standings_emails(tournament, teams, request, round):
     messages = []
 
     subject = Template(tournament.pref('team_points_email_subject'))
-    message = Template(tournament.pref('team_points_email_message'))
+    message = tournament.pref('team_points_email_message')
 
     context = {'TOURN': str(tournament)}
 
-    message_link = ''
     if tournament.pref('public_team_standings'):
         url = request.build_absolute_uri(reverse_tournament('standings-public-teams-current', tournament))
-        message_link += "\n\n" + tournament.pref('team_points_email_link_text') + "\n" + url
+        message += "\n\n" + tournament.pref('team_points_email_link_text') + "\n" + url
 
     for team in teams:
         context['POINTS'] = str(team.points_count)
@@ -208,7 +207,7 @@ def send_standings_emails(tournament, teams, request, round):
 
             context['USER'] = speaker.name
 
-            messages.append(TournamentEmailMessage(subject, message + message_link, tournament, round, SentMessageRecord.EVENT_TYPE_POINTS, speaker, context))
+            messages.append(TournamentEmailMessage(subject, Template(message), tournament, round, SentMessageRecord.EVENT_TYPE_POINTS, speaker, context))
 
     try:
         get_connection().send_messages(messages)


### PR DESCRIPTION
This commit searches for duplicate private URL key notifications through the email recipient and the private key that was sent, rather than just the Person recipient object. This is to pick up and not count emails for when the private URL has changed or their email as duplicates. (Mentioned in #684)