### PR TITLE
Clarify speaker tab label

### DIFF
--- a/tabbycat/standings/templates/standings_menu.html
+++ b/tabbycat/standings/templates/standings_menu.html
@@ -33,9 +33,22 @@
   <div class="btn btn-outline-primary disabled">{% trans "Speakers" %}</div>
   <a class="btn btn-outline-primary {% if standings_speaker_nav %}active{% endif %}"
      href="{% roundurl 'standings-speaker' current_round %}">
-    {% trans "All" %}
+    {% if pref.reply_scores_enabled %}
+      {% trans "Substantives" %}
+    {% else %}
+      {% trans "All" %}
+    {% endif %}
   </a>
+  {% if pref.reply_scores_enabled %}
+    <a class="btn btn-outline-primary {% if standings_reply_nav %}active{% endif %}"
+       href="{% roundurl 'standings-reply' current_round %}">
+      {% trans "Replies" %}
+    </a>
+  {% endif %}
   {% for category in tournament.speakercategory_set.all %}
+    {% if forloop.first and pref.reply_scores_enabled %}
+      <div class="btn btn-outline-primary disabled">{% trans "Categories" %}</div>
+    {% endif %}
     <a class="btn btn-outline-primary"
        href="{% roundurl 'standings-speaker-category' round=current_round category=category.slug %}">
       {% blocktrans trimmed with category_name=category.name %}
@@ -43,12 +56,6 @@
       {% endblocktrans %}
     </a>
   {% endfor %}
-  {% if pref.reply_scores_enabled %}
-    <a class="btn btn-outline-primary {% if standings_reply_nav %}active{% endif %}"
-       href="{% roundurl 'standings-reply' current_round %}">
-      {% trans "Replies" %}
-    </a>
-  {% endif %}
 </div>
 
 <div class="btn-group">

--- a/tabbycat/standings/templates/standings_menu.html
+++ b/tabbycat/standings/templates/standings_menu.html
@@ -20,7 +20,7 @@
   <a class="btn btn-outline-primary {% if standings_team_nav %}active{% endif %}"
      href="{% roundurl 'standings-team' current_round %}">
     {% if tournament.break_categories_nongeneral.count > 0 %}
-      {% trans "All" %}
+      {% trans "All" context "All [Teams]" %}
     {% else %}
       {% trans "Teams" %}
     {% endif %}
@@ -42,9 +42,9 @@
   <a class="btn btn-outline-primary {% if standings_speaker_nav %}active{% endif %}"
      href="{% roundurl 'standings-speaker' current_round %}">
     {% if pref.reply_scores_enabled %}
-      {% trans "Substantives" %}
+      {% trans "Substantives" context "Substantive speeches" %}
     {% elif tournament.speakercategory_set.all.count > 0 %}
-      {% trans "All" %}
+      {% trans "All" context "All [Speakers]" %}
     {% else %}
       {% trans "Speakers " %}
     {% endif %}

--- a/tabbycat/standings/templates/standings_menu.html
+++ b/tabbycat/standings/templates/standings_menu.html
@@ -14,10 +14,16 @@
 </div>
 
 <div class="btn-group flex-wrap">
-  <div class="btn btn-outline-primary disabled">{% trans "Teams" %}</div>
+  {% if tournament.break_categories_nongeneral.count > 0 %}
+    <div class="btn btn-outline-primary disabled">{% trans "Teams" %}</div>
+  {% endif %}
   <a class="btn btn-outline-primary {% if standings_team_nav %}active{% endif %}"
      href="{% roundurl 'standings-team' current_round %}">
-    {% trans "All" %}
+    {% if tournament.break_categories_nongeneral.count > 0 %}
+      {% trans "All" %}
+    {% else %}
+      {% trans "Teams" %}
+    {% endif %}
   </a>
   {% for category in tournament.break_categories_nongeneral %}
     <a class="btn btn-outline-primary"
