### PR TITLE
Add gender to registration card

### DIFF
--- a/tabbycat/participants/templates/adjudicator_registration_card.html
+++ b/tabbycat/participants/templates/adjudicator_registration_card.html
@@ -21,6 +21,20 @@
       </div>
     {% endif %}
 
+    {% if admin_page or private_url %}
+      <div class="list-group-item">
+        <strong>{% trans "Gender:" %}</strong>
+        {% if adjudicator.gender %}
+          {{ adjudicator.get_gender_display|capfirst }}
+        {% else %}
+          <span class="text-muted">{% trans "Unspecified" %}</span>
+        {% endif %}
+        {% if adjudicator.pronoun %}
+          ({{ adjudicator.pronoun }})
+        {% endif %}
+      </div>
+    {% endif %}
+
     {% if adjudicator.institution and pref.show_adjudicator_institutions or admin_page or private_url %}
       <div class="list-group-item">
         <strong>{% trans "Institution:" %}</strong>

--- a/tabbycat/participants/templates/team_registration_card.html
+++ b/tabbycat/participants/templates/team_registration_card.html
@@ -9,6 +9,20 @@
       </h4>
     </div>
 
+    {% if participant and admin_page or private_url %}
+      <div class="list-group-item">
+        <strong>{% trans "Gender:" %}</strong>
+        {% if participant.gender %}
+          {{ participant.get_gender_display|capfirst }}
+        {% else %}
+          <span class="text-muted">{% trans "Unspecified" %}</span>
+        {% endif %}
+        {% if participant.pronoun %}
+          ({{ participant.pronoun }})
+        {% endif %}
+      </div>
+    {% endif %}
+
     {% if not use_code_names and team.short_name != team.long_name %}
       <div class="list-group-item">
         <strong>{% if participant %}{% trans "Team name:" %}{% else %}{% trans "Full name:" %}{% endif %}</strong>
@@ -21,7 +35,7 @@
       </div>
     {% endif %}
 
-    {% if pref.show_speakers_in_draw %}
+    {% if pref.show_speakers_in_draw or admin_page or private_url %}
       <div class="list-group-item">
         <strong>{% trans "Speakers:" %}</strong>
         {% for speaker in team.speakers %}


### PR DESCRIPTION
This commit makes the participants' registered gender available on the admin interface and private URLs. Will make a note if unspecified.

Might be good to check whether the gender field is used for the tournament to see whether displaying it is relevant.

Idea from a FB post: https://www.facebook.com/groups/1681761898801915/permalink/2107386472906120/?comment_id=2107635126214588