### PR TITLE
Include only preliminary scores in speaks overview

### DIFF
--- a/tabbycat/standings/views.py
+++ b/tabbycat/standings/views.py
@@ -67,6 +67,7 @@ class StandingsIndexView(AdministratorMixin, RoundMixin, TemplateView):
             'debate_team__team__institution'
         )
         if self.tournament.pref('teams_in_debate') == 'bp':
+            team_scores.filter(debate_team__debate__round__stage=Round.STAGE_PRELIMINARY)
             kwargs["top_team_scores"] = team_scores.order_by('-score')[:9]
             kwargs["bottom_team_scores"] = team_scores.order_by('score')[:9]
         else:


### PR DESCRIPTION
In the standings overview, the top scores would have the elimination
rounds included. Or, they do not receive scores so they become None
which deplaces real scores. This commit filters the scores to only
include preliminary rounds.