### PR TITLE
Correct omission in unlocalize filter

### DIFF
--- a/tabbycat/motions/templates/motion_statistics_bp_elim.html
+++ b/tabbycat/motions/templates/motion_statistics_bp_elim.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n l10n %}
 
 <div class="col-sm-12">
 

--- a/tabbycat/motions/templates/motion_statistics_bp_prelim.html
+++ b/tabbycat/motions/templates/motion_statistics_bp_prelim.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n l10n %}
 
 <div class="col-sm-12">
 

--- a/tabbycat/motions/templates/motion_statistics_twoteam.html
+++ b/tabbycat/motions/templates/motion_statistics_twoteam.html
@@ -1,4 +1,4 @@
-{% load debate_tags i18n %}
+{% load debate_tags i18n l10n %}
 
 {% tournament_side_names tournament 'abbr' as side_names %}
 


### PR DESCRIPTION
Didn't notice that the l10n module had to be loaded, thought i18n would have covered it.