### PR TITLE
Notification documentation

### DIFF
--- a/docs/features/notifications.rst
+++ b/docs/features/notifications.rst
@@ -14,31 +14,45 @@ All emails have the ``{{ USER }}`` and ``{{ TOURN }}`` variables to indicate who
 .. list-table::
   :header-rows: 1
 
-  * - Event
-    - Description
+  * - Email content
+    - Description and when sent
     - Variables
 
-  * - Adjudicator assignment
-    - Email to adjudicators indicating their room when draw is released.
+  * - **Adjudicator draw notification**
+    - Email to adjudicators indicating their room assignment.
+
+      Sent when the draw is released, if enabled.
     - * ``{{ ROUND }}``: The round name
       * ``{{ VENUE }}``: The venue of the assigned debate
       * ``{{ PANEL }}``: A list of all the adjudicators assigned to the venue (with positions)
       * ``{{ DRAW }}``: A list of the team matchup with their roles
       * ``{{ POSITION }}``: The target adjudicator's position in the panel
-  * - Private URL distribution
-    - Email to participants giving them their private URL for e-forms
+
+  * - **Private URL distribution**
+    - Email to participants giving them their private URL for electronic forms.
+
+      Sent when you click the "Email URLs" button under Private URLs.
     - * ``{{ URL }}``: The personalized URL
       * ``{{ KEY }}``: The private code in the URL
-  * - Ballot submission receipt
-    - Email to adjudicators of their ballot after tabroom confirmation
+
+  * - **Ballot submission receipt**
+    - Email to adjudicators of their ballot after tabroom confirmation.
+
+      Sent when their ballot's result status becomes confirmed, if enabled.
     - * ``{{ DEBATE }}``: The name (with round & venue) of the relevent debate
       * ``{{ SCORES }}``: The submitted ballot with speaker scores ands team names
-  * - Current team standings
-    - Email to speakers with their point total
+
+  * - **Current team standings**
+    - Email to speakers with their point total.
+
+      Sent when you click the "Email Team Wins/Losses" or "Email Team Points" button on the "Confirm Round Completion" page.
     - * ``{{ URL }}``: The URL of the team standings page (if public)
       * ``{{ TEAM }}``: The team's name
       * ``{{ POINTS }}``: The team's number of points
-  * - Motion release
-    - Email to speakers with the motion(s) of the current round
+
+  * - **Motion release**
+    - Email to speakers with the motion(s) of the current round.
+
+      Sent when you release the motion(s), if enabled.
     - * ``{{ ROUND }}``: The name of the round
       * ``{{ MOTIONS }}``: A list of the motions released

--- a/docs/features/notifications.rst
+++ b/docs/features/notifications.rst
@@ -1,0 +1,44 @@
+=====================
+Sending Notifications
+=====================
+
+Tabbycat offers integrations with email delivery services to send notifications to participants on certain enumerated events. For sending these emails, `SendGrid <https://sendgrid.com/>`_ is readily available as an add-on in Heroku. It may be necessary to install the `SendGrid add-on <https://elements.heroku.com/addons/sendgrid>`_ manually. Other integrations may also be used in its place by changing the relevant environment variables.
+
+Events
+======
+
+The messages sent with these events can be modified in the Notifications section of the tournament settings. Some of these notifications additionally need to be enabled in the same section. There are also variables which are included between curly brackets which are substituted for personalized information passed by email.
+
+All emails have the ``{{ USER }}`` and ``{{ TOURN }}`` variables to indicate who the email is sent to, and the tournament it relates to. The "From" in the emails will also be the tournament's name.
+
+.. list-table::
+  :header-rows: 1
+
+  * - Event
+    - Description
+    - Variables
+
+  * - Adjudicator assignment
+    - Email to adjudicators indicating their room when draw is released.
+    - * ``{{ ROUND }}``: The round name
+      * ``{{ VENUE }}``: The venue of the assigned debate
+      * ``{{ PANEL }}``: A list of all the adjudicators assigned to the venue (with positions)
+      * ``{{ DRAW }}``: A list of the team matchup with their roles
+      * ``{{ POSITION }}``: The target adjudicator's position in the panel
+  * - Private URL distribution
+    - Email to participants giving them their private URL for e-forms
+    - * ``{{ URL }}``: The personalized URL
+      * ``{{ KEY }}``: The private code in the URL
+  * - Ballot submission receipt
+    - Email to adjudicators of their ballot after tabroom confirmation
+    - * ``{{ DEBATE }}``: The name (with round & venue) of the relevent debate
+      * ``{{ SCORES }}``: The submitted ballot with speaker scores ands team names
+  * - Current team standings
+    - Email to speakers with their point total
+    - * ``{{ URL }}``: The URL of the team standings page (if public)
+      * ``{{ TEAM }}``: The team's name
+      * ``{{ POINTS }}``: The team's number of points
+  * - Motion release
+    - Email to speakers with the motion(s) of the current round
+    - * ``{{ ROUND }}``: The name of the round
+      * ``{{ MOTIONS }}``: A list of the motions released

