### PR TITLE
Mark strings in HTML files to be translated

### DIFF
--- a/tabbycat/adjfeedback/templates/add_feedback.html
+++ b/tabbycat/adjfeedback/templates/add_feedback.html
@@ -1,8 +1,8 @@
 {% extends "feedback_base.html" %}
-{% load debate_tags %}
+{% load debate_tags i18n %}
 {% load static %}
 
-{% block head-title %}Who is the feedback from?{% endblock %}
-{% block page-title %}Enter Feedback{% endblock %}
+{% block head-title %}{% trans "Who is the feedback from?" %}{% endblock %}
+{% block page-title %}{% trans "Enter Feedback" %}{% endblock %}
 
 {% block page-subnav-actions %}{% endblock %}

--- a/tabbycat/adjfeedback/templates/feedback_base.html
+++ b/tabbycat/adjfeedback/templates/feedback_base.html
@@ -17,7 +17,7 @@
     </a>
     <a class="btn btn-outline-primary {% if feedback_important_nav %}active disabled{% endif %}"
        href="{% tournamenturl 'adjfeedback-view-important' %}">
-      Important
+      {% trans "Important" %}
     </a>
     <a class="btn btn-outline-primary {% if feedback_source_nav %}active disabled{% endif %}"
        href="{% tournamenturl 'adjfeedback-view-by-source' %}">

--- a/tabbycat/adjfeedback/templates/feedback_by_source.html
+++ b/tabbycat/adjfeedback/templates/feedback_by_source.html
@@ -1,8 +1,8 @@
 {% extends "feedback_base.html" %}
 {% load debate_tags i18n %}
 
-{% block head-title %}Feedback {{ source_type }} {{ source_name }}{% endblock %}
-{% block page-title %}Feedback {{ source_type }} {{ source_name }}{% endblock %}
+{% block head-title %}{% blocktrans trimmed %}Feedback {{ source_type }} {{ source_name }}{% endblocktrans %}{% endblock %}
+{% block page-title %}{% blocktrans trimmed %}Feedback {{ source_type }} {{ source_name }}{% endblocktrans %}{% endblock %}
 
 {% block content %}
 

--- a/tabbycat/adjfeedback/templates/feedback_card.html
+++ b/tabbycat/adjfeedback/templates/feedback_card.html
@@ -27,7 +27,9 @@
             {% elif feedback.score > score_thresholds.high_score %}badge-success
             {% else %}badge-primary{% endif %}" data-toggle="tooltip"
             title="{% trans "The score given in this piece of feedback." %}">
-        Given {{ feedback.score }}
+        {% blocktrans trimmed with score=feedback.score %}
+          Given {{ score }}
+        {% endblocktrans %}
       </span>
       <span class="badge mr-2 badge-light float-right" data-toggle="tooltip">
         {% blocktrans trimmed with test=feedback.adjudicator.test_score %}
@@ -86,10 +88,10 @@
       </span>
       <span class="float-right" data-toggle="tooltip"
             title="{% trans 'Ignored feedback is counted as having been submitted, but does not affect this adjudicator\'s score.' %}">
-        <form method="POST" action="{% tournamenturl 'adjfeedback-ignore-feedback' feedback.id %}"      class='text-secondary'>
+        <form method="POST" action="{% tournamenturl 'adjfeedback-ignore-feedback' feedback.id %}" class='text-secondary'>
           {% csrf_token %}
           <button type="submit" class="btn btn-link text-muted p-0">
-            <small>{% if feedback.ignored %}Un-ignore{% else %}Ignore{% endif %}</small>
+            <small>{% if feedback.ignored %}{% trans "Un-ignore" %}{% else %}{% trans "Ignore" %}{% endif %}</small>
           </button>
         </form>
       </span>

--- a/tabbycat/adjfeedback/templates/feedback_cards_list.html
+++ b/tabbycat/adjfeedback/templates/feedback_cards_list.html
@@ -1,5 +1,5 @@
 {% extends "feedback_base.html" %}
-{% load debate_tags %}
+{% load debate_tags i18n %}
 
 {% block content %}
   <div class="row">
@@ -14,7 +14,8 @@
 
   {% if not feedbacks %}
     <!-- Can't use empty as card-columns div messes up the alert -->
-    {% include "components/alert.html" with type="info" message="No feedback has been submitted yet" %}
+    {% trans "No feedback has been submitted yet" as message %}
+    {% include "components/alert.html" with type="info" %}
   {% endif %}
 
 {% endblock content %}

--- a/tabbycat/adjfeedback/templates/feedback_overview.html
+++ b/tabbycat/adjfeedback/templates/feedback_overview.html
@@ -1,7 +1,7 @@
 {% extends "feedback_base.html" %}
 {% load debate_tags i18n static %}
 
-{% block sub-title %}<span id="c_breaking">{{ c_breaking }}</span> marked as breaking{% endblock %}
+{% block sub-title %}{% blocktrans trimmed %}<span id="c_breaking">{{ c_breaking }}</span> marked as breaking{% endblocktrans %}{% endblock %}
 
 {% block page-alerts %}
 

--- a/tabbycat/adjfeedback/templates/overview_modals.html
+++ b/tabbycat/adjfeedback/templates/overview_modals.html
@@ -7,31 +7,39 @@
         <div class="modal-body pb-0 pt-0">
           <div class="list-group list-group-flush">
 
-            {% include "components/form-title.html" with title="Change Test Score" %}
+            {% trans "Change Test Score" as title %}
+            {% include "components/form-title.html" %}
 
             {% csrf_token %}
 
             <div class="list-group-item text-info py-3">
-              The score range for adjudicators is between <strong>{{ pref.adj_min_score }}</strong> and
-              <strong>{{ pref.adj_max_score }}</strong>. Decimals are permitted. This can be configured in
-              <a href="{% tournamenturl 'options-tournament-section' section='feedback' %}">Feedback settings</a>.
+              {% tournamenturl 'options-tournament-section' section='feedback' as feedback_options %}
+              {% blocktrans trimmed with min_score=pref.adj_min_score max_score=pref.adj_max_score %}
+                The score range for adjudicators is between <strong>{{ pref.adj_min_score }}</strong> and
+                <strong>{{ pref.adj_max_score }}</strong>. Decimals are permitted. This can be configured in
+                <a href="{{ feedback_options }}">Feedback settings</a>.
+              {% endblocktrans %}
             </div>
             <div class="list-group-item text-info py-3">
-              The minimum score require to be allocated as a panellist or chair (when using the
-              auto-allocator) is <strong>{{ pref.adj_min_voting_score }}</strong>. This can be configured in
-              <a href="{% tournamenturl 'options-tournament-section' section='draw_rules' %}">Draw settings</a>.
+              {% tournamenturl 'options-tournament-section' section='draw_rules' as draw_rules %}
+              {% blocktrans trimmed with min_voting_score=pref.adj_min_voting_score %}
+                The minimum score require to be allocated as a panellist or chair (when using the
+                auto-allocator) is <strong>{{ min_voting_score }}</strong>. This can be configured in
+                <a href="{{ draw_rules }}">Draw settings</a>.
+              {% endblocktrans %}
             </div>
             <div class="list-group-item">
               <input id="id_adj_id" name="adj_id" type="hidden" />
               <div class="form-group pb-3">
-                <label>Test score</label>
+                <label>{% trans "Test score" %}</label>
                 <input id="id_test_score" class="form-control" name="test_score" placeholder="3.5"
                        min="{{ pref.adj_min_score }}" max="{{ pref.adj_max_score }}"
                        type="number" step="any"></input>
               </div>
             </div>
 
