### PR TITLE
Fix typos in djangojs gettext

### DIFF
--- a/tabbycat/locale/ar/LC_MESSAGES/djangojs.po
+++ b/tabbycat/locale/ar/LC_MESSAGES/djangojs.po
@@ -18,7 +18,7 @@ msgstr ""
 "Language: ar\n"
 "Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;\n"
 
-#: templates/tables/TablesContrainer.vue:8
+#: templates/tables/TablesContainer.vue:8
 msgid "Find in Table"
 msgstr "البحث في الجدول"
 
@@ -56,59 +56,59 @@ msgstr ""
 msgid "Copy From Check-Ins"
 msgstr "نسخة من تسجيل الدخول "
 
-#: participants/templates/DiversityContrainer.vue:6
+#: participants/templates/DiversityContainer.vue:6
 msgid "Speaker Demographics"
 msgstr "توزيع المتحدثين "
 
-#: participants/templates/DiversityContrainer.vue:11
+#: participants/templates/DiversityContainer.vue:11
 msgid "No Gender Information"
 msgstr "لا يوجد معلومات الجنس"
 
-#: participants/templates/DiversityContrainer.vue:18
+#: participants/templates/DiversityContainer.vue:18
 msgid "No Speaker Categories Information"
 msgstr "لا يوجد معلومات عن فئة المتحدث "
 
-#: participants/templates/DiversityContrainer.vue:33
+#: participants/templates/DiversityContainer.vue:33
 msgid "Speaker Results"
 msgstr "نتائج المتحدث "
 
-#: participants/templates/DiversityContrainer.vue:36
+#: participants/templates/DiversityContainer.vue:36
 msgid "speakers with gender data"
 msgstr "المتحدثون مع بيانات جنسهم"
 
-#: participants/templates/DiversityContrainer.vue:38
+#: participants/templates/DiversityContainer.vue:38
 msgid "speaker scores total"
 msgstr "مجموع درجات المتحدث "
 
-#: participants/templates/DiversityContrainer.vue:49
+#: participants/templates/DiversityContainer.vue:49
 msgid "No Region Information"
 msgstr "لا يوجد معلومات عن المنطقة "
 
-#: participants/templates/DiversityContrainer.vue:56
+#: participants/templates/DiversityContainer.vue:56
 msgid "Adjudicator Demographics"
 msgstr "توزيع الحكام "
 
-#: participants/templates/DiversityContrainer.vue:68
+#: participants/templates/DiversityContainer.vue:68
 msgid "No Position Information"
 msgstr "لا يوجد معلومات عن الوظيفة "
 
-#: participants/templates/DiversityContrainer.vue:83
+#: participants/templates/DiversityContainer.vue:83
 msgid "Adjudicator Results"
 msgstr "نتائج الحكم "
 
-#: participants/templates/DiversityContrainer.vue:86
+#: participants/templates/DiversityContainer.vue:86
 msgid "adjudicators with gender data"
 msgstr "الحكام مع بيانات جنسهم"
 
-#: participants/templates/DiversityContrainer.vue:88
+#: participants/templates/DiversityContainer.vue:88
 msgid "feedback scores total"
 msgstr "مجموع درجات التغذية الراجعة "
 
-#: participants/templates/DiversityContrainer.vue:94
+#: participants/templates/DiversityContainer.vue:94
 msgid "No Adjudicator Ratings Information"
 msgstr "لا توجد معلومات حول تصنيف الحكام"
 
-#: participants/templates/DiversityContrainer.vue:99
+#: participants/templates/DiversityContainer.vue:99
 msgid "No Adjudicator-Adjudicator Feedback Information"
 msgstr "لا يوجد معلومات عن التغذية الراجعة حول تحكيم المحكمين "
 

--- a/tabbycat/locale/en/LC_MESSAGES/djangojs.po
+++ b/tabbycat/locale/en/LC_MESSAGES/djangojs.po
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 
-#: templates/tables/TablesContrainer.vue:8
+#: templates/tables/TablesContainer.vue:8
 msgid "Find in Table"
 msgstr ""
 
