### PR TITLE
Use team codes in emails according to options

### DIFF
--- a/tabbycat/draw/models.py
+++ b/tabbycat/draw/models.py
@@ -100,6 +100,20 @@ class Debate(models.Model):
         return ", ".join(["%s (%s)" % (dt.team.short_name, dt.get_side_display())
                 for dt in self.debateteam_set.all()])
 
+    @property
+    def matchup_codes(self):
+        # Like matchup, but uses team codes. It is not as protected.
+        if not self.sides_confirmed:
+            teams_list = ", ".join([dt.team.code_name for dt in self.debateteam_set.all()])
+            return teams_list + gettext(" (sides not confirmed)")
+
+        try:
+            sides = self.round.tournament.sides
+            return gettext(" vs ").join(self.get_team(side).code_name for side in sides)
+        except (IndexError, ObjectDoesNotExist, MultipleObjectsReturned):
+            return ", ".join(["%s (%s)" % (dt.team.code_name, dt.get_side_display())
+                for dt in self.debateteam_set.all()])
+
     # --------------------------------------------------------------------------
     # Team properties
     # --------------------------------------------------------------------------

--- a/tabbycat/draw/utils.py
+++ b/tabbycat/draw/utils.py
@@ -9,6 +9,7 @@ from django.utils.translation import gettext as _
 from adjallocation.allocation import AdjudicatorAllocation
 from notifications.models import SentMessageRecord
 from notifications.utils import TournamentEmailMessage
+from options.utils import use_team_code_names
 from participants.models import Team
 from tournaments.models import Round
 
@@ -38,6 +39,7 @@ def annotate_npullups(teams, until):
 def send_mail_to_adjs(round):
     tournament = round.tournament
     draw = round.debate_set_with_prefetches(speakers=False, divisions=False).all()
+    use_codes = use_team_code_names(tournament, False)
 
     subject = Template(tournament.pref('adj_email_subject_line'))
     body = Template(tournament.pref('adj_email_message'))
@@ -58,11 +60,12 @@ def send_mail_to_adjs(round):
         return ", ".join(adj_string)
 
     for debate in draw:
+        matchup = debate.matchup_codes if use_codes else debate.matchup
         context = {
             'ROUND': round.name,
             'VENUE': debate.venue.name,
             'PANEL': _assemble_panel(debate.adjudicators.with_positions()),
-            'DRAW': debate.matchup
+            'DRAW': matchup
         }
 
         for adj, pos in debate.adjudicators.with_positions():

--- a/tabbycat/results/utils.py
+++ b/tabbycat/results/utils.py
@@ -8,6 +8,7 @@ from django.template import Template
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy
 
+from adjallocation.models import DebateAdjudicator
 from draw.models import Debate
 from notifications.models import SentMessageRecord
 from notifications.utils import TournamentEmailMessage
@@ -228,17 +229,16 @@ def send_ballot_receipt_emails_to_adjudicators(ballots, debate):
         if 'adjudicator' in ballot:
             judge = ballot['adjudicator']
         else:
-            judge = debate.debateadjudicator_set.get(type="C").adjudicator
+            judge = debate.debateadjudicator_set.get(type=DebateAdjudicator.TYPE_CHAIR).adjudicator
 
         if judge.email is None:
             continue
 
-        scores = ''
+        scores = ""
         for team in ballot['teams']:
-            if use_codes:
-                scores += _("(%(side)s) %(team)s\n") % {'side': team['side'], 'team': team['team'].code_name}
-            else:
-                scores += _("(%(side)s) %(team)s\n") % {'side': team['side'], 'team': team['team'].short_name}
+
+            team_name = team['team'].code_name if use_codes else team['team'].short_name
+            scores += _("(%(side)s) %(team)s\n") % {'side': team['side'], 'team': team_name}
 
             for speaker in team['speakers']:
                 scores += _("- %(debater)s: %(score)s\n") % {'debater': speaker['speaker'], 'score': speaker['score']}

--- a/tabbycat/results/utils.py
+++ b/tabbycat/results/utils.py
@@ -11,6 +11,7 @@ from django.utils.translation import gettext_lazy
 from draw.models import Debate
 from notifications.models import SentMessageRecord
 from notifications.utils import TournamentEmailMessage
+from options.utils import use_team_code_names
 from tournaments.utils import get_side_name
 
 logger = logging.getLogger(__name__)
@@ -221,6 +222,7 @@ def send_ballot_receipt_emails_to_adjudicators(ballots, debate):
     message = Template(debate.round.tournament.pref('ballot_email_message'))
 
     context = {'DEBATE': round_name}
+    use_codes = use_team_code_names(debate.round.tournament, False)
 
     for ballot in ballots:
         if 'adjudicator' in ballot:
@@ -233,7 +235,10 @@ def send_ballot_receipt_emails_to_adjudicators(ballots, debate):
 
         scores = ''
         for team in ballot['teams']:
-            scores += _("(%(side)s) %(team)s\n") % {'side': team['side'], 'team': team['team'].short_name}
+            if use_codes:
+                scores += _("(%(side)s) %(team)s\n") % {'side': team['side'], 'team': team['team'].code_name}
+            else:
+                scores += _("(%(side)s) %(team)s\n") % {'side': team['side'], 'team': team['team'].short_name}
 
             for speaker in team['speakers']:
                 scores += _("- %(debater)s: %(score)s\n") % {'debater': speaker['speaker'], 'score': speaker['score']}


### PR DESCRIPTION
The team_codes preference was ignored in emails, always opting for the teams' short names even when the codes are preferred (in the preferences). This adds switches to email generators between codes and short names.

Fixes #804.