### PR TITLE
Get tournament based on debate/round

### DIFF
--- a/tabbycat/__init__.py
+++ b/tabbycat/__init__.py
@@ -1,7 +1,0 @@
-from __future__ import absolute_import
-
-# This will make sure the app is always imported when
-# Django starts so that shared_task will use this app.
-from celery import app as celery_tabbycat
-
-__all__ = ('celery_tabbycat',)

--- a/tabbycat/results/views.py
+++ b/tabbycat/results/views.py
@@ -258,13 +258,8 @@ class BaseBallotSetView(LogActionMixin, TournamentMixin, FormView):
         pass
 
     def should_send_email_receipts(self):
-        # For proper error handling for admin/assistants, overwrite this
-        if not self.tournament.pref('enable_ballot_receipts'):
-            return False
-        if self.debate.round.stage == Round.STAGE_ELIMINATION and self.tournament.pref('teams_in_debate') == 'bp':
-            return False
-
-        return True
+        return self.tournament.pref('enable_ballot_receipts') and not (self.debate.round.stage == Round.STAGE_ELIMINATION and
+            self.tournament.pref('teams_in_debate') == 'bp')
 
     def matchup_description(self):
         """This is primarily shown in messages, some of which are public. This


### PR DESCRIPTION
The notifications worker looks for a tournament_id, which might not be
present. This change looks for other object ids that can be used to get
the tournament (and round if applicable).