--- a/docs/features/notifications.rst
+++ b/docs/features/notifications.rst
@@ -14,12 +14,12 @@ All emails have the ``{{ USER }}`` and ``{{ TOURN }}`` variables to indicate who
 .. list-table::
   :header-rows: 1
 
-  * - Email content
-    - Description and when sent
+  * - Email content and description
     - Variables
 
   * - **Adjudicator draw notification**
-    - Email to adjudicators indicating their room assignment.
+
+      Email to adjudicators indicating their room assignment.
 
       Sent when the draw is released, if enabled.
     - * ``{{ ROUND }}``: The round name
@@ -29,21 +29,24 @@ All emails have the ``{{ USER }}`` and ``{{ TOURN }}`` variables to indicate who
       * ``{{ POSITION }}``: The target adjudicator's position in the panel
 
   * - **Private URL distribution**
-    - Email to participants giving them their private URL for electronic forms.
+
+      Email to participants giving them their private URL for electronic forms.
 
       Sent when you click the "Email URLs" button under Private URLs.
     - * ``{{ URL }}``: The personalized URL
       * ``{{ KEY }}``: The private code in the URL
 
   * - **Ballot submission receipt**
-    - Email to adjudicators of their ballot after tabroom confirmation.
+
+      Email to adjudicators of their ballot after tabroom confirmation.
 
       Sent when their ballot's result status becomes confirmed, if enabled.
     - * ``{{ DEBATE }}``: The name (with round & venue) of the relevent debate
       * ``{{ SCORES }}``: The submitted ballot with speaker scores ands team names
 
   * - **Current team standings**
-    - Email to speakers with their point total.
+
+      Email to speakers with their point total.
 
       Sent when you click the "Email Team Wins/Losses" or "Email Team Points" button on the "Confirm Round Completion" page.
     - * ``{{ URL }}``: The URL of the team standings page (if public)
@@ -51,7 +54,8 @@ All emails have the ``{{ USER }}`` and ``{{ TOURN }}`` variables to indicate who
       * ``{{ POINTS }}``: The team's number of points
 
   * - **Motion release**
-    - Email to speakers with the motion(s) of the current round.
+
+      Email to speakers with the motion(s) of the current round.
 
       Sent when you release the motion(s), if enabled.
     - * ``{{ ROUND }}``: The name of the round

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -62,6 +62,7 @@ formats too. If you're looking for a general overview of the software, check out
    features/draw-generation
    features/draw-generation-bp
    features/printing
+   features/notifications
    features/standings-rules
    features/team-code-names
    features/data-importers

--- a/tabbycat/notifications/utils.py
+++ b/tabbycat/notifications/utils.py
@@ -124,7 +124,7 @@ def randomized_url_email_generator(url, tournament_id):
     for instance in participants:
         url_ind = url + instance.url_key + '/'
 
