### PR TITLE
Implement team information emails

### DIFF
--- a/docs/features/notifications.rst
+++ b/docs/features/notifications.rst
@@ -60,3 +60,17 @@ All emails have the ``{{ USER }}`` and ``{{ TOURN }}`` variables to indicate who
       Sent when you release the motion(s), if enabled.
     - * ``{{ ROUND }}``: The name of the round
       * ``{{ MOTIONS }}``: A list of the motions released
+
+  * - **Team information**
+
+      Email to speakers with information pertaining to their team, such as eligibility and codes.
+
+      Sent when you click the "Email Registration" button under Participants.
+    - * ``{{ SHORT }}``: The team's short name
+      * ``{{ LONG }}``: The team's long name
+      * ``{{ CODE }}``: The team's code name
+      * ``{{ EMOJI }}``: The team's assigned emoji
+      * ``{{ DIVISION }}``: The team's division if applicable
+      * ``{{ BREAK }}``: Break categories which the team is a member
+      * ``{{ SPEAKERS }}``: A list of the speakers in the team
+      * ``{{ INSTITUTION }}``: The team's affiliation

--- a/tabbycat/notifications/consumers.py
+++ b/tabbycat/notifications/consumers.py
@@ -11,7 +11,8 @@ from tournaments.models import Round, Tournament
 
 from .models import SentMessageRecord
 from .utils import (adjudicator_assignment_email_generator, ballots_email_generator,
-                    motion_release_email_generator, randomized_url_email_generator, standings_email_generator)
+                    motion_release_email_generator, randomized_url_email_generator,
+                    standings_email_generator, team_speaker_email_generator)
 
 
 class NotificationQueueConsumer(SyncConsumer):
@@ -21,14 +22,16 @@ class NotificationQueueConsumer(SyncConsumer):
         "url": randomized_url_email_generator,
         "ballot": ballots_email_generator,
         "team_points": standings_email_generator,
-        "motion": motion_release_email_generator
+        "motion": motion_release_email_generator,
+        "team": team_speaker_email_generator
     }
     NOTIFICATION_EVENTS = {
         "adj": SentMessageRecord.EVENT_TYPE_DRAW,
         "url": SentMessageRecord.EVENT_TYPE_URL,
         "ballot": SentMessageRecord.EVENT_TYPE_BALLOT_CONFIRMED,
         "team_points": SentMessageRecord.EVENT_TYPE_POINTS,
-        "motion": SentMessageRecord.EVENT_TYPE_MOTIONS
+        "motion": SentMessageRecord.EVENT_TYPE_MOTIONS,
+        "team": SentMessageRecord.EVENT_TYPE_TEAM
     }
 
     def email(self, event):

--- a/tabbycat/notifications/utils.py
+++ b/tabbycat/notifications/utils.py
@@ -123,9 +123,11 @@ def standings_email_generator(url, round_id):
     teams = round.active_teams.prefetch_related('speaker_set')
     populate_win_counts(teams)
 
-    context = {'TOURN': str(tournament)}
-
-    context['URL'] = url if tournament.pref('public_team_standings') else ""
+    context = {
+        'TOURN': str(tournament),
+        'ROUND': round.name,
+        'URL': url if tournament.pref('public_team_standings') else ""
+    }
 
     for team in teams:
         context_team = context.copy()

--- a/tabbycat/notifications/utils.py
+++ b/tabbycat/notifications/utils.py
@@ -171,3 +171,31 @@ def motion_release_email_generator(round_id):
             emails.append((context, speaker))
 
     return emails
+
+
+def team_speaker_email_generator(tournament_id):
+    emails = []
+    tournament = Tournament.objects.get(id=tournament_id)
+
+    for team in tournament.team_set.all().prefetch_related('speaker_set', 'break_categories').select_related('division', 'institution'):
+        context = {
+            'TOURN': str(tournament),
+            'SHORT': team.short_name,
+            'LONG': team.long_name,
+            'CODE': team.code_name,
+            'DIVISION': team.division.name,
+            'BREAK': _(", ").join([breakq.name for breakq in team.break_categories.all()]),
+            'SPEAKERS': _(", ").join([p.name for p in team.speaker_set.all()]),
+            'INSTITUTION': str(team.institution),
+            'EMOJI': team.emoji
+        }
+
+        for speaker in team.speakers:
+            if speaker.email is None:
+                continue
+
+            context['USER'] = speaker.name
+
+            emails.append((context, speaker))
+
+    return emails

--- a/tabbycat/notifications/utils.py
+++ b/tabbycat/notifications/utils.py
@@ -190,7 +190,7 @@ def team_speaker_email_generator(tournament_id):
             'SHORT': team.short_name,
             'LONG': team.long_name,
             'CODE': team.code_name,
