### PR TITLE
Fix simple typos (French translation)

### DIFF
--- a/tabbycat/options/locale/fr/LC_MESSAGES/django.po
+++ b/tabbycat/options/locale/fr/LC_MESSAGES/django.po
@@ -1675,7 +1675,7 @@ msgstr "Modifier la Configuration : %(section_name)s"
 #: options/views.py:68
 #, python-format
 msgid "Tournament options (%(section)s) saved."
-msgstr "Options de tournoi (%(section)s sauvegardés."
+msgstr "Options de tournoi (%(section)s) sauvegardés."
 
 #: options/views.py:118
 #, python-format

--- a/tabbycat/participants/locale/fr/LC_MESSAGES/django.po
+++ b/tabbycat/participants/locale/fr/LC_MESSAGES/django.po
@@ -717,7 +717,7 @@ msgid ""
 "(whoever gave the oral adjudication)"
 msgstr ""
 "N’a pas présenté d’évaluation pour un d’entre eux : <strong>"
-"%(adjudicators)s</stong> (celui qui a rendu la décision)"
+"%(adjudicators)s</strong> (celui qui a rendu la décision)"
 
 #: participants/templates/feedback_progress_panel.html:30
 #, python-format


### PR DESCRIPTION
- HTML tag typo in feedback
- Missing closing parenthesis in options.