### PR TITLE
Remove localization on attribute numbers

### DIFF
--- a/tabbycat/motions/templates/motion_statistics_bp_elim.html
+++ b/tabbycat/motions/templates/motion_statistics_bp_elim.html
@@ -35,7 +35,7 @@
           {% endblocktrans %}
 
           <div class="progress-bar progress-bar-advancing"
-               style="width: {{ advancing_pc }}%" data-toggle="tooltip"
+               style="width: {{ advancing_pc|unlocalize }}%" data-toggle="tooltip"
                title="{{ advancing_tooltip_text }}">
             {% if advancing_pc >= 25 %}
               {% trans "advanced" %}
@@ -44,7 +44,7 @@
             {% endif %}
           </div>
           <div class="progress-bar progress-bar-eliminated"
-               style="width: {{ eliminated_pc }}%" data-toggle="tooltip"
+               style="width: {{ eliminated_pc|unlocalize }}%" data-toggle="tooltip"
                title="{{ eliminated_tooltip_text }}">
             {% if eliminated_pc >= 25 %}
               {% trans "eliminated" %}

--- a/tabbycat/motions/templates/motion_statistics_bp_prelim.html
+++ b/tabbycat/motions/templates/motion_statistics_bp_prelim.html
@@ -10,7 +10,7 @@
         {% for side, average, width in motion.averages %}
           {% if average > 0 %}
             <div class="progress-bar progress-bar-{{ side }}"
-                 style="width: {{ width }}%">
+                 style="width: {{ width|unlocalize }}%">
               {{ side.upper }} {{ average|floatformat:2 }}
             </div>
           {% endif %}
@@ -42,7 +42,7 @@
             {% endblocktrans %}
 
             <div class="progress-bar progress-points-{{ points }}"
-                 style="width: {{ percentage }}%" data-toggle="tooltip"
+                 style="width: {{ percentage|unlocalize }}%" data-toggle="tooltip"
                  title="{{ tooltip_text }}">
               {% if count > 0 %}
                 {% if points == 3 %}

--- a/tabbycat/motions/templates/motion_statistics_twoteam.html
+++ b/tabbycat/motions/templates/motion_statistics_twoteam.html
@@ -8,12 +8,12 @@
     <div class="col">
 
       <div class="progress">
-        <div class="progress-bar progress-bar-aff" style="width: {{ motion.aff_win_percentage }}%">
+        <div class="progress-bar progress-bar-aff" style="width: {{ motion.aff_win_percentage|unlocalize }}%">
           {% if motion.aff_win_percentage >= 5 %}
             {{ motion.aff_win_percentage|floatformat:"0" }}%
           {% endif %}
         </div>
-        <div class="progress-bar progress-bar-neg" style="width: {{ motion.neg_win_percentage }}%">
+        <div class="progress-bar progress-bar-neg" style="width: {{ motion.neg_win_percentage|unlocalize }}%">
           {% if motion.neg_win_percentage >= 5 %}
             {{ motion.neg_win_percentage|floatformat:"0" }}%
           {% endif %}
@@ -65,14 +65,14 @@
       <div class="col">
         <div class="progress">
           {% if motion.aff_veto_percentage %}
-            <div class="progress-bar progress-bar-aff" style="width: {{ motion.aff_veto_percentage }}%">
+            <div class="progress-bar progress-bar-aff" style="width: {{ motion.aff_veto_percentage|unlocalize }}%">
               {% if motion.aff_veto_percentage >= 5 %}
                 {{ motion.aff_veto_percentage|floatformat:"0" }}%
               {% endif %}
             </div>
           {% endif %}
           {% if motion.neg_veto_percentage %}
-            <div class="progress-bar progress-bar-neg" style="width: {{ motion.neg_veto_percentage }}%">
+            <div class="progress-bar progress-bar-neg" style="width: {{ motion.neg_veto_percentage|unlocalize }}%">
               {% if motion.neg_veto_percentage >= 5 %}
                 {{ motion.neg_veto_percentage|floatformat:"0" }}%
               {% endif %}


### PR DESCRIPTION
When numbers are being used as attributes in HTML tags, they should not be localized, as HTML can only deal with one. This is apparent in the motion statistics.