-            'DIVISION': team.division.name if not None else "",
+            'DIVISION': team.division.name if team.division is not None else "",
             'BREAK': _(", ").join([breakq.name for breakq in team.break_categories.all()]),
             'SPEAKERS': _(", ").join([p.name for p in team.speaker_set.all()]),
             'INSTITUTION': str(team.institution),

--- a/tabbycat/notifications/utils.py
+++ b/tabbycat/notifications/utils.py
@@ -46,10 +46,11 @@ def adjudicator_assignment_email_generator(round_id):
             if adj.email is None:
                 continue
 
-            context['USER'] = adj.name
-            context['POSITION'] = adj_position_names[pos]
+            context_user = context.copy()
+            context_user['USER'] = adj.name
+            context_user['POSITION'] = adj_position_names[pos]
 
-            emails.append((context, adj))
+            emails.append((context_user, adj))
 
     return emails
 
@@ -105,8 +106,9 @@ def ballots_email_generator(debate_id):
             for speaker in team['speakers']:
                 scores += _("- %(debater)s: %(score)s\n") % {'debater': speaker['speaker'], 'score': speaker['score']}
 
-        context['USER'] = judge.name
-        context['SCORES'] = scores
+        context_user = context.copy()
+        context_user['USER'] = judge.name
+        context_user['SCORES'] = scores
 
         emails.append((context, judge))
 
@@ -126,16 +128,18 @@ def standings_email_generator(url, round_id):
     context['URL'] = url if tournament.pref('public_team_standings') else ""
 
     for team in teams:
-        context['POINTS'] = str(team.points_count)
-        context['TEAM'] = team.short_name
+        context_team = context.copy()
+        context_team['POINTS'] = str(team.points_count)
+        context_team['TEAM'] = team.short_name
 
         for speaker in team.speaker_set.all():
             if speaker.email is None:
                 continue
 
-            context['USER'] = speaker.name
+            context_user = context_team.copy()
+            context_user['USER'] = speaker.name
 
-            emails.append((context, speaker))
+            emails.append((context_user, speaker))
 
     return emails
 
@@ -166,9 +170,10 @@ def motion_release_email_generator(round_id):
             if speaker.email is None:
                 continue
 
-            context['USER'] = speaker.name
+            context_user = context.copy()
+            context_user['USER'] = speaker.name
 
-            emails.append((context, speaker))
+            emails.append((context_user, speaker))
 
     return emails
 
@@ -183,7 +188,7 @@ def team_speaker_email_generator(tournament_id):
             'SHORT': team.short_name,
             'LONG': team.long_name,
             'CODE': team.code_name,
-            'DIVISION': team.division.name,
+            'DIVISION': team.division.name if not None else "",
             'BREAK': _(", ").join([breakq.name for breakq in team.break_categories.all()]),
             'SPEAKERS': _(", ").join([p.name for p in team.speaker_set.all()]),
             'INSTITUTION': str(team.institution),
@@ -194,8 +199,9 @@ def team_speaker_email_generator(tournament_id):
             if speaker.email is None:
                 continue
 
-            context['USER'] = speaker.name
+            context_user = context.copy()
+            context_user['USER'] = speaker.name
 
-            emails.append((context, speaker))
+            emails.append((context_user, speaker))
 
     return emails

--- a/tabbycat/options/preferences.py
+++ b/tabbycat/options/preferences.py
@@ -1341,7 +1341,7 @@ class PointsEmailSubjectLine(StringPreference):
     verbose_name = _("Team points subject line")
     section = email
     name = 'team_points_email_subject'
-    default = "Your current number of wins for {{ TEAM }} ({{ TOURN }}): {{ POINTS }}"
+    default = "Your current number of wins after {{ ROUND }} for {{ TEAM }} ({{ TOURN }}): {{ POINTS }}"
 
 
 @tournament_preferences_registry.register
@@ -1350,7 +1350,7 @@ class PointsEmailMessageBody(LongStringPreference):
     verbose_name = _("Team points message")
     section = email
     name = 'team_points_email_message'
-    default = "Hi {{ USER }},\n\nYour team ({{ TEAM }}) currently has {{ POINTS }} wins in the {{ TOURN }}.\n\n{{ URL }}"
+    default = "Hi {{ USER }},\n\nAfter {{ ROUND }}, your team ({{ TEAM }}) currently has {{ POINTS }} wins in the {{ TOURN }}.\n\n{{ URL }}"
 
 
 @tournament_preferences_registry.register

--- a/tabbycat/options/preferences.py
+++ b/tabbycat/options/preferences.py
@@ -1430,3 +1430,22 @@ class MotionReleaseEmailMessage(LongStringPreference):
     section = email
     name = 'motion_email_message'
     default = "{{ MOTIONS }}"
