### PR TITLE
Add average speaker average to Team metrics

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ Change Log
 ------------------
 *Release date: TBD*
 
+- Added the "average individual speaker score" metric which averages the scores of all substantive speeches by the team within preliminary rounds.
+- Renamed the "average speaker score" to "average total speaker score."
 - Implemented a new server architecture on Heroku that should significantly improve performance under load. If upgrading an existing Heroku instance this requires a few tweaks:
     - Adding the `https://github.com/heroku/heroku-buildpack-nginx.git` build pack under the Settings area of the Heroku Dashboard and positioning it first
     - If your Heroku Stack is not "heroku-16" (noted under that same Settings page) it will need to be set as such using the Heroku CLI and the `heroku stack:set heroku-16 --app APP_NAME` command

--- a/docs/features/standings-rules.rst
+++ b/docs/features/standings-rules.rst
@@ -52,6 +52,12 @@ metrics that will be shown in the team standings, but not used to rank teams.
     - The average total speaker score over all debates the team has had, not
       counting debates where they or their opponents forfeited.
 
+  * - Average individual score
+    - The total substantive speaker score, over all debates the team has had and
+      the number of speakers. Provides an equivalent metric to average speaker
+      score in no-reply formats, but within the substantive speech scoring
+      range.
+
   * - Speaker score standard deviation
     - The standard deviation of total speaker scores over all debates the team
       has had, not counting debates where they or their opponents forfeited.

--- a/docs/features/standings-rules.rst
+++ b/docs/features/standings-rules.rst
@@ -48,15 +48,15 @@ metrics that will be shown in the team standings, but not used to rank teams.
   * - Total speaker score
     - The sum of all speaker scores attained in all debates.
 
-  * - Average speaker score
+  * - Average total speaker score
     - The average total speaker score over all debates the team has had, not
       counting debates where they or their opponents forfeited.
 
-  * - Average individual score
+  * - Average individual speaker score
     - The total substantive speaker score, over all debates the team has had and
-      the number of speakers. Provides an equivalent metric to average speaker
-      score in no-reply formats, but within the substantive speech scoring
-      range.
+      the number of speakers. Provides an equivalent metric to average total
+      speaker score in no-reply formats, but within the substantive speech
+      scoring range.
 
   * - Speaker score standard deviation
     - The standard deviation of total speaker scores over all debates the team

--- a/tabbycat/standings/teams.py
+++ b/tabbycat/standings/teams.py
@@ -165,6 +165,22 @@ class AverageMarginMetricAnnotator(TeamScoreQuerySetMetricAnnotator):
     exclude_forfeits = True
 
 
+class AverageIndividalScoreMetricAnnotator(TeamScoreQuerySetMetricAnnotator):
+    """Metric annotator for total constructive speaker score."""
+    key = "speaks_ind_avg"
+    name = _("average individual score")
+    abbr = _("AIS")
+
+    def get_annotation(self, round=None):
+        annotation_filter = Q(
+            debateteam__teamscore__ballot_submission__confirmed=True,
+            debateteam__debate__round__stage=Round.STAGE_PRELIMINARY,
+            debateteam__teamscore__forfeit=False,
+            debateteam__speakerscore__position__lte=round.tournament.last_substantive_position
+        )
+        return Avg('debateteam__speakerscore__score', filter=annotation_filter)
+
+
 class DrawStrengthMetricAnnotator(BaseMetricAnnotator):
     """Metric annotator for draw strength."""
     key = "draw_strength"
@@ -349,6 +365,7 @@ class TeamStandingsGenerator(BaseStandingsGenerator):
         "wins"          : WinsMetricAnnotator,
         "speaks_sum"    : TotalSpeakerScoreMetricAnnotator,
         "speaks_avg"    : AverageSpeakerScoreMetricAnnotator,
+        "speaks_ind_avg": AverageIndividalScoreMetricAnnotator,
         "speaks_stddev" : SpeakerScoreStandardDeviationMetricAnnotator,
         "draw_strength" : DrawStrengthMetricAnnotator,
         "margin_sum"    : SumMarginMetricAnnotator,

--- a/tabbycat/standings/teams.py
+++ b/tabbycat/standings/teams.py
@@ -124,8 +124,8 @@ class TotalSpeakerScoreMetricAnnotator(TeamScoreQuerySetMetricAnnotator):
 class AverageSpeakerScoreMetricAnnotator(TeamScoreQuerySetMetricAnnotator):
     """Metric annotator for total speaker score."""
     key = "speaks_avg"
-    name = _("average speaker score")
-    abbr = _("ASS")
+    name = _("average total speaker score")
+    abbr = _("ATSS")
     exclude_forfeits = True
 
     function = Avg
@@ -165,11 +165,11 @@ class AverageMarginMetricAnnotator(TeamScoreQuerySetMetricAnnotator):
     exclude_forfeits = True
 
 
-class AverageIndividalScoreMetricAnnotator(TeamScoreQuerySetMetricAnnotator):
+class AverageIndividualScoreMetricAnnotator(TeamScoreQuerySetMetricAnnotator):
     """Metric annotator for total constructive speaker score."""
     key = "speaks_ind_avg"
-    name = _("average individual score")
-    abbr = _("AIS")
+    name = _("average individual speaker score")
+    abbr = _("AISS")
 
     def get_annotation(self, round=None):
         annotation_filter = Q(
@@ -365,7 +365,7 @@ class TeamStandingsGenerator(BaseStandingsGenerator):
         "wins"          : WinsMetricAnnotator,
         "speaks_sum"    : TotalSpeakerScoreMetricAnnotator,
         "speaks_avg"    : AverageSpeakerScoreMetricAnnotator,
-        "speaks_ind_avg": AverageIndividalScoreMetricAnnotator,
+        "speaks_ind_avg": AverageIndividualScoreMetricAnnotator,
         "speaks_stddev" : SpeakerScoreStandardDeviationMetricAnnotator,
         "draw_strength" : DrawStrengthMetricAnnotator,
         "margin_sum"    : SumMarginMetricAnnotator,


### PR DESCRIPTION
~~Fixes #733.~~

The average speaker average (ASA) is like the average speaker score (ASS), but it returns values within the tournament's scoring range as it averages the speaker scores between all speakers in all rounds, and not just between all rounds. Would there be a better name?

I kinda prefer this new metric honestly :)