### PR TITLE
Don't select people with duplicates by default

### DIFF
--- a/tabbycat/notifications/views.py
+++ b/tabbycat/notifications/views.py
@@ -275,12 +275,20 @@ class TemplateEmailCreateView(BaseSelectPeopleEmailView):
 
 class TournamentTemplateEmailCreateView(TemplateEmailCreateView):
 
+    def get_default_send_queryset(self):
+        return super().get_default_send_queryset().exclude(
+            sentmessagerecord__notification__event=self.event, sentmessagerecord__notification__tournament=self.tournament)
+
     def get_extra(self):
         extra = {'tournament_id': self.tournament.id}
         return extra
 
 
 class RoundTemplateEmailCreateView(TemplateEmailCreateView, RoundMixin):
+
+    def get_default_send_queryset(self):
+        return super().get_default_send_queryset().exclude(
+            sentmessagerecord__notification__event=self.event, sentmessagerecord__notification__round=self.round)
 
     def get_extra(self):
         extra = {'round_id': self.round.id}


### PR DESCRIPTION
This commit adds filters for participants for who to select by default to exclude participants who have already been sent a notification of the same type in the same tournament/round.