### PR TITLE
Use more select_related in get_table_by_team

### DIFF
--- a/tabbycat/results/views.py
+++ b/tabbycat/results/views.py
@@ -143,10 +143,11 @@ class PublicResultsForRoundView(RoundMixin, PublicTournamentPageMixin, VueTableT
     def get_table_by_team(self):
         teamscores = TeamScore.objects.filter(debate_team__debate__round=self.round,
                 ballot_submission__confirmed=True).prefetch_related(
-                'debate_team__team__speaker_set', 'debate_team__team__institution',
+                'debate_team__team__speaker_set',
                 'debate_team__debate__debateadjudicator_set__adjudicator',
-                'debate_team__debate__debateteam_set__team',
-                'debate_team__debate__round').select_related('ballot_submission')
+                'debate_team__debate__debateteam_set__team').select_related(
+                'debate_team__debate__round', 'debate_team__debate',
+                'ballot_submission', 'debate_team__team__institution')
         debates = [ts.debate_team.debate for ts in teamscores]
 
         if self.tournament.pref('teams_in_debate') == 'two':


### PR DESCRIPTION
Hopefully fixes #727. Candidate for inclusion in hotfixes.
Some fields were mis-categorised, and debate_team__debate was missing, causing more queries to be made.