### PR TITLE
Split venue constraints page(s)

### DIFF
--- a/tabbycat/actionlog/models.py
+++ b/tabbycat/actionlog/models.py
@@ -39,7 +39,11 @@ class ActionLogEntry(models.Model):
     ACTION_TYPE_VENUES_SAVE                       = 've.save'
     ACTION_TYPE_VENUES_AUTOALLOCATE               = 've.auto'
     ACTION_TYPE_VENUE_CATEGORIES_EDIT             = 've.ca.edit'
-    ACTION_TYPE_VENUE_CONSTRAINTS_EDIT            = 've.co.edit'
+    ACTION_TYPE_VENUE_CONSTRAINTS_EDIT            = 've.co.edit' # obsolete
+    ACTION_TYPE_VENUE_CONSTRAINTS_ADJ_EDIT        = 've.cj.edit'
+    ACTION_TYPE_VENUE_CONSTRAINTS_TEAM_EDIT       = 've.ct.edit'
+    ACTION_TYPE_VENUE_CONSTRAINTS_INST_EDIT       = 've.ci.edit'
+    ACTION_TYPE_VENUE_CONSTRAINTS_DIV_EDIT        = 've.cd.edit'
     ACTION_TYPE_MATCHUP_SAVE                      = 'mu.save'
     ACTION_TYPE_SIDES_SAVE                        = 'ms.save'
     ACTION_TYPE_DRAW_RELEASE                      = 'dr.rele'
@@ -102,6 +106,10 @@ class ActionLogEntry(models.Model):
         (ACTION_TYPE_VENUES_AUTOALLOCATE              , _("Auto-allocated venues")),
         (ACTION_TYPE_VENUE_CATEGORIES_EDIT            , _("Edited venue categories")),
         (ACTION_TYPE_VENUE_CONSTRAINTS_EDIT           , _("Edited venue constraints")),
+        (ACTION_TYPE_VENUE_CONSTRAINTS_ADJ_EDIT       , _("Edited venue-adjudicator constraints")),
+        (ACTION_TYPE_VENUE_CONSTRAINTS_TEAM_EDIT      , _("Edited venue-team constraints")),
+        (ACTION_TYPE_VENUE_CONSTRAINTS_INST_EDIT      , _("Edited venue-institution constraints")),
+        (ACTION_TYPE_VENUE_CONSTRAINTS_DIV_EDIT       , _("Edited venue-division constraints")),
         (ACTION_TYPE_DRAW_CREATE                      , _("Created draw")),
         (ACTION_TYPE_DRAW_CONFIRM                     , _("Confirmed draw")),
         (ACTION_TYPE_DRAW_REGENERATE                  , _("Regenerated draw")),

--- a/tabbycat/importer/templates/simple_import_index.html
+++ b/tabbycat/importer/templates/simple_import_index.html
@@ -36,9 +36,23 @@
     {% trans "Add/Edit Venue Categories" as text %}
     {% include "components/item-action.html" with emoji="🏪" %}
 
-    {% tournamenturl 'venues-constraints' as url %}
-    {% trans "Add/Edit Venue Constraints" as text %}
+    {% tournamenturl 'venues-constraints-team' as url %}
+    {% trans "Add/Edit Venue-Team Constraints" as text %}
     {% include "components/item-action.html" with emoji="🏰" %}
+
+    {% tournamenturl 'venues-constraints-adjudicator' as url %}
+    {% trans "Add/Edit Venue-Adjudicator Constraints" as text %}
+    {% include "components/item-action.html" with emoji="🏰" %}
+
+    {% tournamenturl 'venues-constraints-institution' as url %}
+    {% trans "Add/Edit Venue-Institution Constraints" as text %}
+    {% include "components/item-action.html" with emoji="🏰" %}
+
+    {% if pref.division_venues %}
+      {% tournamenturl 'venues-constraints-division' as url %}
+      {% trans "Add/Edit Venue-Division Constraints" as text %}
+      {% include "components/item-action.html" with emoji="🏰" %}
+    {% endif %}
 
   </ul>
   <ul class="list-group mt-3">

--- a/tabbycat/utils/tables.py
+++ b/tabbycat/utils/tables.py
@@ -740,7 +740,7 @@ class TabbycatTableBuilder(BaseTableBuilder):
                 self.add_column(divisions_header, divisions_data)
 
         if self.tournament.pref('division_venues'):
-            # For public displays of the draw fopr leagues we only
+            # For public displays of the draw for leagues we only
             # show the venue category derive from each debate's division
             venue_data = [{'text': d.division.venue_category if d.division else ''} for d in debates]
         else:

--- a/tabbycat/venues/urls_admin.py
+++ b/tabbycat/venues/urls_admin.py
@@ -1,26 +1,40 @@
-from django.urls import path
+from django.urls import include, path
 
 from . import views
 
 urlpatterns = [
 
-    path('round/<int:round_seq>/edit/',
-        views.EditDebateVenuesView.as_view(),
-        name='edit-debate-venues'),
-    path('round/<int:round_seq>/edit-legacy/',
-        views.LegacyEditVenuesView.as_view(),
-        name='legacy-venues-edit'),
-    path('round/<int:round_seq>/save/',
-        views.LegacySaveVenuesView.as_view(),
-        name='legacy-save-debate-venues'),
-    path('round/<int:round_seq>/autoallocate/',
-        views.LegacyAutoAllocateVenuesView.as_view(),
-        name='legacy-venues-auto-allocate'),
+    path('round/<int:round_seq>/', include([
+        path('edit/',
+            views.EditDebateVenuesView.as_view(),
+            name='edit-debate-venues'),
+        path('edit-legacy/',
+            views.LegacyEditVenuesView.as_view(),
+            name='legacy-venues-edit'),
+        path('save/',
+            views.LegacySaveVenuesView.as_view(),
+            name='legacy-save-debate-venues'),
+        path('autoallocate/',
+            views.LegacyAutoAllocateVenuesView.as_view(),
+            name='legacy-venues-auto-allocate'),
+    ])),
 
     path('categories/',
         views.VenueCategoriesView.as_view(),
         name='venues-categories'),
-    path('constraints/',
-        views.VenueConstraintsView.as_view(),
-        name='venues-constraints'),
+
+    path('constraints/', include([
+        path('team/',
+            views.VenueTeamConstraintsView.as_view(),
+            name='venues-constraints-team'),
+        path('adjudicator/',
+            views.VenueAdjudicatorConstraintsView.as_view(),
+            name='venues-constraints-adjudicator'),
+        path('institution/',
+            views.VenueInstitutionConstraintsView.as_view(),
+            name='venues-constraints-institution'),
+        path('division/',
+            views.VenueDivisionConstraintsView.as_view(),
+            name='venues-constraints-division'),
+    ])),
 ]


### PR DESCRIPTION
As subclasses of the adjudicator conflict views, the venue constraints views have been split in the same fashion and listed in the simple importer page. New action log events have been created to specify what kind of constraint have been added.