### PR TITLE
Reduce DB calls in public ballot view

### DIFF
--- a/tabbycat/participants/tables.py
+++ b/tabbycat/participants/tables.py
@@ -50,7 +50,7 @@ class AdjudicatorDebateTable:
         debateadjs = DebateAdjudicator.objects.filter(
             adjudicator=participant,
         ).select_related(
-            'debate__round'
+            'debate__round', 'debate__round__tournament'
         ).prefetch_related(
             Prefetch('debate__debateadjudicator_set',
                 queryset=DebateAdjudicator.objects.select_related('adjudicator__institution')),

--- a/tabbycat/results/result.py
+++ b/tabbycat/results/result.py
@@ -498,7 +498,7 @@ class VotingDebateResult(BaseDebateResultWithSpeakers):
         self.load_scoresheets()
 
     def load_scoresheets(self):
-        debateadjs = self.debate.debateadjudicator_set.exclude(type=DebateAdjudicator.TYPE_TRAINEE)
+        debateadjs = self.debate.debateadjudicator_set.exclude(type=DebateAdjudicator.TYPE_TRAINEE).select_related('adjudicator')
         self.debateadjs = {da.adjudicator: da for da in debateadjs}
         self.scoresheets = {adj: self.scoresheet_class(self.positions) for adj in self.debateadjs.keys()}
 
@@ -506,7 +506,7 @@ class VotingDebateResult(BaseDebateResultWithSpeakers):
             debate_adjudicator__in=debateadjs,
             debate_team__side__in=self.sides,
             position__in=self.positions,
-        ).select_related('debate_adjudicator__adjudicator', 'debate_team')
+        ).select_related('debate_adjudicator__adjudicator', 'debate_adjudicator__adjudicator__institution', 'debate_team')
 
         for ssba in speakerscorebyadjs:
             self.set_score(ssba.debate_adjudicator.adjudicator,

--- a/tabbycat/results/views.py
+++ b/tabbycat/results/views.py
@@ -589,6 +589,14 @@ class PublicBallotScoresheetsView(PublicTournamentPageMixin, SingleObjectFromTou
         else:
             return self.object.matchup
 
+    def get_object(self):
+        debate = self.model.objects.select_related(
+            'round'
+        ).prefetch_related(
+            'debateteam_set__team'
+        ).get(id=self.kwargs.get('pk'))
+        return debate
+
     def check_permissions(self):
         debate = self.object
         round = debate.round


### PR DESCRIPTION
Teams were being `SELECT`ed repetitively in the public ballot view. This commit adds an `select_related` to alleviate it.