### PR TITLE
Use dictionary copy in email generators

### DIFF
--- a/tabbycat/draw/utils.py
+++ b/tabbycat/draw/utils.py
@@ -72,10 +72,11 @@ def send_mail_to_adjs(round):
             if adj.email is None:
                 continue
 
-            context['USER'] = adj.name
-            context['POSITION'] = adj_position_names[pos]
+            context_user = context.copy()
+            context_user['USER'] = adj.name
+            context_user['POSITION'] = adj_position_names[pos]
 
-            messages.append(TournamentEmailMessage(subject, body, tournament, round, SentMessageRecord.EVENT_TYPE_DRAW, adj, context))
+            messages.append(TournamentEmailMessage(subject, body, tournament, round, SentMessageRecord.EVENT_TYPE_DRAW, adj, context_user))
 
     try:
         get_connection().send_messages(messages)

--- a/tabbycat/results/utils.py
+++ b/tabbycat/results/utils.py
@@ -248,10 +248,11 @@ def send_ballot_receipt_emails_to_adjudicators(ballots, debate):
             for speaker in team['speakers']:
                 scores += _("- %(debater)s: %(score)s\n") % {'debater': speaker['speaker'], 'score': speaker['score']}
 
-        context['USER'] = judge.name
-        context['SCORES'] = scores
+        context_user = context.copy()
+        context_user['USER'] = judge.name
+        context_user['SCORES'] = scores
 
-        messages.append(TournamentEmailMessage(subject, message, debate.round.tournament, debate.round, SentMessageRecord.EVENT_TYPE_BALLOT_CONFIRMED, judge, context))
+        messages.append(TournamentEmailMessage(subject, message, debate.round.tournament, debate.round, SentMessageRecord.EVENT_TYPE_BALLOT_CONFIRMED, judge, context_user))
 
     try:
         get_connection().send_messages(messages)

--- a/tabbycat/tournaments/utils.py
+++ b/tabbycat/tournaments/utils.py
@@ -198,16 +198,18 @@ def send_standings_emails(tournament, teams, request, round):
         message += "\n\n" + tournament.pref('team_points_email_link_text') + "\n" + url
 
     for team in teams:
-        context['POINTS'] = str(team.points_count)
-        context['TEAM'] = team.short_name
+        context_team = context.copy()
+        context_team['POINTS'] = str(team.points_count)
+        context_team['TEAM'] = team.short_name
 
         for speaker in team.speakers:
             if speaker.email is None:
                 continue
 
-            context['USER'] = speaker.name
+            context_user = context_team.copy()
+            context_user['USER'] = speaker.name
 
-            messages.append(TournamentEmailMessage(subject, Template(message), tournament, round, SentMessageRecord.EVENT_TYPE_POINTS, speaker, context))
+            messages.append(TournamentEmailMessage(subject, Template(message), tournament, round, SentMessageRecord.EVENT_TYPE_POINTS, speaker, context_user))
 
     try:
         get_connection().send_messages(messages)


### PR DESCRIPTION
As dictionaries are passed by reference, variables that change per
recipient may not actually be modified. As a result, the general context
dictionary has to be copied for applicability for users.

Not cherry-picked, but would still affect emails. Please note that this probably won't merge nicely as all the logic has been refactored since 2.2.