### PR TITLE
Re-factor email generator classes

### DIFF
--- a/tabbycat/draw/views.py
+++ b/tabbycat/draw/views.py
@@ -22,7 +22,7 @@ from actionlog.models import ActionLogEntry
 from adjallocation.models import DebateAdjudicator
 from adjallocation.utils import adjudicator_conflicts_display
 from divisions.models import Division
-from notifications.utils import AdjudicatorAssignmentEmailGenerator
+from notifications.utils import adjudicator_assignment_email_generator
 from options.preferences import BPPositionCost
 from participants.models import Adjudicator, Institution, Team
 from participants.utils import get_side_history
@@ -688,7 +688,7 @@ class DrawReleaseView(DrawStatusEdit):
         email_success_message = ""
         if self.tournament.pref('enable_adj_email'):
             try:
-                AdjudicatorAssignmentEmailGenerator(self.tournament).run(self.round.id)
+                adjudicator_assignment_email_generator(self.round.id)
             except SMTPException:
                 messages.error(self.request, _("There was a problem sending adjudication assignment emails."))
             except ConnectionError as e:

--- a/tabbycat/privateurls/views.py
+++ b/tabbycat/privateurls/views.py
@@ -13,7 +13,7 @@ from django.utils.translation import ngettext
 from checkins.models import PersonIdentifier
 from checkins.utils import get_unexpired_checkins
 from notifications.models import SentMessageRecord
-from notifications.utils import RandomizedURLEmailGenerator
+from notifications.utils import randomized_url_email_generator
 from participants.models import Adjudicator, Person, Speaker
 from tournaments.mixins import PersonalizablePublicTournamentPageMixin, TournamentMixin
 from utils.misc import reverse_tournament
@@ -147,10 +147,7 @@ class EmailRandomizedUrlsView(RandomisedUrlsMixin, PostOnlyRedirectView):
         url = request.build_absolute_uri(path)[:-2]
 
         try:
-            generator = RandomizedURLEmailGenerator(t)
-            generator.run(url, t.id)
-
-            nparticipants = len(generator.emails)
+            nparticipants = randomized_url_email_generator(url, t.id)
         except SMTPException:
             messages.error(self.request, _("There was a problem sending private URLs to participants."))
         except ConnectionError as e:

--- a/tabbycat/results/mixins.py
+++ b/tabbycat/results/mixins.py
@@ -3,7 +3,7 @@ from smtplib import SMTPException
 from django.contrib import messages
 from django.utils.translation import gettext as _
 
-from notifications.utils import BallotEmailGenerator
+from notifications.utils import ballots_email_generator
 from utils.misc import get_ip_address
 
 from .models import Submission
@@ -37,7 +37,7 @@ class PublicSubmissionFieldsMixin:
 class BallotEmailWithStatusMixin:
     def send_email_receipts(self):
         try:
-            BallotEmailGenerator(self.tournament).run(self.debate.id)
+            ballots_email_generator(self.debate.id)
         except SMTPException:
             messages.error(self.request, _("There was a problem sending ballot receipts to adjudicators."))
             return False

--- a/tabbycat/results/views.py
+++ b/tabbycat/results/views.py
@@ -17,7 +17,7 @@ from actionlog.models import ActionLogEntry
 from adjallocation.models import DebateAdjudicator
 from draw.models import Debate
 from draw.prefetch import populate_opponents
-from notifications.utils import BallotEmailGenerator
+from notifications.utils import ballots_email_generator
 from options.utils import use_team_code_names_data_entry
 from participants.models import Adjudicator
 from tournaments.mixins import (CurrentRoundMixin, PersonalizablePublicTournamentPageMixin, PublicTournamentPageMixin,
@@ -260,7 +260,7 @@ class BaseBallotSetView(LogActionMixin, TournamentMixin, FormView):
     def send_email_receipts(self):
         # For proper error handling for admin/assistants, overwrite this
         try:
-            BallotEmailGenerator(self.tournament).run(self.debate.id)
+            ballots_email_generator(self.debate.id)
         except (SMTPException, ConnectionError):
             return False
         else:

--- a/tabbycat/tournaments/views.py
+++ b/tabbycat/tournaments/views.py
@@ -21,7 +21,7 @@ from actionlog.mixins import LogActionMixin
 from actionlog.models import ActionLogEntry
 from draw.models import Debate
 from notifications.models import SentMessageRecord
-from notifications.utils import StandingsEmailGenerator
+from notifications.utils import standings_email_generator
 from results.models import BallotSubmission
 from tournaments.models import Round
 from utils.forms import SuperuserCreationForm
@@ -192,7 +192,7 @@ class SendStandingsEmailsView(RoundMixin, AdministratorMixin, PostOnlyRedirectVi
         url = request.build_absolute_uri(reverse_tournament('standings-public-teams-current', self.tournament))
 
         try:
-            StandingsEmailGenerator(self.tournament).run(url, self.round_id)
+            standings_email_generator(url, self.round.id)
         except (ConnectionError, SMTPException):
             messages.error(request, _("Team point emails could not be sent."))
         else:


### PR DESCRIPTION
Having the classes take in a tournament object was un-necessary and might have been counter-productive for Celery-ifiation. Also removed the select_related from objects as that is just for QuerySets.

(Is the query count good in emails? The request history tab is broken)
I'm getting timeouts when trying Celery; given up a bit on that.