### PR TITLE
Use half-in checkin style when team not complete

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,7 +28,8 @@ Change Log
     - A adjudicator/team conflicts with an adjudicator if *any* institution appears as an institutional conflict for both parties
 - When printing scoresheets you can now edit the motions display just on that printing page. This allows you to use placeholder motions in Tabbycat (in order to prevent leaks) while still producing ballots with the correct motions
 - Info-slides can now be split into paragraphs
-- Instiututional caps in breaks can be based on the number of teams in the break. Thanks to Viran Weerasekera for this feature!
+- Check-in pages now differentiate between teams with 1 and 2 checked-in people in two-team formats
+- Institutional caps in breaks can be based on the number of teams in the break. Thanks to Viran Weerasekera for this feature!
 - Several Tabbycat functions, adjudicator/venue allocation and email notifications, have been shifted to worker processes to help make them more reliable. If you are upgrading a Tabbycat instance that you will continue to use for new tournaments you will need to install the Heroku toolbelt and run ``heroku ps:scale worker=1``
 - Upgraded to Python 3.6, dropped support for Python 3.5 and below. Note that this will require you to upgrade your python versions if running locally.
 

--- a/tabbycat/checkins/templates/CheckInStatusContainer.vue
+++ b/tabbycat/checkins/templates/CheckInStatusContainer.vue
@@ -162,6 +162,7 @@ export default {
     teamCodes: Boolean,
     tournamentSlug: String,
     forAdmin: Boolean,
+    teamSize: Number,
   },
   computed: {
     statsAbsent: function () {
@@ -253,8 +254,8 @@ export default {
       } else {
         css += 'text-uppercase '
       }
-      if (entity.speakersIn === 1) {
-        css += 'half-in-team ' // One speaker checked in
+      if (entity.speakersIn < this.teamSize && entity.speakersIn !== 0) {
+        css += 'half-in-team ' // Not all speakers checked-in
       } else if (entity.status === false) {
         css += 'bg-secondary ' // Nothing checked in
       } else {

--- a/tabbycat/checkins/templates/CheckInStatusContainer.vue
+++ b/tabbycat/checkins/templates/CheckInStatusContainer.vue
@@ -254,12 +254,18 @@ export default {
       } else {
         css += 'text-uppercase '
       }
-      if (entity.speakersIn < this.teamSize && entity.speakersIn !== 0) {
-        css += 'half-in-team ' // Not all speakers checked-in
-      } else if (entity.status === false) {
-        css += 'bg-secondary ' // Nothing checked in
+      if (entity.type !== 'Team' && entity.status !== false) {
+        css += 'bg-success ' // For venues/adjudicators that are checked in
+      } else if (entity.speakersIn >= this.teamSize && entity.speakersIn !== 0) {
+        css += 'bg-success ' // All speakers checked in
+      } else if (this.teamSize === 2 && entity.speakersIn === 1) {
+        css += 'viable-checkins-team ' // Half present in BP (viable to debate)
+      } else if (this.teamSize === 3 && entity.speakersIn === 2) {
+        css += 'viable-checkins-team ' // 2/3rds present in Australs (viable to debate)
+      } else if (this.teamSize === 3 && entity.speakersIn === 1) {
+        css += 'not-viable-checkins-team ' // 1/3rd present in Australs (not viable to debate)
       } else {
-        css += 'bg-success '
+        css += 'bg-secondary ' // Nothing checked in
       }
       return css
     },

--- a/tabbycat/checkins/templates/checkin_status.html
+++ b/tabbycat/checkins/templates/checkin_status.html
@@ -11,7 +11,8 @@
                                :venues="venues"
                                :assistant-url="assistantUrl"
                                :team-codes="teamCodes"
-                               :for-admin="forAdmin">
+                               :for-admin="forAdmin"
+                               :team-size="teamSize">
     </check-in-status-container>
   </div>
 
@@ -28,6 +29,7 @@
       'assistantUrl': {% if user_role == "admin" %}{% if venues %}'{% tournamenturl "assistant-venues-statuses" %}'{% else %}'{% tournamenturl "assistant-people-statuses" %}'{% endif %}{% else %}''{% endif %},
       'teamCodes': {{ team_codes }},
       'forAdmin': {% if for_admin %}true{% else %}false{% endif %},
+      'teamSize': {{ team_size }},
     }
   </script>
   {{ block.super }}

--- a/tabbycat/checkins/views.py
+++ b/tabbycat/checkins/views.py
@@ -51,6 +51,7 @@ class BaseCheckInStatusView(TournamentMixin, TemplateView):
         if self.scan_view:
             kwargs["scan_url"] = self.tournament.slug + '/checkins/'
         kwargs["for_admin"] = self.for_admin
+        kwargs["team_size"] = self.tournament.pref('substantive_speakers')
         return super().get_context_data(**kwargs)
 
 

--- a/tabbycat/templates/scss/components/page-specific.scss
+++ b/tabbycat/templates/scss/components/page-specific.scss
@@ -59,7 +59,11 @@
 // Check-In Status
 //------------------------------------------------------------------------------
 
-.half-in-team {
+.not-viable-checkins-team {
+  background: repeating-linear-gradient(45deg, $primary, $primary 10px, $secondary 10px, $secondary 20px);
+}
+
+.viable-checkins-team {
   background: repeating-linear-gradient(45deg, $success, $success 10px, $secondary 10px, $secondary 20px);
 }
 


### PR DESCRIPTION
Team checkin entities had striped green bars when only one speaker (out of two) were checked-in. This commit adds the style when not all speakers are, for the case where 2/3 are.

Fixes #1091.