-            {% include "components/form-submit.html" with title="Save Test Score" %}
+            {% trans "Save Test Score" as title %}
+            {% include "components/form-submit.html" %}
 
             </div>
         </div>
@@ -45,7 +53,7 @@
     <div class="modal-dialog modal-dialog-centered modal-md">
       <div class="modal-content">
         <div class="modal-header  text-center">
-          <h3>Edit Note</h3>
+          <h3>{% trans "Edit Note" %}</h3>
         </div>
         <div class="modal-body">
           <form id="adjNoteForm" method="POST" action="{% tournamenturl 'adjfeedback-set-adj-note' %}">
@@ -59,7 +67,7 @@
             <div class="form-group">
               <div class="col-sm-12">
                 <button type="submit" value="Save" class="btn btn-block btn-success">
-                  Save
+                  {% trans "Save" %}
                 </button>
               </div>
             </div>

--- a/tabbycat/adjfeedback/templates/public_add_feedback.html
+++ b/tabbycat/adjfeedback/templates/public_add_feedback.html
@@ -1,8 +1,8 @@
 {% extends "add_feedback.html" %}
-{% load debate_tags %}
+{% load debate_tags i18n %}
 
-{% block head-title %}Who are you?{% endblock %}
-{% block sub-title %}click your name or your team on this list{% endblock %}
+{% block head-title %}{% trans "Who are you?" %}{% endblock %}
+{% block sub-title %}{% trans "click your name or your team on this list" %}{% endblock %}
 
 {% block page-subnav-sections %}{% endblock %}
 {% block page-subnav-actions %}{% endblock %}
@@ -10,9 +10,15 @@
 
 {% block enter-feedback-adj-link %}
   <a href="{% tournamenturl 'adjfeedback-public-add-from-adjudicator-pk' adj.id %}">
-  Add feedback from {{ adj.name }}</a>
+    {% blocktrans trimmed with name=adj.name %}
+      Add feedback from {{ name }}
+    {% endblocktrans %}
+  </a>
 {% endblock %}
 {% block enter-feedback-team-link %}
   <a href="{% tournamenturl 'adjfeedback-public-add-from-team-pk' team.id %}">
-  Add feedback from {{ team.long_name }}</a>
+    {% blocktrans trimmed with name=team.long_name %}
+      Add feedback from {{ name }}
+    {% endblocktrans %}
+  </a>
 {% endblock %}

--- a/tabbycat/adjfeedback/templates/update_adjudicator_scores.html
+++ b/tabbycat/adjfeedback/templates/update_adjudicator_scores.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static debate_tags add_field_css i18n %}
+{% load static debate_tags add_field_css i18n l10n %}
 
 {% block head-title %}<span class="emoji">🔟</span> {% trans "Update Adjudicator Scores" context "page title" %}
 {% endblock %}
@@ -32,7 +32,7 @@
     </div>
 
     <div class="list-group-item list-group-item-secondary pb-0">
-<pre><code>{% for adj, score in sample %}{{ adj }},{{ score }}
+<pre><code>{% for adj, score in sample %}{{ adj }},{{ score|unlocalize }}
 {% endfor %}</code></pre>
     </div>
 

--- a/tabbycat/availability/templates/availability_index.html
+++ b/tabbycat/availability/templates/availability_index.html
@@ -42,9 +42,8 @@
   {% else %}
     {% if previous_unconfirmed %}
       <button class="btn btn-warning" id="createDraw"
-        data-toggle="tooltip" title="{{ previous_unconfirmed }} debates from
-        {{ round.prev.name }} do not have a completed ballot —
-        this may lead to a draw that fails or is incorrect">
+        data-toggle="tooltip" title="{% blocktrans trimmed with round_name=round.prev.name %}{{ previous_unconfirmed }} debates from
+        {{ round_name }} do not have a completed ballot — this may lead to a draw that fails or is incorrect{% endblocktrans %}">
         {% trans "Generate Draw" %} <i data-feather="chevron-right"></i>
       </button>
     {% elif availability_info.teams.in_now == 0 %}

--- a/tabbycat/breakqual/templates/breaking_adjs.html
+++ b/tabbycat/breakqual/templates/breaking_adjs.html
@@ -1,12 +1,13 @@
 {% extends "tables/base_vue_table.html" %}
-{% load static %}
-{% load debate_tags %}
+{% load static debate_tags i18n %}
 
 {% block page-alerts %}
   <div class="alert alert-info">
+  	{% tournamenturl 'adjfeedback-overview' as feedback_url %}
     <i data-feather="alert-circle"></i>
-    Adjudicators can be marked as breaking in the
-    <a href="{% tournamenturl 'adjfeedback-overview' %}">Feedback Overview</a> section.
+    {% blocktrans trimmed %}
+	    Adjudicators can be marked as breaking in the <a href="{{ feedback_url }}">Feedback Overview</a> section.
+    {% endblocktrans %}
   </div>
 {% endblock %}
 

--- a/tabbycat/breakqual/templates/breaking_teams.html
+++ b/tabbycat/breakqual/templates/breaking_teams.html
@@ -72,13 +72,16 @@
     {% if pref.public_breaking_teams %}
       <div class="alert alert-danger">
         <i data-feather="alert-circle"></i>
-        The <strong>public breaking teams</strong> configuration setting is
-        enabled. As soon as you click the button, the breaking teams list will
-        be visible on the public site, before you have a chance to
-        double-check it! It is strongly recommended that you disable this
-        setting on the <a href="{% tournamenturl 'options-tournament-index' %}">
-        tournament configuration page</a> before generating the team
-        breaks.
+        {% tournamenturl 'options-tournament-index' as options_url %}
+        {% blocktrans trimmed %}
+          The <strong>public breaking teams</strong> configuration setting is
+          enabled. As soon as you click the button, the breaking teams list will
+          be visible on the public site, before you have a chance to
+          double-check it! It is strongly recommended that you disable this
+          setting on the <a href="{{ options_url }}">
+          tournament configuration page</a> before generating the team
+          breaks.
+        {% endblocktrans %}
       </div>
     {% else %}
 

--- a/tabbycat/breakqual/templates/public_break_index.html
+++ b/tabbycat/breakqual/templates/public_break_index.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
-{% load debate_tags %}
+{% load debate_tags i18n %}
 
-{% block head-title %}<span class="emoji">👑</span>Break{% endblock %}
-{% block page-title %}Break{% endblock %}
+{% block head-title %}<span class="emoji">👑</span> {% trans "Break" %}{% endblock %}
+{% block page-title %}{% trans "Break" %}{% endblock %}
 
 {% block content %}
 
@@ -12,13 +12,15 @@
     {% if pref.public_breaking_teams %}
       {% for category in tournament.breakcategory_set.all %}
       <li class="list-group-item"><a  href="{% tournamenturl 'breakqual-public-teams' category.slug %}">
-        {{ category.name }} Break
+        {% blocktrans trimmed with category_name=category.name %}
+          {{ category.name }} Break
+        {% endblocktrans %}
       </a></li>
       {% endfor %}
     {% endif %}
     {% if pref.public_breaking_adjs %}
       <li class="list-group-item"><a href="{% tournamenturl 'breakqual-public-adjs' %}">
-        Adjudicators
+        {% trans "Adjudicators" %}
       </a></li>
     {% endif %}
     </ul>

--- a/tabbycat/divisions/templates/division_allocations.html
+++ b/tabbycat/divisions/templates/division_allocations.html
@@ -1,9 +1,9 @@
 {% extends "base.html" %}
