### PR TITLE
Add tournament keyword to private URL emails

### DIFF
--- a/tabbycat/privateurls/utils.py
+++ b/tabbycat/privateurls/utils.py
@@ -49,7 +49,7 @@ def send_randomised_url_emails(request, tournament, participants, subject, messa
         path = reverse_tournament('privateurls-person-index', tournament, kwargs={'url_key': instance.url_key})
         url = request.build_absolute_uri(path)
 
-        variables = {'NAME': instance.name, 'URL': url, 'key': instance.url_key}
+        variables = {'NAME': instance.name, 'URL': url, 'key': instance.url_key, 'TOURN': str(tournament)}
 
         messages.append(TournamentEmailMessage(subject, message, tournament, None, SentMessageRecord.EVENT_TYPE_URL, instance, variables))
     try:


### PR DESCRIPTION
This keyword (as {{ TOURN }}) was forgotten about, leaving a blank space.

Also not quite sure about putting the tournament name in quotes; but I didn't revert it.

I'm also guessing that all the changes that are made on the `release/2.2` branch will be merged in `develop` once released.