### PR TITLE
Bump Summernote version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ django-ipware==2.1.0                    # IP Address logging
 django-jet==1.0.7                       # Admin Backend
 django-gfklookupwidget==1.0.6           # Replaces object_id field with a search link
 django-statici18n==1.8.2                # Compile translations files as static file
-django-summernote==0.8.8.7              # WYSIWYG editor
+django-summernote==0.8.8.8              # WYSIWYG editor
 munkres==1.0.12                         # Algorithm for adjudicator allocation
 dj-cmd==1.0                             # Provides the dj command alias
 raven==6.9.0                            # Client for Sentry error tracking

--- a/tabbycat/options/fields.py
+++ b/tabbycat/options/fields.py
@@ -2,18 +2,9 @@ import logging
 
 from django.forms import ChoiceField, MultiValueField, MultiWidget, Select
 
-from django_summernote.widgets import SummernoteWidget
-
 logger = logging.getLogger(__name__)
 
 EMPTY_CHOICE = '__no_choice__'
-
-
-class FixedSummernoteWidget(SummernoteWidget):
-    """Summernote 0.8.8.6 is incompatible with Django 2.1;
-    this can be removed when it is compatible"""
-    def render(self, name, value, attrs=None, renderer=None):
-        return super().render(name, value, attrs)
 
 
 class MultiSelect(MultiWidget):

--- a/tabbycat/options/preferences.py
+++ b/tabbycat/options/preferences.py
@@ -2,6 +2,7 @@ from django.core.validators import MinValueValidator
 from django.forms import ValidationError
 from django.utils.encoding import force_text
 from django.utils.translation import gettext_lazy as _
+from django_summernote.widgets import SummernoteWidget
 from dynamic_preferences.preferences import Section
 from dynamic_preferences.types import BooleanPreference, ChoicePreference, FloatPreference, IntegerPreference, LongStringPreference, StringPreference
 
@@ -11,7 +12,6 @@ from tournaments.utils import get_side_name_choices
 
 from .types import MultiValueChoicePreference
 from .models import tournament_preferences_registry
-from .fields import FixedSummernoteWidget
 
 
 # ==============================================================================
@@ -990,7 +990,7 @@ class TournamentStaff(LongStringPreference):
     section = public_features
     name = 'tournament_staff'
     default = ""
-    widget = FixedSummernoteWidget(attrs={'height': 150})
+    widget = SummernoteWidget(attrs={'height': 150})
     field_kwargs = {'required': False}
 
 
@@ -1001,7 +1001,7 @@ class WelcomeMessage(LongStringPreference):
     section = public_features
     name = 'welcome_message'
     default = ""
-    widget = FixedSummernoteWidget
+    widget = SummernoteWidget
     field_kwargs = {'required': False}
 
 

--- a/tabbycat/tournaments/forms.py
+++ b/tabbycat/tournaments/forms.py
@@ -3,10 +3,10 @@ import math
 from django.forms.fields import IntegerField
 from django.forms import CharField, ChoiceField, ModelChoiceField, ModelForm
 from django.utils.translation import gettext_lazy as _
+from django_summernote.widgets import SummernoteWidget
 
 from adjfeedback.models import AdjudicatorFeedbackQuestion
 from breakqual.models import BreakCategory
-from options.fields import FixedSummernoteWidget
 from options.preferences import TournamentStaff
 from options.presets import all_presets, get_preferences_data, presets_for_form, public_presets_for_form
 
@@ -94,7 +94,7 @@ class TournamentConfigureForm(ModelForm):
         initial=_("<strong>Tabulation:</strong> [list tabulation staff here]<br />"
             "<strong>Organisation:</strong> [list organising committee members here]<br />"
             "<strong>Adjudication:</strong> [list chief adjudicators here]"),
-        widget=FixedSummernoteWidget,
+        widget=SummernoteWidget,
     )
 
     def save(self):


### PR DESCRIPTION
0.8.8.7 does not exist (it was skipped). 0.8.8.8 exists and fixes the incompatibility with Django 2.1. This commit also removes our workaround for the widget.