### PR TITLE
Add QR codes to private URL sheets

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Change Log
 ------------------
 *Release date: ?*
 
+- When printing the per-participant private URLs they now feature QR codes in addition to the URL. Thanks to Étienne Beaulé for contributing this feature!
 - Split up the Django settings files. Note that this means if you are upgrading a local install of Tabbycat to this version you will need to:
     - Copy `tabbycat/settings/local.example` to become `local.py` (and fill in your original database details).
     - Optional: repeat the same copying procedure for `development.example` and set the `LOCAL_DEVELOPMENT` environmental variable to `True` if you would like to use the settings designed to aid local development.

--- a/config/requirements_core.txt
+++ b/config/requirements_core.txt
@@ -27,3 +27,4 @@ channels_redis==2.2.1                   # Channels Layer
 
 # Misc
 ipython==6.3.1
+qrcode==6.0

--- a/tabbycat/printing/templates/randomised_url_sheets.html
+++ b/tabbycat/printing/templates/randomised_url_sheets.html
@@ -23,24 +23,26 @@
   {% for p in parts %}
     <div class="h1 text-center printable-page-break">
       <br>
-      {% if p.adjudicator %}
-        {% blocktrans trimmed with name=p.name group=p.adjudicator.institution.code team=p.speaker.team.short_name %}
+      {% if p.adjudicator__institution__code %}
+        {% blocktrans trimmed with name=p.name group=p.adjudicator__institution__code %}
           Private URL for {{ name }} ({{ group }})
         {% endblocktrans %}
       {% else %}
-        {% blocktrans trimmed with name=p.name group=p.speaker.team.short_name %}
+        {% blocktrans trimmed with name=p.name group=p.speaker__team__short_name %}
           Private URL for {{ name }} ({{ group }})
         {% endblocktrans %}
       {% endif %}
     </div>
     <div class="h4 text-center printable-page-break">
-      <br><br><br>
-      {% blocktrans %}
-      Please bookmark the following URL, you will use it to submit forms
-      throughout the tournament:
-      {% endblocktrans %}
-      <br><br>
-      {% tournament_absurl 'privateurls-person-index' p.url_key %}
+      <p>
+        {% blocktrans trimmed %}
+          Please bookmark the following URL, you will use it to submit forms throughout the tournament:
+        {% endblocktrans %}
+      </p>
+      <p>{{ p.url }}</p>
+      <svg version="1.1" viewBox="0 0 37 37" width="200px" xmlns="http://www.w3.org/2000/svg">
+        <path d="{{ p.qr }}" />
+      </svg>
     </div>
   {% endfor %}
 

--- a/tabbycat/printing/views.py
+++ b/tabbycat/printing/views.py
@@ -1,5 +1,8 @@
 import json
 
+import qrcode
+from qrcode.image import svg
+
 from django.db.models import Q
 from django.utils.translation import gettext as _
 from django.views.generic.base import TemplateView
@@ -15,6 +18,7 @@ from results.utils import side_and_position_names
 from tournaments.mixins import (CurrentRoundMixin, OptionalAssistantTournamentPageMixin,
                                 RoundMixin, TournamentMixin)
 from tournaments.models import Tournament
+from utils.misc import reverse_tournament
 from utils.mixins import AdministratorMixin
 from venues.models import VenueCategory
 
@@ -280,16 +284,28 @@ class PrintableRandomisedURLs(TournamentMixin, AdministratorMixin, TemplateView)
 
     template_name = 'randomised_url_sheets.html'
 
+    def add_urls(self, participants):
+        for participant in participants:
+            url = reverse_tournament('privateurls-person-index', self.tournament, kwargs={'url_key': participant['url_key']})
+            abs_url = self.request.build_absolute_uri(url)
+            qr_code = qrcode.make(abs_url, image_factory=svg.SvgPathImage)
+
+            participant['url'] = abs_url
+            participant['qr'] = ' '.join(qr_code._generate_subpaths())
+
+        return participants
+
     def get_context_data(self, **kwargs):
-        kwargs['tournament_slug'] = self.tournament.slug
 
         if not self.tournament.pref('share_adjs'):
-            kwargs['parts'] = self.tournament.participants.filter(
-                url_key__isnull=False).select_related(
-                'speaker', 'speaker__team', 'adjudicator__institution',
-                'adjudicator')
+            participants = self.tournament.participants.filter(url_key__isnull=False)
         else:
-            kwargs['parts'] = Person.objects.filter(Q(speaker__team__tournament=self.tournament) | Q(adjudicator__tournament__isnull=True) & Q(url_key__isnull=False))
+            participants = Person.objects.filter(
+                Q(speaker__team__tournament=self.tournament) | Q(adjudicator__tournament__isnull=True) & Q(url_key__isnull=False))
+
+        participants_array = list(participants.select_related('speaker', 'speaker__team', 'adjudicator__institution', 'adjudicator')
+            .values('name', 'speaker__team__short_name', 'adjudicator__institution__code', 'url_key'))
+        kwargs['parts'] = self.add_urls(participants_array)
 
         kwargs['exists'] = self.tournament.participants.filter(url_key__isnull=False).exists()
 


### PR DESCRIPTION
It is awkward to type in a coded URL. To make it easier, QR codes allow for a URL to be encoded in a 2D barcode, redirecting to a URL when scanned with a cell-phone. The QR codes are generated in the client with qrcode, a new python dependency.

As this is done server-side, it will load slower, but PDFs are generated quicker.

Fixes #775.

On another note, thinking about dropping the HTML interface of printable pages in favour of server-side conversion to PDF, making printables automatically download. That would avoid people needing to fiddle with settings or wait for Chrome (also allows other browsers to work as well)