@@ -30,25 +36,20 @@
 </div>
 
 <div class="btn-group flex-wrap">
-  <div class="btn btn-outline-primary disabled">{% trans "Speakers" %}</div>
+  {% if tournament.speakercategory_set.all.count > 0 or pref.reply_scores_enabled %}
+    <div class="btn btn-outline-primary disabled">{% trans "Speakers" %}</div>
+  {% endif %}
   <a class="btn btn-outline-primary {% if standings_speaker_nav %}active{% endif %}"
      href="{% roundurl 'standings-speaker' current_round %}">
     {% if pref.reply_scores_enabled %}
       {% trans "Substantives" %}
-    {% else %}
+    {% elif tournament.speakercategory_set.all.count > 0 %}
       {% trans "All" %}
+    {% else %}
+      {% trans "Speakers " %}
     {% endif %}
   </a>
-  {% if pref.reply_scores_enabled %}
-    <a class="btn btn-outline-primary {% if standings_reply_nav %}active{% endif %}"
-       href="{% roundurl 'standings-reply' current_round %}">
-      {% trans "Replies" %}
-    </a>
-  {% endif %}
   {% for category in tournament.speakercategory_set.all %}
-    {% if forloop.first and pref.reply_scores_enabled %}
-      <div class="btn btn-outline-primary disabled">{% trans "Categories" %}</div>
-    {% endif %}
     <a class="btn btn-outline-primary"
        href="{% roundurl 'standings-speaker-category' round=current_round category=category.slug %}">
       {% blocktrans trimmed with category_name=category.name %}
@@ -56,6 +57,12 @@
       {% endblocktrans %}
     </a>
   {% endfor %}
+  {% if pref.reply_scores_enabled %}
+    <a class="btn btn-outline-primary {% if standings_reply_nav %}active{% endif %}"
+       href="{% roundurl 'standings-reply' current_round %}">
+      {% trans "Replies" %}
+    </a>
+  {% endif %}
 </div>
 
 <div class="btn-group">

--- a/tabbycat/templates/nav/admin_nav.html
+++ b/tabbycat/templates/nav/admin_nav.html
@@ -186,7 +186,11 @@
         <i data-feather="maximize"></i>{% trans "Overview" %}
       </a>
       <a class="list-group-item" href="{% roundurl 'standings-team' current_round %}">
-        <i data-feather="users"></i>{% trans "Teams" %}
+        {% if tournament.break_categories_nongeneral.count > 0 %}
+          <i data-feather="users"></i>{% trans "All Teams" %}
+        {% else %}
+          <i data-feather="users"></i>{% trans "Teams" %}
+        {% endif %}
       </a>
       {% for category in tournament.break_categories_nongeneral %}
         <a class="list-group-item {% if standings_active %}active{% endif %}" href="{% roundurl 'standings-break-category' round=current_round category=category.slug %}">
@@ -201,7 +205,11 @@
       </a>
       {% endif %}
       <a class="list-group-item" href="{% roundurl 'standings-speaker' current_round %}">
-        <i data-feather="user"></i>{% trans "Speakers" %}
+        {% if tournament.speakercategory_set.all.count > 0 %}
+          <i data-feather="user"></i>{% trans "All Speakers" %}
+        {% else %}
+          <i data-feather="user"></i>{% trans "Speakers" %}
+        {% endif %}
       </a>
       {% for category in tournament.speakercategory_set.all %}
         <a class="list-group-item" href="{% roundurl 'standings-speaker-category' round=current_round category=category.slug %}">


### PR DESCRIPTION
As there is a different tab for reply speeches (without division classifiers), it makes more sense to use "Substantive speeches" (abbreviated to "Substantives") to describe that kind of tab.

Brings me to another question. How is (grammatical) gender dealt with in strings? Because if "All" is kept, there would have to be two different strings for that word in French: "toutes" for teams and "tous" for speakers.