-{% load debate_tags %}
+{% load static debate_tags i18n %}
 {% load static %}
 
-{% block head-title %}Allocate Divisions{% endblock %}
-{% block page-title %}Allocate Divisions{% endblock %}
+{% block head-title %}{% trans "Allocate Divisions" %}{% endblock %}
+{% block page-title %}{% trans "Allocate Divisions" %}{% endblock %}
 
 {% block page-subnav-sections %}
   <!-- DISABLED UNTIL WORKING
@@ -21,12 +21,12 @@
   </form>
    -->
   <div>
-    <div class="btn btn-inactive text-muted">Preference:</div>
+    <div class="btn btn-inactive text-muted">{% trans "Preference:" %}</div>
     <div class="btn-group">
-      <div class="btn btn-success" disabled="disabled">1/2</div>
-      <div class="btn btn-primary" disabled="disabled">3/4</div>
-      <div class="btn btn-warning" disabled="disabled">5+</div>
-      <div class="btn btn-danger" disabled="disabled">NA</div>
+      <div class="btn btn-success" disabled="disabled">{% trans "1/2" context "1 or 2" %}</div>
+      <div class="btn btn-primary" disabled="disabled">{% trans "3/4" context "3 or 4" %}</div>
+      <div class="btn btn-warning" disabled="disabled">{% trans "5+" context "5 or higher" %}</div>
+      <div class="btn btn-danger" disabled="disabled">{% trans "NA" context "Not applicable" %}</div>
     </div>
   </div>
 {% endblock %}
@@ -36,7 +36,7 @@
   <form method="POST" action="{% tournamenturl 'create_division' %}">
     {% csrf_token %}
     <button class="btn btn-success " type="submit">
-      <i data-feather="plus-circle"></i> Add New Division
+      <i data-feather="plus-circle"></i>{% trans "Add New Division" %}
     </button>
   </form>
 {% endblock %}

--- a/tabbycat/divisions/templates/public_divisions.html
+++ b/tabbycat/divisions/templates/public_divisions.html
@@ -1,21 +1,24 @@
 {% extends "base.html" %}
-{% load debate_tags %}
-{% load static %}
+{% load static debate_tags i18n %}
 
-{% block head-title %}All Divisions{% endblock %}
-{% block page-title %}All Divisions{% endblock %}
+{% block head-title %}{% trans "All Divisions" %}{% endblock %}
+{% block page-title %}{% trans "All Divisions" %}{% endblock %}
 
 {% block content %}
   {% for venue_category in venue_categories %}
   <div class="col-sm-12">
 
-    <h3 class="page-header">At {{ venue_category.name }}</h3>
+    <h3 class="page-header">
+      {% blocktrans trimmed with venue_category_name=venue_category.name %}At {{ venue_category_name }}{% endblocktrans %}
+    </h3>
     {% if venue_category.divisions %}
       {% for division in venue_category.divisions %}
         <ul class="list-group col-sm-2">
           <li class="list-group-item">
             <span class="badge badge-secondary">{{ division.time_slot|time:'h:i A' }}</span>
-            <h5 class="list-group-item-heading">Division {{ division.name }}</h5>
+            <h5 class="list-group-item-heading">
+              {% blocktrans trimmed with div=division.name %}Division {{ div }}{% endblocktrans %}
+            </h5>
           </li>
           {% for team in division.teams.all %}
             <li class="list-group-item small">{{ team.long_name }}</li>

--- a/tabbycat/draw/templates/confirmations_view.html
+++ b/tabbycat/draw/templates/confirmations_view.html
@@ -1,12 +1,12 @@
 {% extends "base.html" %}
-{% load debate_tags %}
+{% load debate_tags i18n %}
 
-{% block head-title %}Shift Confirmations{% endblock %}
-{% block page-title %}Shift Confirmations{% endblock %}
+{% block head-title %}{% trans "Shift Confirmations" %}{% endblock %}
+{% block page-title %}{% trans "Shift Confirmations" %}{% endblock %}
 
 {% block page-subnav-sections %}
   <a class="btn btn-primary " href="{% roundurl 'draw' %}">
-    <i data-feather="chevron-left"></i> Back to Draw
+    <i data-feather="chevron-left"></i>{% trans "Back to Draw" %}
   </a>
 {% endblock %}
 
@@ -15,7 +15,7 @@
   <div class="col-md-12">
     <div class="card">
       <div class="panel-heading">
-        <h3 class="panel-title">Adjudicators with no confirmed shifts</h3>
+        <h3 class="panel-title">{% trans "Adjudicators with no confirmed shifts" %}</h3>
       </div>
       <div class="card-body">
         {% for adj in adjs %}

--- a/tabbycat/draw/templates/draw_confirm_regeneration.html
+++ b/tabbycat/draw/templates/draw_confirm_regeneration.html
@@ -1,33 +1,38 @@
 {% extends "base.html" %}
-{% load debate_tags %}
+{% load debate_tags i18n %}
 
 {% block page-title %}
-  Confirm draw regeneration
+  {% trans "Confirm draw regeneration" %}
 {% endblock %}
 
 {% block page-subnav-sections %}
   <a class="btn btn-outline-primary " href="{% roundurl 'draw' %}">
-    <i data-feather="chevron-left"></i> Back to Draw
+    <i data-feather="chevron-left"></i>{% trans "Back to Draw" %}
   </a>
 {% endblock %}
 
 {% block head-title %}
-  <span class="emoji">🔥</span>Confirm Draw Deletion for {{ round.name }}
+  <span class="emoji">🔥</span>
+  {% blocktrans trimmed with name=round.name %}Confirm Draw Deletion for {{ name }}{% endblocktrans %}
 {% endblock %}
 
 {% block page-alerts %}
 
   <div class="alert alert-warning">
-    Do you really want to regenerate the draw for {{ round.name }}? This will
+    {% blocktrans trimmed with name=round.name %}
+    Do you really want to regenerate the draw for {{ name }}? This will
     delete <strong>all the debates in the current draw</strong> —  including
     their ballots and adjudicator allocations — and cannot be undone.
     You probably don't want to do this if any results have been entered!
+    {% endblocktrans %}
   </div>
 
   <form method="POST" action="{% roundurl 'draw-regenerate' %}">
     {% csrf_token %}
     <button class="btn btn-block btn-danger " type="submit">
-      Yes, I want to delete the current draw for {{ round.name }}
+      {% blocktrans trimmed with name=round.name %}
+      Yes, I want to delete the current draw for {{ name }}
+      {% endblocktrans %}
     </button>
   </form>
 

--- a/tabbycat/draw/templates/draw_display_admin.html
+++ b/tabbycat/draw/templates/draw_display_admin.html
@@ -317,7 +317,7 @@
 
           <div class="list-group-item pb-3">
             <div class="form-group">
-              <label>Start at</label>
+              <label>{% trans "Start at" %}</label>
               <input class="form-control" placeholder="{{ round.starts_at|time:'H:i' }}" name="start_time"></input>
             </div>
           </div>

--- a/tabbycat/draw/templates/draw_display_assistant.html
+++ b/tabbycat/draw/templates/draw_display_assistant.html
@@ -48,7 +48,7 @@
 
           <div class="list-group-item pb-3">
             <div class="form-group">
-              <label>Start at</label>
+              <label>{% trans "Start at" %}</label>
               <input class="form-control" placeholder="{{ round.starts_at|time:'H:i' }}" name="start_time"></input>
             </div>
           </div>

--- a/tabbycat/draw/templates/draw_set_debate_times.html
+++ b/tabbycat/draw/templates/draw_set_debate_times.html
@@ -1,19 +1,19 @@
 {% extends "base.html" %}