@@ -50,59 +50,59 @@ msgstr ""
 msgid "Copy From Check-Ins"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:6
+#: participants/templates/DiversityContainer.vue:6
 msgid "Speaker Demographics"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:11
+#: participants/templates/DiversityContainer.vue:11
 msgid "No Gender Information"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:18
+#: participants/templates/DiversityContainer.vue:18
 msgid "No Speaker Categories Information"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:33
+#: participants/templates/DiversityContainer.vue:33
 msgid "Speaker Results"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:36
+#: participants/templates/DiversityContainer.vue:36
 msgid "speakers with gender data"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:38
+#: participants/templates/DiversityContainer.vue:38
 msgid "speaker scores total"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:49
+#: participants/templates/DiversityContainer.vue:49
 msgid "No Region Information"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:56
+#: participants/templates/DiversityContainer.vue:56
 msgid "Adjudicator Demographics"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:68
+#: participants/templates/DiversityContainer.vue:68
 msgid "No Position Information"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:83
+#: participants/templates/DiversityContainer.vue:83
 msgid "Adjudicator Results"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:86
+#: participants/templates/DiversityContainer.vue:86
 msgid "adjudicators with gender data"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:88
+#: participants/templates/DiversityContainer.vue:88
 msgid "feedback scores total"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:94
+#: participants/templates/DiversityContainer.vue:94
 msgid "No Adjudicator Ratings Information"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:99
+#: participants/templates/DiversityContainer.vue:99
 msgid "No Adjudicator-Adjudicator Feedback Information"
 msgstr ""
 

--- a/tabbycat/locale/es/LC_MESSAGES/djangojs.po
+++ b/tabbycat/locale/es/LC_MESSAGES/djangojs.po
@@ -17,7 +17,7 @@ msgstr ""
 "Language: es\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: templates/tables/TablesContrainer.vue:8
+#: templates/tables/TablesContainer.vue:8
 msgid "Find in Table"
 msgstr ""
 
@@ -53,59 +53,59 @@ msgstr ""
 msgid "Copy From Check-Ins"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:6
+#: participants/templates/DiversityContainer.vue:6
 msgid "Speaker Demographics"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:11
+#: participants/templates/DiversityContainer.vue:11
 msgid "No Gender Information"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:18
+#: participants/templates/DiversityContainer.vue:18
 msgid "No Speaker Categories Information"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:33
+#: participants/templates/DiversityContainer.vue:33
 msgid "Speaker Results"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:36
+#: participants/templates/DiversityContainer.vue:36
 msgid "speakers with gender data"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:38
+#: participants/templates/DiversityContainer.vue:38
 msgid "speaker scores total"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:49
+#: participants/templates/DiversityContainer.vue:49
 msgid "No Region Information"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:56
+#: participants/templates/DiversityContainer.vue:56
 msgid "Adjudicator Demographics"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:68
+#: participants/templates/DiversityContainer.vue:68
 msgid "No Position Information"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:83
+#: participants/templates/DiversityContainer.vue:83
 msgid "Adjudicator Results"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:86
+#: participants/templates/DiversityContainer.vue:86
 msgid "adjudicators with gender data"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:88
+#: participants/templates/DiversityContainer.vue:88
 msgid "feedback scores total"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:94
+#: participants/templates/DiversityContainer.vue:94
 msgid "No Adjudicator Ratings Information"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:99
+#: participants/templates/DiversityContainer.vue:99
 msgid "No Adjudicator-Adjudicator Feedback Information"
 msgstr ""
 

--- a/tabbycat/locale/fr/LC_MESSAGES/djangojs.po
+++ b/tabbycat/locale/fr/LC_MESSAGES/djangojs.po
@@ -19,7 +19,7 @@ msgstr ""
 "Last-Translator: Étienne Beaulé <beauleetienne0@gmail.com>\n"
 "X-Generator: Poedit 2.2\n"
 
