### PR TITLE
Use template array in response_class()

### DIFF
--- a/tabbycat/results/views.py
+++ b/tabbycat/results/views.py
@@ -500,7 +500,7 @@ class BasePublicNewBallotSetView(PersonalizablePublicTournamentPageMixin, BaseBa
         context = {'adjudicator': self.object, 'message': message}
         return self.response_class(
             request=self.request,
-            template='public_enter_results_error.html',
+            template=['public_enter_results_error.html'],
             context=context,
             using=self.template_engine
         )
@@ -582,7 +582,7 @@ class PublicBallotScoresheetsView(PublicTournamentPageMixin, SingleObjectFromTou
             status, message = error
             return self.response_class(
                 request=self.request,
-                template='public_ballot_set_error.html',
+                template=['public_ballot_set_error.html'],
                 context={'message': message},
                 using=self.template_engine,
                 status=status,


### PR DESCRIPTION
As the TemplateResponse uses an array, it might be necessary for the custom response (for errors in scoresheet views).

Closes [BACKEND-12P](https://sentry.io/tabbycat-ig/backend/issues/768062785/).