-{% load debate_tags %}
+{% load debate_tags i18n %}
 
-{% block page-title %}Schedule Debates{% endblock %}
-{% block head-title %}<span class="emoji">⏰</span>Schedule Debates {% endblock %}
-{% block sub-title %}for {{ round.name }}{% endblock %}
+{% block page-title %}{% trans "Schedule Debates" %}{% endblock %}
+{% block head-title %}<span class="emoji">⏰</span>{% trans "Schedule Debates" %}{% endblock %}
+{% block sub-title %}{% blocktrans trimmed with name=round.name %}for {{ name }}{% endblocktrans %}{% endblock %}
 
 {% block page-subnav-sections %}
   <a class="btn btn-primary " href="{% roundurl 'draw' %}">
-    <i data-feather="chevron-left"></i> Back to Draw
+    <i data-feather="chevron-left"></i>{% trans "Back to Draw" %}
   </a>
 {% endblock %}
 
 {% block page-subnav-actions %}
   <a href="{% roundurl 'draw-schedule-apply' %}" class="btn btn-success " id="assignTimes">
-    Apply Times to Debates
+    {% trans "Apply Times to Debates" %}
   </a>
 {% endblock %}
 
@@ -23,7 +23,7 @@
   <div class="col-md-6">
     <div class="card">
       <div class="panel-heading">
-        <h4 class="panel-title">Assign Dates to Venue Catgories</h4>
+        <h4 class="panel-title">{% trans "Assign Dates to Venue Catgories" %}</h4>
       </div>
       <form id="assignForm" method="POST" action="{% roundurl 'draw-schedule-apply' %}">
         {% csrf_token %}
@@ -51,7 +51,7 @@
   <div class="col-md-6">
     <div class="card">
       <div class="panel-heading">
-        <h4 class="panel-title">Assign Times to Divisions</h4>
+        <h4 class="panel-title">{% trans "Assign Times to Divisions" %}</h4>
       </div>
       <ul class="list-group">
         {% for d in divisions %}

--- a/tabbycat/draw/templates/draw_status_draft.html
+++ b/tabbycat/draw/templates/draw_status_draft.html
@@ -14,7 +14,7 @@
   <form id="confirmForm" method="POST" action="{% roundurl 'draw-confirm' %}">
     {% csrf_token %}
     <button id="confirmDraw" class="btn btn-success" type="submit">
-      Confirm Draw <i data-feather="chevron-right"></i>
+      {% trans "Confirm Draw" %}<i data-feather="chevron-right"></i>
     </button>
   </form>
 {% endblock %}

--- a/tabbycat/draw/templates/draw_subpage.html
+++ b/tabbycat/draw/templates/draw_subpage.html
@@ -1,8 +1,8 @@
 {% extends "draw_base.html" %}
-{% load debate_tags %}
+{% load debate_tags i18n %}
 
 {% block page-subnav-sections %}
   <a class="btn btn-outline-primary " href="{% roundurl 'draw' %}">
-    <i data-feather="chevron-left"></i> Back to Draw
+    <i data-feather="chevron-left"></i>{% trans "Back to Draw" %}
   </a>
 {% endblock %}

--- a/tabbycat/draw/templates/edit_matchups.html
+++ b/tabbycat/draw/templates/edit_matchups.html
@@ -1,9 +1,12 @@
 {% extends "base.html" %}
 {% load static debate_tags i18n %}
-{% load debate_tags %}
 
-{% block head-title %}Edit Sides/Matchups for {{ round.abbreviation }}{% endblock %}
-{% block page-title %}Edit Sides/Matchups for {{ round.abbreviation }}{% endblock %}
+{% block head-title %}
+  {% blocktrans trimmed with abbreviation=round.abbreviation %}Edit Sides/Matchups for {{ abbreviation }}{% endblocktrans %}
+{% endblock %}
+{% block page-title %}
+  {% blocktrans trimmed with abbreviation=round.abbreviation %}Edit Sides/Matchups for {{ abbreviation }}{% endblocktrans %}
+{% endblock %}
 
 {% block content %}
   <div id="vueMount">

--- a/tabbycat/draw/templates/public_all_tournament_institutions.html
+++ b/tabbycat/draw/templates/public_all_tournament_institutions.html
@@ -1,16 +1,15 @@
 {% extends "base.html" %}
-{% load debate_tags %}
-{% load static %}
+{% load static debate_tags i18n %}
 
-{% block head-title %}All Institutions{% endblock %}
-{% block page-title %}All Institutions{% endblock %}
+{% block head-title %}{% trans "All Institutions" %}{% endblock %}
+{% block page-title %}{% trans "All Institutions" %}{% endblock %}
 
 {% block content %}
   <ul class="list-group">
     {% for institution in institutions %}
       <a class="list-group-item" href="{% url 'all-draws-for-institution' institution.id %}">
-        <span>Draws for {{ institution.name }}</span>
-        <span class="badge badge-secondary float-right">VIEW ALL</span>
+        <span>{% blocktrans trimmed with institution_name=institution.name %}Draws for {{ institution_name }}{% endblocktrans %}</span>
+        <span class="badge badge-secondary float-right">{% trans "VIEW ALL" %}</span>
       </a>
     {% endfor %}
   </ul>

--- a/tabbycat/draw/templates/public_all_tournament_venues.html
+++ b/tabbycat/draw/templates/public_all_tournament_venues.html
@@ -2,15 +2,15 @@
 {% load debate_tags %}
 {% load static %}
 
-{% block head-title %}All Venues{% endblock %}
-{% block page-title %}All Venues{% endblock %}
+{% block head-title %}{% trans "All Venues" %}{% endblock %}
+{% block page-title %}{% trans "All Venues" %}{% endblock %}
 
 {% block content %}
   <ul class="list-group">
     {% for vc in venue_categories %}
       <a href="{% url 'all-draws-for-venue' vc.id %}"class="list-group-item">
-        <span>Draws for {{ vc }}</span>
-        <span class="badge badge-secondary float-right">VIEW ALL</span>
+        <span>{% blocktrans trimmed %}Draws for {{ vc }}{% endblocktrans %}</span>
+        <span class="badge badge-secondary float-right">{% trans "VIEW ALL" %}</span>
       </a>
     {% endfor %}
   </ul>

--- a/tabbycat/motions/templates/motion_statistics.html
+++ b/tabbycat/motions/templates/motion_statistics.html
@@ -1,8 +1,8 @@
 {% extends "standings_base.html" %}
 {% load debate_tags static i18n %}
 
-{% block page-title %}Motion Statistics{% endblock %}
-{% block head-title %}<span class="emoji">💭</span> Motion Statistics{% endblock %}
+{% block page-title %}{% trans "Motion Statistics" %}{% endblock %}
+{% block head-title %}<span class="emoji">💭</span>{% trans "Motion Statistics" %}{% endblock %}
 
 {% block content %}
 

--- a/tabbycat/motions/templates/motions_info.html
+++ b/tabbycat/motions/templates/motions_info.html
@@ -1,9 +1,11 @@
+{% load i18n %}
+
 <div class="modal fade" id="info_{{ motion.id }}" tabindex="-1" role="dialog"
      aria-labelledby="" aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered modal-lg" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title">Info Slide</h5>
+        <h5 class="modal-title">{% trans "Info Slide" %}</h5>
         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">&times;</span>
         </button>

--- a/tabbycat/motions/templates/public_division_motions.html
+++ b/tabbycat/motions/templates/public_division_motions.html
@@ -1,14 +1,13 @@
 {% extends "base.html" %}
