### PR TITLE
Don't send ballot receipts on elimination rounds

### DIFF
--- a/tabbycat/results/mixins.py
+++ b/tabbycat/results/mixins.py
@@ -4,6 +4,7 @@ from django.contrib import messages
 from django.utils.translation import gettext as _
 
 from notifications.utils import ballots_email_generator
+from tournaments.models import Round
 from utils.misc import get_ip_address
 
 from .models import Submission
@@ -36,6 +37,9 @@ class PublicSubmissionFieldsMixin:
 
 class BallotEmailWithStatusMixin:
     def send_email_receipts(self):
+        if self.debate.round.stage == Round.STAGE_ELIMINATION:
+            return False
+
         try:
             ballots_email_generator(self.debate.id)
         except SMTPException:

--- a/tabbycat/results/views.py
+++ b/tabbycat/results/views.py
@@ -259,6 +259,9 @@ class BaseBallotSetView(LogActionMixin, TournamentMixin, FormView):
 
     def send_email_receipts(self):
         # For proper error handling for admin/assistants, overwrite this
+        if self.debate.round.stage == Round.STAGE_ELIMINATION:
+            return False
+
         try:
             ballots_email_generator(self.debate.id)
         except (SMTPException, ConnectionError):


### PR DESCRIPTION
Ballot emails are score-oriented, which is not compatible with elimination-type ballots.

Closes BACKEND-ZJ