### PR TITLE
Improve queries in adjudicator feedback views

### DIFF
--- a/tabbycat/adjfeedback/forms.py
+++ b/tabbycat/adjfeedback/forms.py
@@ -244,7 +244,8 @@ def make_feedback_form_class_for_adj(source, tournament, submission_fields, conf
         debate__round__seq__lte=tournament.current_round.seq,
         debate__round__stage=Round.STAGE_PRELIMINARY
     ).order_by('-debate__round__seq').prefetch_related(
-        'debate__debateadjudicator_set__adjudicator'
+        'debate__debateadjudicator_set__adjudicator',
+        'debate__round'
     )
 
     if include_unreleased_draws:


### PR DESCRIPTION
To improve the performance of views for adjudicator feedback, Django annotations (`Count()`) were used with prefetches for the query-sets which are used by those views. This chips away a bit at #676.