-{% load debate_tags %}
-{% load static %}
+{% load static debate_tags i18n %}
 
-{% block head-title %}Motions{% endblock %}
-{% block page-title %}Motions{% endblock %}
+{% block head-title %}{% trans "Motions" %}{% endblock %}
+{% block page-title %}{% trans "Motions" %}{% endblock %}
 
 {% block page-alerts %}
   {% if rounds.all.count == 0 %}
     <div class="alert alert-info" role="alert">
-      No motions have been released yet.
+      {% trans "No motions have been released yet." %}
     </div>
   {% endif %}
 {% endblock %}
@@ -22,14 +21,14 @@
           <table class="table">
             <thead>
               <tr>
-                <th>RSeq</th>
-                <th>Round</th>
-                <th>Reference</th>
-                <th>Venue(s)</th>
-                <th>Divisions</th>
-                <th>Text</th>
+                <th>{% trans "RSeq" %}</th>
+                <th>{% trans "Round" %}</th>
+                <th>{% trans "Reference" %}</th>
+                <th>{% trans "Venue(s)" %}</th>
+                <th>{% trans "Divisions" %}</th>
+                <th>{% trans "Text" %}</th>
                 {% if pref.enable_flagged_motions %}
-                  <th>Contentious</th>
+                  <th>{% trans "Contentious" %}</th>
                 {% endif %}
               </tr>
             </thead>
@@ -37,8 +36,8 @@
             {% for round in rounds %}
               {% for motion in round.motion_set.all %}
                 <tr>
-                  <td>{{ motion.round.seq }}</td>
-                  <td>{{ motion.round.abbreviation }}</td>
+                  <td>{{ round.seq }}</td>
+                  <td>{{ round.abbreviation }}</td>
                   <td>{{ motion.reference }}</td>
                   <td>
                     {% regroup motion.divisions.all by venue_category as unique_venues %}

--- a/tabbycat/options/templates/preferences_presets_confirm.html
+++ b/tabbycat/options/templates/preferences_presets_confirm.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load debate_tags i18n %}
 
-{% block head-title %}❔ {% blocktrans %}Confirm Presets: {{ preset_title }}{% endblocktrans %}{% endblock %}
+{% block head-title %}<span class="emoji">❔</span>{% blocktrans %}Confirm Presets: {{ preset_title }}{% endblocktrans %}{% endblock %}
 {% block page-title %}{% blocktrans %}Confirm Presets: {{ preset_title }}{% endblocktrans %}{% endblock %}
 
 {% block page-subnav-sections %}

--- a/tabbycat/participants/templates/confirm_shifts.html
+++ b/tabbycat/participants/templates/confirm_shifts.html
@@ -1,9 +1,9 @@
 {% extends "base.html" %}
-{% load debate_tags %}
+{% load debate_tags i18n %}
 {% load add_field_css %}
 
-{% block head-title %}Shift Check-In for {{ adjudicator.name }}{% endblock %}
-{% block page-title %}Shift Check-In for {{ adjudicator.name }}{% endblock %}
+{% block head-title %}{% blocktrans trimmed with name=adjudicator.name %}Shift Check-In for {{ name }}{% endblocktrans %}{% endblock %}
+{% block page-title %}{% blocktrans trimmed with name=adjudicator.name %}Shift Check-In for {{ name }}{% endblocktrans %}{% endblock %}
 
 {% block content %}
 
@@ -35,7 +35,7 @@
     <div class="row">
       <div class="col-md-12">
         <button type="submit" name="submit" class="btn btn-success btn-block">
-          Save Availability
+          {% trans "Save Availability" %}
         </button>
       </div>
     </div>

--- a/tabbycat/printing/templates/division_sheets_list.html
+++ b/tabbycat/printing/templates/division_sheets_list.html
@@ -1,15 +1,15 @@
 {% extends "base.html" %}
-{% load debate_tags %}
+{% load debate_tags i18n %}
 
-{% block head-title %}Division Sheets List{% endblock %}
-{% block page-title %}Division Sheets List{% endblock %}
+{% block head-title %}{% trans "Division Sheets List" %}{% endblock %}
+{% block page-title %}{% trans "Division Sheets List" %}{% endblock %}
 
 {% block content %}
 
 <div class="col-md-6">
   <div class="card">
     <div class="panel-heading">
-      <h4 class="panel-title">Master Sheets</h4>
+      <h4 class="panel-title">{% trans "Master Sheets" %}</h4>
     </div>
     <ul class="list-group">
       {% for venue_category in venue_categories %}
@@ -26,7 +26,7 @@
 <div class="col-md-6">
   <div class="card">
     <div class="panel-heading">
-      <h4 class="panel-title">Room Sheets</h4>
+      <h4 class="panel-title">{% trans "Room Sheets" %}</h4>
     </div>
     <ul class="list-group">
       {% for venue_category in venue_categories %}

--- a/tabbycat/printing/templates/master_sheets_view.html
+++ b/tabbycat/printing/templates/master_sheets_view.html
@@ -1,11 +1,17 @@
 {% extends "base.html" %}
-{% load debate_tags %}
+{% load debate_tags i18n %}
 
 {% block head-title %}
-  <div class="text-center d-print-none">Master Sheet for Debates at {{ base_venue_category.name }} in {{ round.name }}</div>
+  <div class="text-center d-print-none">
+    {% blocktrans trimmed with category_name=base_venue_category.name round_name=round.name %}
+    Master Sheet for Debates at {{ category_name }} in {{ round_name }}
+    {% endblocktrans %}
+  </div>
 {% endblock %}
 {% block page-title %}
+  {% blocktrans trimmed with category_name=base_venue_category.name %}
   Master Sheet for Debates at {{ venue_category.name }}
+  {% endblocktrans %}
 {% endblock %}
 
 {% block nav %}{% endblock %}
@@ -36,14 +42,14 @@
               <col style="width:20%">
               <col style="width:8%">
               <col style="width:8%">
-              <th>Div</th>
-              <th>Room</th>
-              <th>Affirmative</th>
-              <th>Negative</th>
-              <th>Adjudicator</th>
-              <th>Winner of the Debate</th>
-              <th>Aff Score</th>
-              <th>Neg Score</th>
+              <th>{% trans "Div" context "Division" %}</th>
+              <th>{% trans "Room" %}</th>
+              <th>{% trans "Affirmative" %}</th>
+              <th>{% trans "Negative" %}</th>
+              <th>{% trans "Adjudicator" %}</th>
+              <th>{% trans "Winner of the Debate" %}</th>
+              <th>{% trans "Aff Score" %}</th>
+              <th>{% trans "Neg Score" %}</th>
             </tr>
           </thead>
           <tbody>
@@ -59,11 +65,13 @@
                 <td></td>
                 <td>
                   {% if debate.aff_team.type == 'B' or debate.neg_team.type == 'B'%}
-                    Bye
+                    {% trans "Bye" context "Odd number of teams" %}
                   {% elif debate.result_status == "P" %}
-                    Postponed
+                    {% trans "Postponed" %}
                   {% elif debate.confirmed_ballot.forfeit %}
-                    Forfeit by {{ debate.confirmed_ballot.forfeit.get_side_name|capfirst }}
+                    {% blocktrans trimmed with side_name=debate.confirmed_ballot.forfeit.get_side_name|capfirst %}
+                    Forfeit by {{ side_name }}
+                    {% endblocktrans %}
                   {% endif %}
                 </td>
                 <td></td>