-#: templates/tables/TablesContrainer.vue:8
+#: templates/tables/TablesContainer.vue:8
 msgid "Find in Table"
 msgstr "Trouver dans la table"
 
@@ -60,59 +60,59 @@ msgstr ""
 msgid "Copy From Check-Ins"
 msgstr "Copier à partir des enregistrements"
 
-#: participants/templates/DiversityContrainer.vue:6
+#: participants/templates/DiversityContainer.vue:6
 msgid "Speaker Demographics"
 msgstr "Démographiques des Orateurs"
 
-#: participants/templates/DiversityContrainer.vue:11
+#: participants/templates/DiversityContainer.vue:11
 msgid "No Gender Information"
 msgstr "Pas d’information de genre"
 
-#: participants/templates/DiversityContrainer.vue:18
+#: participants/templates/DiversityContainer.vue:18
 msgid "No Speaker Categories Information"
 msgstr "Pas d’information des catégories d’orateur"
 
-#: participants/templates/DiversityContrainer.vue:33
+#: participants/templates/DiversityContainer.vue:33
 msgid "Speaker Results"
 msgstr "Résultats d’orateur"
 
-#: participants/templates/DiversityContrainer.vue:36
+#: participants/templates/DiversityContainer.vue:36
 msgid "speakers with gender data"
 msgstr "orateurs avec données de genre"
 
-#: participants/templates/DiversityContrainer.vue:38
+#: participants/templates/DiversityContainer.vue:38
 msgid "speaker scores total"
 msgstr "total des scores d’orateur"
 
-#: participants/templates/DiversityContrainer.vue:49
+#: participants/templates/DiversityContainer.vue:49
 msgid "No Region Information"
 msgstr "Pas d’information de région"
 
-#: participants/templates/DiversityContrainer.vue:56
+#: participants/templates/DiversityContainer.vue:56
 msgid "Adjudicator Demographics"
 msgstr "Démographiques des juges"
 
-#: participants/templates/DiversityContrainer.vue:68
+#: participants/templates/DiversityContainer.vue:68
 msgid "No Position Information"
 msgstr "Pas d’information de rôle"
 
-#: participants/templates/DiversityContrainer.vue:83
+#: participants/templates/DiversityContainer.vue:83
 msgid "Adjudicator Results"
 msgstr "Résultats de juge"
 
-#: participants/templates/DiversityContrainer.vue:86
+#: participants/templates/DiversityContainer.vue:86
 msgid "adjudicators with gender data"
 msgstr "juges avec données de genre"
 
-#: participants/templates/DiversityContrainer.vue:88
+#: participants/templates/DiversityContainer.vue:88
 msgid "feedback scores total"
 msgstr "totale des scores d’évaluation"
 
-#: participants/templates/DiversityContrainer.vue:94
+#: participants/templates/DiversityContainer.vue:94
 msgid "No Adjudicator Ratings Information"
 msgstr "Pas d’information de rang de juge"
 
-#: participants/templates/DiversityContrainer.vue:99
+#: participants/templates/DiversityContainer.vue:99
 msgid "No Adjudicator-Adjudicator Feedback Information"
 msgstr "Pas d’information d’évaluations juge-juge"
 

--- a/tabbycat/locale/ja/LC_MESSAGES/djangojs.po
+++ b/tabbycat/locale/ja/LC_MESSAGES/djangojs.po
@@ -18,7 +18,7 @@ msgstr ""
 "Language: ja\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: templates/tables/TablesContrainer.vue:8
+#: templates/tables/TablesContainer.vue:8
 msgid "Find in Table"
 msgstr ""
 
@@ -54,59 +54,59 @@ msgstr ""
 msgid "Copy From Check-Ins"
 msgstr "チェックインからコピーする"
 
