### PR TITLE
Prevent public forms from being cached

### DIFF
--- a/tabbycat/adjfeedback/views.py
+++ b/tabbycat/adjfeedback/views.py
@@ -17,7 +17,7 @@ from participants.prefetch import populate_feedback_scores
 from participants.templatetags.team_name_for_data_entry import team_name_for_data_entry
 from results.mixins import PublicSubmissionFieldsMixin, TabroomSubmissionFieldsMixin
 from results.prefetch import populate_wins_for_debateteams
-from tournaments.mixins import (PublicTournamentPageMixin, SingleObjectByRandomisedUrlMixin,
+from tournaments.mixins import (PersonalizablePublicTournamentPageMixin, PublicTournamentPageMixin, SingleObjectByRandomisedUrlMixin,
                                 SingleObjectFromTournamentMixin, TournamentMixin)
 from tournaments.models import Round
 
@@ -514,7 +514,7 @@ class AssistantAddFeedbackView(AssistantMixin, BaseTabroomAddFeedbackView):
     pass
 
 
-class PublicAddFeedbackView(PublicSubmissionFieldsMixin, PublicTournamentPageMixin, BaseAddFeedbackView):
+class PublicAddFeedbackView(PublicSubmissionFieldsMixin, PersonalizablePublicTournamentPageMixin, BaseAddFeedbackView):
     """Base class for views for public users to add feedback."""
 
     action_log_type = ActionLogEntry.ACTION_TYPE_FEEDBACK_SUBMIT

--- a/tabbycat/results/mixins.py
+++ b/tabbycat/results/mixins.py
@@ -1,6 +1,13 @@
+from smtplib import SMTPException
+
+from django.contrib import messages
+from django.utils.translation import gettext as _
+
 from utils.misc import get_ip_address
 
 from .models import Submission
+from .result import DebateResult
+from .utils import send_ballot_receipt_emails_to_adjudicators
 
 
 class TabroomSubmissionFieldsMixin:
@@ -26,3 +33,17 @@ class PublicSubmissionFieldsMixin:
             'submitter_type': Submission.SUBMITTER_PUBLIC,
             'ip_address': get_ip_address(self.request)
         }
+
+
+class BallotEmailWithStatusMixin:
+    def send_email_receipts(self):
+        try:
+            send_ballot_receipt_emails_to_adjudicators(DebateResult(self.ballotsub).as_dicts(), self.debate)
+        except SMTPException:
+            messages.error(self.request, _("There was a problem sending ballot receipts to adjudicators."))
+            return False
+        except ConnectionError:
+            messages.error(self.request, _("There was a problem connecting to the e-mail server when trying to send ballot receipts to adjudicators."))
+            return False
+        else:
+            return True


### PR DESCRIPTION
The public forms to add feedback or ballots should not be cached as they are personalized to the submitter, and having them cached could mean success messages cannot be properly displayed. The fix is similar to that of the private URL landing page. (see #701)

Also moved `BallotEmailWithStatusMixin` to the `mixins.py` file as it seems more appropriate of a place for it than in `views.py`.