### PR TITLE
Fix viewbox for QR codes

### DIFF
--- a/tabbycat/printing/templates/randomised_url_sheets.html
+++ b/tabbycat/printing/templates/randomised_url_sheets.html
@@ -40,7 +40,7 @@
         {% endblocktrans %}
       </p>
       <p>{{ p.url }}</p>
-      <svg version="1.1" viewBox="0 0 37 37" width="200px" xmlns="http://www.w3.org/2000/svg">
+      <svg version="1.1" viewBox="0 0 41 41" width="200px" xmlns="http://www.w3.org/2000/svg">
         <path d="{{ p.qr }}" />
       </svg>
     </div>


### PR DESCRIPTION
While the size of the codes are of 37px, QR codes have a buffer of 4px. This caused the bottom and right sides to be cut-off. To keep the buffer, a break tag was added.