### PR TITLE
Add filter for institutions in constraints

### DIFF
--- a/tabbycat/adjallocation/views.py
+++ b/tabbycat/adjallocation/views.py
@@ -14,7 +14,7 @@ from actionlog.models import ActionLogEntry
 from availability.utils import annotate_availability
 from breakqual.models import BreakCategory
 from draw.models import Debate
-from participants.models import Adjudicator, Region
+from participants.models import Adjudicator, Institution, Region
 from participants.prefetch import populate_feedback_scores
 from tournaments.models import Round
 from tournaments.mixins import DebateDragAndDropMixin, LegacyDrawForDragAndDropMixin, RoundMixin, TournamentMixin
@@ -437,8 +437,10 @@ class AdjudicatorInstitutionConflictsView(BaseAdjudicatorConflictsView):
     def get_formset(self):
         formset = super().get_formset()
         all_adjs = self.tournament.adjudicator_set.order_by('name').all()
+        all_inst = self.tournament.relevant_institutions.all()
         for form in formset:
             form.fields['adjudicator'].queryset = all_adjs  # order alphabetically
+            form.fields['institution'].queryset = all_inst
         return formset
 
     def get_formset_queryset(self):
@@ -479,8 +481,10 @@ class TeamInstitutionConflictsView(BaseAdjudicatorConflictsView):
     def get_formset(self):
         formset = super().get_formset()
         all_teams = self.tournament.team_set.order_by('short_name').all()
+        all_inst = self.tournament.relevant_institutions.all()
         for form in formset:
             form.fields['team'].queryset = all_teams  # order alphabetically
+            form.fields['institution'].queryset = all_inst
         return formset
 
     def get_formset_queryset(self):

--- a/tabbycat/tournaments/models.py
+++ b/tabbycat/tournaments/models.py
@@ -6,7 +6,7 @@ from django.urls import reverse
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
-from participants.models import Person
+from participants.models import Person, Institution
 from utils.managers import LookupByNameFieldsMixin
 
 import logging
@@ -165,6 +165,12 @@ class Tournament(models.Model):
             return Venue.objects.filter(Q(tournament=self) | Q(tournament__isnull=True))
         else:
             return self.venue_set.all()
+
+    @property
+    def relevant_institutions(self):
+        adjs_inst = self.relevant_adjudicators.values_list('institution_id', flat=True)
+        teams_inst = self.team_set.all().values_list('institution_id', flat=True)
+        return Institution.objects.filter(Q(pk__in=teams_inst) | Q(pk__in=adjs_inst))
 
     @property
     def participants(self):


### PR DESCRIPTION
Not all institutions may be relevant to be included in the constraints form-sets. When no one from an institution is present in a tournament, there is no need for the institution to be listed. This commit adds a property to the Tournament model to get the relevant institutions.