### PR TITLE
Specify email backend in development settings

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -34,10 +34,6 @@ Getting started with development
 
     $ pip install -r 'config/requirements_development.txt'
 
-- The email backend should be changed in ``settings_local.py`` to display sent messages in ``STDOUT``, not by real email. Insert::
-
-    EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
-
 - Our ``package.json`` provides a convenience command that runs a standard set of development tools simultaneously, such as the Django server and the automatic recompilation with live injecting of javascript and CSS. Once you have set ``USE_WEBPACK_SERVER=True`` in your ``settings_local.py`` you can then run this with::
 
     $ npm run serve

--- a/tabbycat/settings/development.example
+++ b/tabbycat/settings/development.example
@@ -108,3 +108,9 @@ if ENABLE_DEBUG_TOOLBAR:
         'debug_toolbar.panels.profiling.ProfilingPanel',
         'ddt_request_history.panels.request_history.RequestHistoryPanel',
     )
+
+# ==============================================================================
+# Email Backend (print all emails to STDOUT)
+# ==============================================================================
+
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'


### PR DESCRIPTION
Using the Django STDOUT email backend is now encoded in the dev settings example file. It is no longer needed in the CONTRIBUTOR doc.

Also left some comments in the parent commit.