### PR TITLE
Don't display venue in iron-list if None

### DIFF
--- a/tabbycat/results/templates/admin_results.html
+++ b/tabbycat/results/templates/admin_results.html
@@ -25,7 +25,12 @@
         <div class="list-group">
           {% for iron in iron_speeches %}
             <div class="list-group-item">
-              <h5>For Current Debate in Venue {{ iron.venue }}</h5>
+              <h5>
+                For Current Debate
+                {% if iron.venue %}
+                  in Venue {{ iron.venue }}
+                {% endif %}
+              </h5>
               {% if iron.previous_round %}
                 <p class="text-warning mt-3 mb-0">
                   {% blocktrans trimmed with team=iron.team %}


### PR DESCRIPTION
Continuation on BACKEND-10T.

PR on the allocations branch as it has the first part of the fix (even though the link between the branches is non-existant :) ) Thought for a second I assigned myself to this, but realized I had removed myself...