### PR TITLE
Fix notifications bulknotification migration

### DIFF
--- a/tabbycat/notifications/migrations/0006_separate_tables.py
+++ b/tabbycat/notifications/migrations/0006_separate_tables.py
@@ -17,7 +17,7 @@ def create_bulk_notifications(apps, schema_editor):
             timestamps.append(m.timestamp)
             BulkNotification.objects.create(event=m.event, timestamp=m.timestamp,
                                             round=m.round, tournament=m.tournament)
-        m.notification_id = timestamps.index(m.timestamp)
+        m.notification_id = timestamps.index(m.timestamp) + 1
         m.save()
 
 


### PR DESCRIPTION
Index of timestamps (as used to determine bulk notification IDs) was off-by-one.