### PR TITLE
Name parameters in translation strings

### DIFF
--- a/tabbycat/adjfeedback/views.py
+++ b/tabbycat/adjfeedback/views.py
@@ -710,10 +710,10 @@ class BaseFeedbackProgressView(TournamentMixin, VueTableTemplateView):
         total_expected = sum([progress.num_expected() for progress in all_progress])
         percentage_fulfilled = (1 - total_missing / total_expected) * 100
         return ngettext_lazy(
-            "%d missing feedback submission (%.1f%% returned)",
-            "%d missing feedback submissions (%.1f%% returned)",
+            "%(nmissing)d missing feedback submission (%(fulfilled).1f%% returned)",
+            "%(nmissing)d missing feedback submissions (%(fulfilled).1f%% returned)",
             total_missing
-        ) % (total_missing, percentage_fulfilled)
+        ) % {'nmissing': total_missing, 'fulfilled': percentage_fulfilled}
 
     def get_tables(self):
         teams_progress, adjs_progress = self.get_feedback_progress()

--- a/tabbycat/breakqual/views.py
+++ b/tabbycat/breakqual/views.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.db.models import Count, Q
 from django.http import JsonResponse
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext as _, ngettext
 from django.views.generic import FormView, TemplateView, View
 
 from actionlog.mixins import LogActionMixin
@@ -259,7 +259,11 @@ class EditTeamEligibilityView(AdministratorMixin, TournamentMixin, VueTableTempl
         for sc in speaker_categories:
             table.add_column({'title': _('%s Speakers') % sc.name, 'key': sc.name}, [{
                 'text': getattr(team, 'nspeakers_%s' % sc.slug, 'N/A'),
-                'tooltip': _('Team has %s speakers with the %s speaker category assigned') % (0, sc.name)
+                'tooltip': ngettext(
+                    'Team has %(nspeakers)s speaker with the %(category)s speaker category assigned',
+                    'Team has %(nspeakers)s speakers with the %(category)s speaker category assigned',
+                    getattr(team, 'nspeakers_%s' % sc.slug, 0)
+                ) % {'nspeakers': getattr(team, 'nspeakers_%s' % sc.slug, 'N/A'), 'category': sc.name}
             } for team in teams])
 
         return table

--- a/tabbycat/results/templates/ballot_entry_form.html
+++ b/tabbycat/results/templates/ballot_entry_form.html
@@ -46,19 +46,19 @@
             </div>
 
             {% for error in position.speaker.errors %}
-              {% blocktrans asvar message with pos=position.name error=error %}
+              {% blocktrans trimmed asvar message with pos=position.name error=error %}
                 Error with {{ pos }}'s speaker field: {{ error }}
               {% endblocktrans %}
               {% include "components/form-errors.html" %}
             {% endfor %}
             {% for error in position.ghost.errors %}
-              {% blocktrans asvar message with pos=position.name error=error %}
+              {% blocktrans trimmed asvar message with pos=position.name error=error %}
                 Error with {{ pos }}'s duplicate speaker field: {{ error }}
               {% endblocktrans %}
               {% include "components/form-errors.html" %}
             {% endfor %}
             {% for error in position.score.errors %}
-              {% blocktrans asvar message with pos=position.name error=error %}
+              {% blocktrans trimmed asvar message with pos=position.name error=error %}
                 Error with {{ pos }}'s score field: {{ error }}
               {% endblocktrans %}
               {% include "components/form-errors.html" %}

--- a/tabbycat/results/templates/public_enter_results.html
+++ b/tabbycat/results/templates/public_enter_results.html
@@ -66,7 +66,7 @@
         <input id="id_debate_result_status" type="hidden" name="debate_result_status" value="{{ debate.STATUS_DRAFT }}" />
         <input id="id_discarded" type="hidden" name="discarded" />
         <input id="id_confirmed" type="hidden" name="confirmed" />
-        <input class="save btn btn-success btn-block " type="submit" value="Submit Ballot(s)" tabindex="{{ form.nexttabindex }}"/>
+        <input class="save btn btn-success btn-block " type="submit" value="{% trans 'Submit Ballot(s)' %}" tabindex="{{ form.nexttabindex }}"/>
         <div class="text-center pt-3 small text-muted">
           {% trans "When submitting this form your IP address will be stored for logging purposes." %}
           {% if pref.enable_ballot_receipts %}


### PR DESCRIPTION
Some strings to translate had un-named parameters, which are disallowed.

Also made the speaker categories tooltip pluralizable and added its number parameter.