+
+
+@tournament_preferences_registry.register
+class TeamNameEmailSubject(StringPreference):
+    help_text = _("The subject-line for emails sent to participants informing them of their team registration.")
+    verbose_name = _("Team registration notification subject line")
+    section = email
+    name = 'team_email_subject'
+    default = "Registration for {{ SHORT }}"
+
+
+@tournament_preferences_registry.register
+class TeamNameEmailMessage(LongStringPreference):
+    help_text = _("The message body for emails sent to participants informing them of their team registration.")
+    verbose_name = _("Team registration notification message")
+    section = email
+    name = 'team_email_message'
+    default = ("Hi {{ USER }},\n\n"
+        "You are registered as {{ LONG }} in {{ TOURN }} with {{ SPEAKERS }}. Your code name is {{ CODE }}.")

--- a/tabbycat/options/preferences.py
+++ b/tabbycat/options/preferences.py
@@ -1448,4 +1448,4 @@ class TeamNameEmailMessage(LongStringPreference):
     section = email
     name = 'team_email_message'
     default = ("Hi {{ USER }},\n\n"
-        "You are registered as {{ LONG }} in {{ TOURN }} with {{ SPEAKERS }}. Your code name is {{ CODE }}.")
+        "You are registered as {{ LONG }} in {{ TOURN }} with {{ SPEAKERS }}.")

--- a/tabbycat/options/presets.py
+++ b/tabbycat/options/presets.py
@@ -136,7 +136,7 @@ class BritishParliamentaryPreferences(PreferencesPreset):
     ui_options__show_team_institutions         = False
     ui_options__show_adjudicator_institutions  = True
     # Email Sending
-    email__team_points_email_subject           = 'Your current number of points for {{ TEAM }} ({{ TOURN }}): {{ POINTS }}'
+    email__team_points_email_subject           = 'Your current number of points after {{ ROUND }} for {{ TEAM }} ({{ TOURN }}): {{ POINTS }}'
     email__team_points_email_message           = "Hi {{ USER }},\n\nYour team ({{ TEAM }}) currently has {{ POINTS }} points in the {{ TOURN }}.\n\n{{ URL }}"
 
 

--- a/tabbycat/participants/templates/participants_subnav.html
+++ b/tabbycat/participants/templates/participants_subnav.html
@@ -11,6 +11,20 @@
   </a>
 </div>
 <div class="btn-group btn-group">
+  <form action="{% tournamenturl 'participants-email' %}" method="POST">
+    {% csrf_token %}
+    {% if email_sent %}
+      <button class="btn btn-outline-secondary" id="emailTeams" type="submit" data-toggle="tooltip" title="{% trans "Emails have already been sent." %}">
+        {% trans "Email Registration" %}
+      </button>
+    {% else %}
+      <button class="btn btn-outline-primary" id="emailTeams" type="submit">
+        {% trans "Email Registration" %}
+      </button>
+    {% endif %}
+  </form>
+</div>
+<div class="btn-group btn-group">
   {% if pref.team_code_names != 'off' %}
     <a class="btn btn-outline-primary {% if code_names_nav %}active{% endif %}"
        href="{% tournamenturl 'participants-code-names-list' %}">

--- a/tabbycat/participants/urls_admin.py
+++ b/tabbycat/participants/urls_admin.py
@@ -13,6 +13,10 @@ urlpatterns = [
         views.AdminCodeNamesListView.as_view(),
         name='participants-code-names-list'),
 
+    path('email/',
+        views.EmailParticipantRegistrationView.as_view(),
+        name='participants-email'),
+
     path('eligibility/',
         views.EditSpeakerCategoryEligibilityView.as_view(),
         name='participants-speaker-eligibility'),

--- a/tabbycat/participants/views.py
+++ b/tabbycat/participants/views.py
@@ -172,7 +172,7 @@ class EmailParticipantRegistrationView(TournamentMixin, PostOnlyRedirectView):
             "extra": {'tournament_id': self.tournament.id}
         })
 
-        messages.success(self.request, _("Registration information emails have been successfully queued for sending."))
+        messages.success(self.request, _("Registration information emails have been queued for sending."))
 
         return super().post(request, *args, **kwargs)
 

--- a/tabbycat/privateurls/views.py
+++ b/tabbycat/privateurls/views.py
@@ -157,7 +157,7 @@ class EmailRandomizedUrlsView(RandomisedUrlsMixin, PostOnlyRedirectView):
             "extra": {'url': url, 'tournament_id': t.id}
         })
 
-        messages.success(self.request, _("Private URL emails have been successfully queued for sending."))
+        messages.success(self.request, _("Private URL emails have been queued for sending."))
 
         people_no_email = t.participants.filter(
             Q(email__isnull=True) | Q(email__exact=""), url_key__isnull=False


### PR DESCRIPTION
Team information emails can be used to double-check make sure teams'
registrations are correct by sending them what was recorded in Tabbycat.
These notifications have information such as the members of the team,
the team name, and their category(ies).

Closes #791.