### PR TITLE
Fix escaping in translated string

### DIFF
--- a/tabbycat/adjfeedback/templates/feedback_card.html
+++ b/tabbycat/adjfeedback/templates/feedback_card.html
@@ -87,7 +87,7 @@
         {% endblocktrans %}
       </span>
       <span class="float-right" data-toggle="tooltip"
-            title="{% trans 'Ignored feedback is counted as having been submitted, but does not affect this adjudicator\'s score.' %}">
+            title="{% trans "Ignored feedback is counted as having been submitted, but does not affect this adjudicator's score." %}">
         <form method="POST" action="{% tournamenturl 'adjfeedback-ignore-feedback' feedback.id %}" class='text-secondary'>
           {% csrf_token %}
           <button type="submit" class="btn btn-link text-muted p-0">


### PR DESCRIPTION
Didn't realize that it wasn't needed, and was actively bad.