@@ -81,7 +89,7 @@
 
   <div class="card">
     <div class="panel-heading">
-      <h4 class="panel-title">Additional Comments from the Head Ajudicator</h4>
+      <h4 class="panel-title">{% trans "Additional Comments from the Head Ajudicator" %}</h4>
     </div>
     <div class="card-body">
       <table  class="table">

--- a/tabbycat/printing/templates/randomised_url_sheets.html
+++ b/tabbycat/printing/templates/randomised_url_sheets.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
-{% load debate_tags %}
+{% load debate_tags i18n %}
 
-{% block page-title %}Printable {{ sheet_type|title }} URLs{% endblock %}
+{% block page-title %}{% blocktrans trimmed with sheet=sheet_type|title %}Printable {{ sheet }} URLs{% endblocktrans %}{% endblock %}
 
 {% block header %}{% endblock %}
 {% block nav %}{% endblock %}
@@ -10,9 +10,11 @@
 
 {% block page-alerts %}
   <div class="alert alert-info d-print-none">
+    {% blocktrans %}
     This page is designed to be printed as double sided A4 sheets, with the
     outside facing side showing the participant name and the inside facing side
     showing the URL. Use CTRL-P to print; for best results use Chrome.
+    {% endblocktrans %}
   </div>
 {% endblock %}
 
@@ -21,12 +23,22 @@
   {% for p in parts %}
     <div class="h1 text-center printable-page-break">
       <br>
-      Private URL for {{ p.name }} ({% if p.adjudicator %}{{ p.adjudicator.institution.code }}{% else %}{{ p.speaker.team.short_name }}{% endif %})
+      {% if p.adjudicator %}
+        {% blocktrans trimmed with name=p.name group=p.adjudicator.institution.code team=p.speaker.team.short_name %}
+          Private URL for {{ name }} ({{ group }})
+        {% endblocktrans %}
+      {% else %}
+        {% blocktrans trimmed with name=p.name group=p.speaker.team.short_name %}
+          Private URL for {{ name }} ({{ group }})
+        {% endblocktrans %}
+      {% endif %}
     </div>
     <div class="h4 text-center printable-page-break">
       <br><br><br>
+      {% blocktrans %}
       Please bookmark the following URL, you will use it to submit forms
       throughout the tournament:
+      {% endblocktrans %}
       <br><br>
       {% tournament_absurl 'privateurls-person-index' p.url_key %}
     </div>

--- a/tabbycat/printing/templates/room_sheets_view.html
+++ b/tabbycat/printing/templates/room_sheets_view.html
@@ -1,11 +1,16 @@
 {% extends "base.html" %}
-{% load debate_tags %}
+{% load debate_tags i18n %}
 
 {% block head-title %}
-  <div class="text-center d-print-none">Room Sheets for Debates at {{ base_venue_category.name }} in {{ round.name }}</div>
+  <div class="text-center d-print-none">
+  {% blocktrans trimmed with venue_category=base_venue_category.name round_name=round.name %}
+  Room Sheets for Debates at {{ venue_category }} in {{ round_name }}</div>
+  {% endblocktrans %}
 {% endblock %}
 {% block page-title %}
-  Room Sheets for Debates at {{ venue_category.name }}
+  {% blocktrans trimmed with venue_category=base_venue_category.name %}
+  Room Sheets for Debates at {{ venue_category }}
+  {% endblocktrans %}
 {% endblock %}
 
 {% block nav %}{% endblock %}
@@ -24,8 +29,9 @@
         <div class="card">
           <div class="panel-heading text-center">
             <h3 class="panel-title">
-              {{ debate.round.tournament.short_name }} Division
-              {{ debate.aff_team.division.name }}
+              {% blocktrans trimmed with tournament=debate.round.tournament.short_name division=debate.aff_team.division.name %}
+              {{ tournament }} Division {{ division }}
+              {% endblocktrans %}
             </h3>
           </div>
           <ul class="list-group h4 text-center">
@@ -34,19 +40,24 @@
             </li>
             <li class="list-group-item">
               {% if debate.confirmed_ballot.forfeit %}
-                <del>{{ debate.time|time:"H:i" }}</del>
-                (Forfeit by {{ debate.confirmed_ballot.forfeit.get_side_name|capfirst }})
+                {% blocktrans trimmed with time=debate.time|time:"H:i" side=debate.confirmed_ballot.forfeit.get_side_name|capfirst %}
+                <del>{{ time }}</del> (Forfeit by {{ side }})
+                {% endblocktrans %}
               {% elif debate.time %}
                 {{ debate.time|time:"H:i" }}
               {% else %}
-                (No time set)
+                {% trans "(No time set)" %}
               {% endif %}
             </li>
             <li class="list-group-item">
-              <strong>Affirmative</strong>: {{ debate.aff_team.short_name }}
+              {% blocktrans trimmed with team=debate.aff_team.short_name %}
+              <strong>Affirmative</strong>: {{ team }}
+              {% endblocktrans %}
             </li>
             <li class="list-group-item">
-              <strong>Negative</strong>: {{ debate.neg_team.short_name }}
+              {% blocktrans trimmed with team=debate.neg_team.short_name %}
+              <strong>Negative</strong>: {{ team }}
+              {% endblocktrans %}
             </li>
           </ul>
         </div>

--- a/tabbycat/results/templates/ballot/ballot_scoresheet.html
+++ b/tabbycat/results/templates/ballot/ballot_scoresheet.html
@@ -31,7 +31,7 @@
                   class="btn btn-secondary btn-no-hover {{ team.side_code }}_rank" readonly  />
             ?
           </button>
-          <button class="btn btn-outline-secondary btn-no-hover" readonly />Margin</button>
+          <button class="btn btn-outline-secondary btn-no-hover" readonly />{% trans "Margin" %}</button>
           <button name="{{ team.side_code }}_margin" type="text"
                   class="btn btn-secondary btn-no-hover {{ team.side_code }}_margin" readonly  />
             +0

--- a/tabbycat/results/templates/ballot/standard_ballot_set.html
+++ b/tabbycat/results/templates/ballot/standard_ballot_set.html
@@ -32,7 +32,7 @@
           </h4>
             {% for da in debate.adjudicators.voting_with_positions reversed %}
               <div class="badge badge-secondary float-right ml-2 mt-1">
-                <p class="mb-0">{{ da.0.name }} ({% if da.1 == "o" %}Solo Chair{% elif da.1 == "c" %}Chair{% elif da.1 == "p" %}Panellist{% elif da.1 == "t" %}Trainee{% endif %})</p>
+                <p class="mb-0">{{ da.0.name }} ({% if da.1 == "o" %}{% trans "Solo Chair" %}{% elif da.1 == "c" %}{% trans "Chair" %}{% elif da.1 == "p" %}{% trans "Panellist" %}{% elif da.1 == "t" %}{% trans "Trainee" %}{% endif %})</p>
               </div>
             {% endfor %}
 

--- a/tabbycat/results/templates/public_ballot_set.html
+++ b/tabbycat/results/templates/public_ballot_set.html
@@ -30,7 +30,7 @@
   {% if motion.text  %}
     <div class="card">
       <div class="card-body">
-        <h4 class="card-title">Motion</h4>
+        <h4 class="card-title">{% trans "Motion" %}</h4>
         {{ motion.text }}
       </div>
     </div>
@@ -66,7 +66,7 @@
                 </li>
               {% endfor %}
               <li class="list-group-item list-group-item-{{ team.win_style }}">
