### PR TITLE
Type-cast URL key in query

### DIFF
--- a/tabbycat/privateurls/views.py
+++ b/tabbycat/privateurls/views.py
@@ -40,7 +40,7 @@ class RandomisedUrlsMixin(AdministratorMixin, TournamentMixin):
     def get_participants_to_email(self, already_sent=False):
         subquery = SentMessageRecord.objects.filter(
             tournament=self.tournament, email=OuterRef('email'),
-            context__key=OuterRef('url_key'),
+            context__key=str(OuterRef('url_key')),
             event=SentMessageRecord.EVENT_TYPE_URL
         )
         people = self.tournament.participants.filter(


### PR DESCRIPTION
The JSON field causes an error if the OuterKey is not specifically cast as a string.