### PR TITLE
Add CheckInEventConsumer to self-checkin

### DIFF
--- a/tabbycat/checkins/views.py
+++ b/tabbycat/checkins/views.py
@@ -1,5 +1,7 @@
 import json
 
+from asgiref.sync import async_to_sync
+from channels.layers import get_channel_layer
 from django.contrib import messages
 from django.core.exceptions import ObjectDoesNotExist
 from django.views.generic.base import TemplateView
@@ -15,6 +17,7 @@ from utils.mixins import AdministratorMixin, AssistantMixin
 from utils.views import PostOnlyRedirectView
 from tournaments.mixins import PublicTournamentPageMixin, TournamentMixin
 
+from .consumers import CheckInEventConsumer
 from .models import Event, PersonIdentifier, VenueIdentifier
 from .utils import create_identifiers, get_unexpired_checkins
 
@@ -266,7 +269,6 @@ class ParticipantCheckinView(PublicTournamentPageMixin, PostOnlyRedirectView):
         existing_checkin = checkins.filter(identifier=identifier)
         if action == 'revoke':
             if existing_checkin.exists():
-                existing_checkin.delete()
                 messages.success(self.request, _("You have revoked your check-in."))
             else:
                 messages.error(self.request, _("Whoops! Looks like your check-in was already revoked."))
@@ -274,10 +276,19 @@ class ParticipantCheckinView(PublicTournamentPageMixin, PostOnlyRedirectView):
             if existing_checkin.exists():
                 messages.error(self.request, _("Whoops! Looks like you're already checked in."))
             else:
-                Event(identifier=identifier, tournament=t).save()
                 messages.success(self.request, _("You are now checked in."))
         else:
             return TemplateResponse(request=self.request, template='400.html', status=400)
+
+        group_name = CheckInEventConsumer.group_prefix + "_" + t.slug
+
+        # Override permissions check - no user but authenticated through URL
+        async_to_sync(get_channel_layer().group_send)(
+            group_name, {
+                'type': 'broadcast_checkin',
+                'content': { 'barcodes': [identifier.barcode], 'status': action == 'checkin', 'type': 'people', 'component_id': None }
+            }
+        )
 
         return super().post(request, *args, **kwargs)
 


### PR DESCRIPTION
So that self-checkin events are live in the admin/assistant views, the self-checkins through private URLs have to send messages through the `CheckInEventConsumer` channel.

While this does not address having the private landing pages receive messages, that is much less important, especially as that event is caught with a "already checked-in" message and the fact that people wouldn't be staying on the page for long.

Closes #832.