-                <em>Total for {{ team.team.short_name }} ({{ team.side }})</em>
+                <em>{% blocktrans trimemd with short_name=team.team.short_name side=team.side %}Total for {{ short_name }} ({{ side }}){% endblocktrans %}</em>
                 <span class="badge badge-secondary float-right">
                   {{ team.total }}
                 </span>

--- a/tabbycat/standings/templates/standings_diversity.html
+++ b/tabbycat/standings/templates/standings_diversity.html
@@ -1,8 +1,8 @@
 {% extends "standings_base.html" %}
 {% load debate_tags static i18n %}
 
-{% block page-title %}🗃Diversity Overview{% endblock %}
-{% block head-title %}<span class="emoji">🗃</span>Diversity Overview{% endblock %}
+{% block page-title %}🗃{% trans "Diversity Overview" %}{% endblock %}
+{% block head-title %}<span class="emoji">🗃</span>{% trans "Diversity Overview" %}{% endblock %}
 {% block diversity_active %}active{% endblock %}
 
 {% block page-subnav-sections %}
@@ -19,7 +19,8 @@
 
 {% block page-alerts %}
 
-  {% include "components/explainer-card.html" with type="info" p1="The speaker and adjudicator results data displayed here is presented without tests for statistical significance. Correlations should not be automatically considered reliable; particularly at small tournaments." %}
+  {% trans "The speaker and adjudicator results data displayed here is presented without tests for statistical significance. Correlations should not be automatically considered reliable; particularly at small tournaments." as p1 %}
+  {% include "components/explainer-card.html" with type="info" %}
 
 {% endblock %}
 

--- a/tabbycat/standings/templates/standings_index.html
+++ b/tabbycat/standings/templates/standings_index.html
@@ -2,8 +2,8 @@
 {% load static %}
 {% load debate_tags %}
 
-{% block head-title %}<span class="emoji">📊</span>Standings{% endblock %}
-{% block page-title %}Standings{% endblock %}
+{% block head-title %}<span class="emoji">📊</span>{% trans "Standings" %}{% endblock %}
+{% block page-title %}{% trans "Standings" %}{% endblock %}
 
 {% block standings_active %}active{% endblock %}
 
@@ -15,18 +15,17 @@
     <!-- List group -->
     <ul class="list-group list-group-flush">
       <li class="list-group-item">
-        <h5 class="card-title mb-0">Top Speaks</h5>
+        <h5 class="card-title mb-0">{% trans "Top Speaks" %}</h5>
       </li>
       {% for top_speak in top_speaks %}
         <li class="list-group-item">
-          {{ top_speak.speaker }} in
-          {{ top_speak.debate_team.debate.round.abbreviation }}
+          {% blocktrans trimmed with speaker=top_speak.speaker round=top_speak.debate_team.debate.round.abbreviation %}
+          {{ speaker }} in {{ round }}
+          {% endblocktrans %}
           <span class="badge badge-secondary float-right">{{ top_speak.score|floatformat }}</span>
         </li>
       {% empty %}
-        <li class="list-group-item">
-          No data yet
-        </li>
+        <li class="list-group-item">{% trans "No data yet" %}</li>
       {% endfor %}
     </ul>
   </div>
@@ -35,16 +34,17 @@
     <!-- List group -->
     <ul class="list-group list-group-flush">
       <li class="list-group-item">
-        <h5 class="card-title mb-0">Bottom Speaks</h5>
+        <h5 class="card-title mb-0">{% trans "Bottom Speaks" %}</h5>
       </li>
       {% for bottom_speak in bottom_speaks %}
         <li class="list-group-item">
-          {{ bottom_speak.speaker }} in
-          {{ bottom_speak.debate_team.debate.round.abbreviation }}
+          {% blocktrans trimmed with speaker=bottom_speak.speaker round=bottom_speak.debate_team.debate.round.abbreviation %}
+          {{ speaker }} in {{ round }}
+          {% endblocktrans %}
           <span class="badge badge-secondary float-right">{{ bottom_speak.score|floatformat }}</span>
         </li>
       {% empty %}
-      <li class="list-group-item">No data yet</li>{% endfor %}
+      <li class="list-group-item">{% trans "No data yet" %}</li>{% endfor %}
     </ul>
   </div>
 
@@ -53,17 +53,17 @@
       <!-- List group -->
       <ul class="list-group list-group-flush">
         <li class="list-group-item">
-          <h5 class="card-title mb-0">Largest Margins</h5>
+          <h5 class="card-title mb-0">{% trans "Largest Margins" %}</h5>
         </li>
         {% for top_margin in top_margins %}
           <li class="list-group-item">
-            {{ top_margin.debate_team.team.short_name }}  vs
-            {{ top_margin.debate_team.opponent.team.short_name }} in
-            {{ top_margin.debate_team.debate.round.abbreviation }}
+            {% blocktrans trimmed with team=top_margin.debate_team.team.short_name opp=top_margin.debate_team.opponent.team.short_name round=top_margin.debate_team.debate.round.abbreviation %}
+            {{ team }}  vs {{ opp }} in {{ round }}
+            {% endblocktrans %}
             <span class="badge badge-secondary float-right">{{ top_margin.margin|floatformat }}</span>
           </li>
         {% empty %}
-          <li class="list-group-item">No data yet</li>
+          <li class="list-group-item">{% trans "No data yet" %}</li>
         {% endfor %}
       </ul>
     </div>
@@ -74,17 +74,17 @@
       <!-- List group -->
       <ul class="list-group list-group-flush">
         <li class="list-group-item">
-          <h5 class="card-title mb-0">Closest Margins</h5>
+          <h5 class="card-title mb-0">{% trans "Closest Margins" %}</h5>
         </li>
         {% for bottom_margin in bottom_margins %}
           <li class="list-group-item">
-            {{ bottom_margin.debate_team.team.short_name }} vs
-            {{ bottom_margin.debate_team.opponent.team.short_name }} in
-            {{ bottom_margin.debate_team.debate.round.abbreviation }}
+            {% blocktrans trimmed with team=bottom_margin.debate_team.team.short_name opp=bottom_margin.debate_team.opponent.team.short_name round=bottom_margin.debate_team.debate.round.abbreviation %}
+            {{ team }}  vs {{ opp }} in {{ round }}
+            {% endblocktrans %}
             <span class="badge badge-secondary float-right">{{ bottom_margin.margin|floatformat }}</span>
           </li>
         {% empty %}
-          <li class="list-group-item">No data yet</li>
+          <li class="list-group-item">{% trans "No data yet" %}</li>
         {% endfor %}
       </ul>
     </div>
@@ -95,16 +95,17 @@
       <!-- List group -->
       <ul class="list-group list-group-flush">
         <li class="list-group-item">
-          <h5 class="card-title mb-0">Top Team Scores</h5>
+          <h5 class="card-title mb-0">{% trans "Top Team Scores" %}</h5>
         </li>
         {% for top_score in top_team_scores %}
           <li class="list-group-item">
-            {{ top_score.debate_team.team.short_name }} in
-            {{ top_score.debate_team.debate.round.abbreviation }}
+            {% blocktrans trimmed with team=top_score.debate_team.team.short_name round=top_score.debate_team.debate.round.abbreviation %}
+            {{ team }} in {{ round }}
+            {% endblocktrans %}
             <span class="badge badge-secondary float-right">{{ top_score.score }}</span>
           </li>
         {% empty %}
-          <li class="list-group-item">No data yet</li>
+          <li class="list-group-item">{% trans "No data yet" %}</li>
         {% endfor %}
       </ul>
     </div>
@@ -115,16 +116,17 @@
       <!-- List group -->
       <ul class="list-group list-group-flush">
         <li class="list-group-item">