-#: participants/templates/DiversityContrainer.vue:6
+#: participants/templates/DiversityContainer.vue:6
 msgid "Speaker Demographics"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:11
+#: participants/templates/DiversityContainer.vue:11
 msgid "No Gender Information"
 msgstr "ジェンダーに関する情報なし"
 
-#: participants/templates/DiversityContrainer.vue:18
+#: participants/templates/DiversityContainer.vue:18
 msgid "No Speaker Categories Information"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:33
+#: participants/templates/DiversityContainer.vue:33
 msgid "Speaker Results"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:36
+#: participants/templates/DiversityContainer.vue:36
 msgid "speakers with gender data"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:38
+#: participants/templates/DiversityContainer.vue:38
 msgid "speaker scores total"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:49
+#: participants/templates/DiversityContainer.vue:49
 msgid "No Region Information"
 msgstr "地域情報なし"
 
-#: participants/templates/DiversityContrainer.vue:56
+#: participants/templates/DiversityContainer.vue:56
 msgid "Adjudicator Demographics"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:68
+#: participants/templates/DiversityContainer.vue:68
 msgid "No Position Information"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:83
+#: participants/templates/DiversityContainer.vue:83
 msgid "Adjudicator Results"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:86
+#: participants/templates/DiversityContainer.vue:86
 msgid "adjudicators with gender data"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:88
+#: participants/templates/DiversityContainer.vue:88
 msgid "feedback scores total"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:94
+#: participants/templates/DiversityContainer.vue:94
 msgid "No Adjudicator Ratings Information"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:99
+#: participants/templates/DiversityContainer.vue:99
 msgid "No Adjudicator-Adjudicator Feedback Information"
 msgstr ""
 

--- a/tabbycat/locale/pt/LC_MESSAGES/djangojs.po
+++ b/tabbycat/locale/pt/LC_MESSAGES/djangojs.po
@@ -17,7 +17,7 @@ msgstr ""
 "Language: pt\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: templates/tables/TablesContrainer.vue:8
+#: templates/tables/TablesContainer.vue:8
 msgid "Find in Table"
 msgstr ""
 
@@ -53,59 +53,59 @@ msgstr ""
 msgid "Copy From Check-Ins"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:6
+#: participants/templates/DiversityContainer.vue:6
 msgid "Speaker Demographics"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:11
+#: participants/templates/DiversityContainer.vue:11
 msgid "No Gender Information"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:18
+#: participants/templates/DiversityContainer.vue:18
 msgid "No Speaker Categories Information"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:33
+#: participants/templates/DiversityContainer.vue:33
 msgid "Speaker Results"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:36
+#: participants/templates/DiversityContainer.vue:36
 msgid "speakers with gender data"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:38
+#: participants/templates/DiversityContainer.vue:38
 msgid "speaker scores total"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:49
+#: participants/templates/DiversityContainer.vue:49
 msgid "No Region Information"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:56
+#: participants/templates/DiversityContainer.vue:56
 msgid "Adjudicator Demographics"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:68
+#: participants/templates/DiversityContainer.vue:68
 msgid "No Position Information"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:83
+#: participants/templates/DiversityContainer.vue:83
 msgid "Adjudicator Results"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:86
+#: participants/templates/DiversityContainer.vue:86
 msgid "adjudicators with gender data"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:88
+#: participants/templates/DiversityContainer.vue:88
 msgid "feedback scores total"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:94
+#: participants/templates/DiversityContainer.vue:94
 msgid "No Adjudicator Ratings Information"
 msgstr ""
 
-#: participants/templates/DiversityContrainer.vue:99
+#: participants/templates/DiversityContainer.vue:99
 msgid "No Adjudicator-Adjudicator Feedback Information"
 msgstr ""
 


### PR DESCRIPTION
"Contrainer" -> "Container" in filenames.

@philipbelesky: Should the typo in the translated files be corrected as well? Submitted as hotfix?