### PR TITLE
Fixed ballot adjudicator formating

### DIFF
--- a/tabbycat/printing/templates/PrintableDebateInfo.vue
+++ b/tabbycat/printing/templates/PrintableDebateInfo.vue
@@ -10,8 +10,9 @@
           <span v-if="ballot.debateAdjudicators && ballot.debateAdjudicators.length > 1">
             Adjudicating with
             <span v-for="(da, i) in panellistsExcludingSelf">
-              <template v-if="i !== 0">; </template>
-              <template v-if="i == panellistsExcludingSelf.length - 1">&amp; </template>
+              <template v-if="i !== 0 && i !== panellistsExcludingSelf.length - 1">;</template>
+              <template v-if="i !== 0">&nbsp;</template>
+              <template v-if="i !== 0 && i == panellistsExcludingSelf.length - 1">&amp; </template>
               <strong>{{ da.adjudicator.name }}</strong>
               <template v-if="da.position === 'c'"> (Chair, </template>
               <template v-if="da.position === 'o'"> (Solo Chair, </template>


### PR DESCRIPTION
Printed ballots with two adjudicators print with ```Adjudicating with & Adjudicator Name (Type, Institution)``` under the ballot title. Printed ballots with three adjudicators print with ```Adjudicating with Adjudicator Name (Type, Institution); & Adjudicator Name  (Type, Institution)``` under the ballot title.

Proposing that the first case becomes ```Adjudicating with Adjudicator Name (Type, Institution)``` and the second case becomes ```Adjudicating with Adjudicator Name (Type, Institution) & Adjudicator Name  (Type, Institution)```