### PR TITLE
Cast descriptors to string if empty

### DIFF
--- a/tabbycat/utils/tables.py
+++ b/tabbycat/utils/tables.py
@@ -552,8 +552,7 @@ class TabbycatTableBuilder(BaseTableBuilder):
                     descriptors.append("<span class='text-danger'>in minority</span>")
                 text = a['adj'].name
 
-                if descriptors:
-                    descriptors = "(%s)" % (", ".join(descriptors))
+                descriptors = "(%s)" % (", ".join(descriptors)) if descriptors else ""
 
                 if self._show_record_links:
                     popover_data.append(self._adjudicator_record_link(descriptors, a['adj']))


### PR DESCRIPTION
When the descriptors array is empty, it returns false, which keeps it as an array, causing an error in the adjudicators table.

Fixes #842.