-          <h5 class="card-title mb-0">Bottom Team Scores</h5>
+          <h5 class="card-title mb-0">{% trans "Bottom Team Scores" %}</h5>
         </li>
         {% for bottom_score in bottom_team_scores %}
           <li class="list-group-item">
-            {{ bottom_score.debate_team.team.short_name }} in
-            {{ bottom_score.debate_team.debate.round.abbreviation }}
+            {% blocktrans trimmed with team=bottom_score.debate_team.team.short_name round=bottom_score.debate_team.debate.round.abbreviation %}
+            {{ team }} in {{ round }}
+            {% endblocktrans %}
             <span class="badge badge-secondary float-right">{{ bottom_score.score }}</span>
           </li>
         {% empty %}
-          <li class="list-group-item">No data yet</li>
+          <li class="list-group-item">{% trans "No data yet" %}</li>
         {% endfor %}
       </ul>
     </div>
@@ -135,32 +137,30 @@
       <!-- List group -->
       <ul class="list-group list-group-flush">
         <li class="list-group-item">
-          <h5 class="card-title mb-0">Most/Least Popular Motions</h5>
+          <h5 class="card-title mb-0">{% trans "Most/Least Popular Motions" %}</h5>
         </li>
         {% for top_motion in top_motions %}
           <li class="list-group-item">
-            {{ top_motion.reference }} in
-            {{ top_motion.round.abbreviation }}
+            {% blocktrans trimmed with reference=top_motion.reference abbreviation=top_motion.round.abbreviation %}
+            {{ reference }} in {{ abbreviation }}
+            {% endblocktrans %}
             <span class="badge badge-secondary float-right">{{ top_motion.ballotsubmission__count }}</span>
           </li>
         {% empty %}
-          <li class="list-group-item">
-            No data yet
-          </li>
+          <li class="list-group-item">{% trans "No data yet" %}</li>
         {% endfor %}
         <li class="list-group-item disabled">
         ...
         </li>
         {% for bottom_motion in bottom_motions %}
           <li class="list-group-item">
-            {{ bottom_motion.reference }} in
-            {{ bottom_motion.round.abbreviation }}
+            {% blocktrans trimmed with reference=bottom_motion.reference abbreviation=bottom_motion.round.abbreviation %}
+            {{ reference }} in {{ abbreviation }}
+            {% endblocktrans %}
             <span class="badge badge-secondary float-right">{{ bottom_motion.ballotsubmission__count }}</span>
           </li>
         {% empty %}
-          <li class="list-group-item">
-            No data yet
-          </li>
+          <li class="list-group-item">{% trans "No data yet" %}</li>
         {% endfor %}
       </ul>
     </div>
@@ -170,7 +170,7 @@
     <!-- List group -->
     <ul class="list-group list-group-flush">
       <li class="list-group-item">
-        <h5 class="card-title mb-0">Average Speaks</h5>
+        <h5 class="card-title mb-0">{% trans "Average Speaks" %}</h5>
       </li>
       {% if round_speaks %}
         {% for round_speak in round_speaks %}
@@ -179,7 +179,7 @@
             <span class="badge badge-secondary float-right">{{ round_speak.score|floatformat }}</span>
           </li>
         {% empty %}
-          <li class="list-group-item">No data yet</li>
+          <li class="list-group-item">{% trans "No data yet" %}</li>
         {% endfor %}
       {% endif %}
     </ul>

--- a/tabbycat/tournaments/templates/blank_site_start.html
+++ b/tabbycat/tournaments/templates/blank_site_start.html
@@ -4,7 +4,7 @@
 {% block nav %}{% endblock %}
 
 {% block head-title %}{% endblock %}
-{% block page-title %}Welcome to Tabbycat{% endblock %}
+{% block page-title %}{% trans "Welcome to Tabbycat" %}{% endblock %}
 
 {% block content %}
 

--- a/tabbycat/tournaments/templates/configure_tournament.html
+++ b/tabbycat/tournaments/templates/configure_tournament.html
@@ -6,7 +6,7 @@
     Configure Tournament {{ tournament_name }}
   {% endblocktrans %}
 {% endblock %}
-{% block page-title %}Tabbycat{% endblock %}
+{% block page-title %}{% trans "Tabbycat" %}{% endblock %}
 {% block body-class %}override-sidebar-offset{% endblock %}
 
 {% block nav %}{% endblock %}

--- a/tabbycat/tournaments/templates/round_advance_check.html
+++ b/tabbycat/tournaments/templates/round_advance_check.html
@@ -5,7 +5,7 @@
 {% block head-title %}
   <span class="emoji">🙏</span> {% trans "Confirm Round Advance" %}
 {% endblock %}
-{% block sub-title %}{% blocktrans trimmed %}for {{ round.name }}{% endblocktrans %}{% endblock %}
+{% block sub-title %}{% blocktrans trimmed with name=round.name %}for {{ name }}{% endblocktrans %}{% endblock %}
 
 {% block page-subnav-actions %}
 

--- a/tabbycat/tournaments/templates/set_current_round.html
+++ b/tabbycat/tournaments/templates/set_current_round.html
@@ -2,16 +2,16 @@
 {% load debate_tags %}
 {% load add_field_css i18n %}
 
-{% block page-title %}Set Current Round{% endblock %}
+{% block page-title %}{% trans "Set Current Round" %}{% endblock %}
 {% block head-title %}
-  <span class="emoji">🙏</span>Set Current Round
+  <span class="emoji">🙏</span>{% trans "Set Current Round" %}
 {% endblock %}
 
 {% block page-subnav-sections %}
   {% if current_round %}
     <a class="btn btn-primary "
        href="{% tournamenturl 'options-tournament-index' %}">
-      <i data-feather="chevron-left"></i> Back to Configuration
+      <i data-feather="chevron-left"></i> {% trans "Back to Configuration" %}
     </a>
   {% endif %}
 {% endblock %}

--- a/tabbycat/venues/templates/edit_venues.html
+++ b/tabbycat/venues/templates/edit_venues.html
@@ -1,9 +1,15 @@
 {% extends "base.html" %}
-{% load static %}
-{% load debate_tags %}
+{% load static debate_tags i18n %}
 
-{% block head-title %}<span class="emoji">🏪</span> Edit Venues for {{ round.abbreviation }}{% endblock %}
-{% block page-title %}🏪Edit Venues for {{ round.abbreviation }}{% endblock %}
+{% block head-title %}<span class="emoji">🏪</span>
+  {% blocktrans trimmed with round_abbr=round.abbreviation %}
+  Edit Venues for {{ round_abbr }}
+  {% endblocktrans %}
+{% endblock %}
+{% block page-title %}🏪
+  {% blocktrans trimmed with round_abbr=round.abbreviation %}
+  Edit Venues for {{ round_abbr }}
+  {% endblocktrans %}{% endblock %}
 
 {% block content %}
   <div id="vueMount">


### PR DESCRIPTION
Many strings and files have been forgotten about to be translated. This marks most missed strings to be translated.

Went through a lot of the HTML templates to mark strings for translation.
Some questions about the conventions to translate certain things in the Django way:
* Item separators (_i.e._ commas)
* Variables (saw some {{ var }} being enclosed by translation tags without any extra text)
* Strings in embedded `<script` tags (made an error in `scoresheets_list.html`)
* Are date formats hardcoded (_e.g._ for debate scheduling), and if so, is localization automatically dealt with?

More passes may be needed to pluralize some messages, and Vue templates (#744). The `.po` files are not modified here (the French ones will be in another PR with some translations soon enough though :) )