### PR TITLE
Add attribute check for venue in adj draw email

### DIFF
--- a/tabbycat/notifications/utils.py
+++ b/tabbycat/notifications/utils.py
@@ -48,7 +48,7 @@ def adjudicator_assignment_email_generator(to, url, round_id):
         matchup = debate.matchup_codes if use_codes else debate.matchup
         context = {
             'ROUND': round.name,
-            'VENUE': debate.venue.name,
+            'VENUE': debate.venue.name if hasattr(debate, venue) else _("TBA"),
             'PANEL': _assemble_panel(debate.adjudicators.with_positions()),
             'DRAW': matchup
         }


### PR DESCRIPTION
As the venue can be null, a check was needed. Closes BACKEND-118.