-        variables = {'NAME': instance.name, 'URL': url_ind, 'KEY': instance.url_key, 'TOURN': str(tournament)}
+        variables = {'USER': instance.name, 'URL': url_ind, 'KEY': instance.url_key, 'TOURN': str(tournament)}
 
         emails.append(TournamentEmailMessage(
             'url_email_subject', 'url_email_message',

--- a/tabbycat/options/preferences.py
+++ b/tabbycat/options/preferences.py
@@ -1403,7 +1403,7 @@ class AdjudicatorDrawNotificationMessage(LongStringPreference):
 @tournament_preferences_registry.register
 class PrivateUrlEmailSubject(StringPreference):
     help_text = _("The subject-line for emails sent to participants with their private URLs. "
-        "Use '{{ TOURN }}' as a placeholder for the tournament, '{{ NAME }}' for the participant's name, and '{{ URL }}' for the private URL.")
+        "Use '{{ TOURN }}' as a placeholder for the tournament, '{{ USER }}' for the participant's name, and '{{ URL }}' for the private URL.")
     verbose_name = _("Private URL notification subject line")
     section = email
     name = 'url_email_subject'
@@ -1413,11 +1413,11 @@ class PrivateUrlEmailSubject(StringPreference):
 @tournament_preferences_registry.register
 class PrivateUrlEmailMessage(LongStringPreference):
     help_text = _("The message body for emails sent to participants with their private URLs. "
-        "Use '{{ TOURN }}' as a placeholder for the tournament, '{{ NAME }}' for the participant's name, and '{{ URL }}' for the private URL.")
+        "Use '{{ TOURN }}' as a placeholder for the tournament, '{{ USER }}' for the participant's name, and '{{ URL }}' for the private URL.")
     verbose_name = _("Private URL notification message")
     section = email
     name = 'url_email_message'
