### PR TITLE
Fix spacing in printable ballots

### DIFF
--- a/tabbycat/printing/templates/PrintableDebateInfo.vue
+++ b/tabbycat/printing/templates/PrintableDebateInfo.vue
@@ -10,14 +10,16 @@
           <span v-if="ballot.debateAdjudicators && ballot.debateAdjudicators.length > 1">
             Adjudicating with
             <span v-for="(da, i) in panellistsExcludingSelf">
-              <template v-if="i !== 0">&amp;</template>
+              <template v-if="i !== 0">; </template>
+              <template v-if="i == panellistsExcludingSelf.length - 1">&amp; </template>
               <strong>{{ da.adjudicator.name }}</strong>
-              <template v-if="da.position === 'c'">(Chair, </template>
-              <template v-if="da.position === 'o'">(Solo Chair, </template>
-              <template v-if="da.position === 'p'">(Panellist, </template>
-              <template v-if="da.position === 't'">(Trainee, </template>
-              {{ getAdjudicatorInstitution(da) }}).
+              <template v-if="da.position === 'c'"> (Chair, </template>
+              <template v-if="da.position === 'o'"> (Solo Chair, </template>
+              <template v-if="da.position === 'p'"> (Panellist, </template>
+              <template v-if="da.position === 't'"> (Trainee, </template>
+              <template>{{ getAdjudicatorInstitution(da) }})</template>
             </span>
+            .
           </span>
 
           <span v-if="showScoring">


### PR DESCRIPTION
There was no spacing between adjudicators and their info. Also made the point happen only at the end of the list, rather than after each adj and got the ampersand only with the last adj. Instead of an ampersand, writing out "and" could be less awkward, but that isn't done in this commit.