-    default = ("Hi {{ NAME }},\n\n"
+    default = ("Hi {{ USER }},\n\n"
         "At {{ TOURN }}, we are using an online tabulation system. You can submit "
         "your ballots and/or feedback at the following URL. This URL is unique to you — do not share it with "
         "anyone, as anyone who knows it can submit forms on your behalf. This URL "

--- a/tabbycat/options/preferences.py
+++ b/tabbycat/options/preferences.py
@@ -1328,9 +1328,7 @@ class BallotEmailSubjectLine(StringPreference):
 
 @tournament_preferences_registry.register
 class BallotEmailMessageBody(LongStringPreference):
-    help_text = _("The message body for emails sent to adjudicators with their submitted ballot. "
-                  "Use '{{ DEBATE }}' as a placeholder for the associated debate, '{{ USER }}' for the adjudicator, "
-                  "and '{{ SCORES }}' for the ballot values.")
+    help_text = _("The message body for emails sent to adjudicators with their submitted ballot.")
     verbose_name = _("Ballot receipt message")
     section = email
     name = 'ballot_email_message'
@@ -1339,9 +1337,7 @@ class BallotEmailMessageBody(LongStringPreference):
 
 @tournament_preferences_registry.register
 class PointsEmailSubjectLine(StringPreference):
-    help_text = _("The subject line for emails sent to speakers with their team points. "
-                  "Use '{{ TOURN }}' as a placeholder for the tournament, '{{ POINTS }}' for the team points, "
-                  "and '{{ TEAM }}' for the associated team.")
+    help_text = _("The subject line for emails sent to speakers with their team points.")
     verbose_name = _("Team points subject line")
     section = email
     name = 'team_points_email_subject'
@@ -1350,9 +1346,7 @@ class PointsEmailSubjectLine(StringPreference):
 
 @tournament_preferences_registry.register
 class PointsEmailMessageBody(LongStringPreference):
-    help_text = _("The message body for emails sent to speakers with their team points. "
-                  "Use '{{ TOURN }}' as a placeholder for the tournament, '{{ POINTS }}' for the team points, "
-                  "'{{ USER }}' for the speaker, and '{{ TEAM }}' for the associated team.")
+    help_text = _("The message body for emails sent to speakers with their team points.")
     verbose_name = _("Team points message")
     section = email
     name = 'team_points_email_message'
@@ -1379,8 +1373,7 @@ class EnableAdjudicatorDrawNotification(BooleanPreference):
 
 @tournament_preferences_registry.register
 class AdjudicatorDrawNotificationSubject(StringPreference):
-    help_text = _("The subject-line for emails sent to adjudicators with their assignments. "
-        "Use '{{ ROUND }}' as a placeholder for the current round, and '{{ VENUE }}' for their assigned venue.")
+    help_text = _("The subject-line for emails sent to adjudicators with their assignments.")
     verbose_name = _("Adjudicator draw subject line")
     section = email
     name = 'adj_email_subject_line'
@@ -1389,10 +1382,7 @@ class AdjudicatorDrawNotificationSubject(StringPreference):
 
 @tournament_preferences_registry.register
 class AdjudicatorDrawNotificationMessage(LongStringPreference):
-    help_text = _("The message body for emails sent to adjudicators with their assignments. "
-        "Use '{{ ROUND }}' as a placeholder for the current round, '{{ VENUE }}' for their venue, "
-        "'{{ USER }}' for the adjudicator's name, '{{ POSITION }}' for their role, '{{ PANEL }}' for the full debate adjudication panel, and "
-        "'{{ DRAW }}' for the debate pairing.")
+    help_text = _("The message body for emails sent to adjudicators with their assignments.")
     verbose_name = _("Adjudicator draw message")
     section = email
     name = 'adj_email_message'
@@ -1402,8 +1392,7 @@ class AdjudicatorDrawNotificationMessage(LongStringPreference):
 
 @tournament_preferences_registry.register
 class PrivateUrlEmailSubject(StringPreference):
-    help_text = _("The subject-line for emails sent to participants with their private URLs. "
-        "Use '{{ TOURN }}' as a placeholder for the tournament, '{{ USER }}' for the participant's name, and '{{ URL }}' for the private URL.")
+    help_text = _("The subject-line for emails sent to participants with their private URLs.")
     verbose_name = _("Private URL notification subject line")
     section = email
     name = 'url_email_subject'
@@ -1412,8 +1401,7 @@ class PrivateUrlEmailSubject(StringPreference):
 
 @tournament_preferences_registry.register
 class PrivateUrlEmailMessage(LongStringPreference):
-    help_text = _("The message body for emails sent to participants with their private URLs. "
-        "Use '{{ TOURN }}' as a placeholder for the tournament, '{{ USER }}' for the participant's name, and '{{ URL }}' for the private URL.")
+    help_text = _("The message body for emails sent to participants with their private URLs.")
     verbose_name = _("Private URL notification message")
     section = email
     name = 'url_email_message'
@@ -1437,8 +1425,7 @@ class MotionReleaseNotification(BooleanPreference):
 
 @tournament_preferences_registry.register
 class MotionReleaseEmailSubject(StringPreference):
-    help_text = _("The subject-line for emails sent to participants on motion release. "
-        "Use '{{ TOURN }}' for the tournament, '{{ ROUND }}' for the round, and '{{ USER }}' for the speaker.")
+    help_text = _("The subject-line for emails sent to participants on motion release.")
     verbose_name = _("Motion release notification subject line")
     section = email
     name = 'motion_email_subject'
@@ -1447,9 +1434,7 @@ class MotionReleaseEmailSubject(StringPreference):
 
 @tournament_preferences_registry.register
 class MotionReleaseEmailMessage(LongStringPreference):
-    help_text = _("The message body for emails sent to participants on motion release. "
-        "Use '{{ TOURN }}' for the tournament, '{{ ROUND }}' for the round, '{{ USER }}' for the speaker, "
-        "and '{{ MOTIONS }} for the motions of the round.")
+    help_text = _("The message body for emails sent to participants on motion release.")
     verbose_name = _("Motion release notification message")
     section = email
     name = 'motion_email_message'


### PR DESCRIPTION
New page was added to supplant the help texts in the options. Feel free to suggest better formatting in the documentation.

More details in the commit messages.