### PR TITLE
Fix typo in djangojs.po

### DIFF
--- a/tabbycat/locale/ar/LC_MESSAGES/djangojs.po
+++ b/tabbycat/locale/ar/LC_MESSAGES/djangojs.po
@@ -140,19 +140,19 @@ msgstr ""
 msgid "Ballot Statuses"
 msgstr ""
 
-#: results/templates/BallotsCells.vue:18
+#: results/templates/BallotsCell.vue:18
 msgid "You cannot confirm this ballot because you entered it"
 msgstr ""
 
-#: results/templates/BallotsCells.vue:34
+#: results/templates/BallotsCell.vue:34
 msgid "Add Ballot"
 msgstr ""
 
-#: results/templates/BallotsCells.vue:79
+#: results/templates/BallotsCell.vue:79
 msgid "Re-Edit"
 msgstr ""
 
-#: results/templates/BallotsCells.vue:81
+#: results/templates/BallotsCell.vue:81
 msgid "Review"
 msgstr ""
 

--- a/tabbycat/locale/en/LC_MESSAGES/djangojs.po
+++ b/tabbycat/locale/en/LC_MESSAGES/djangojs.po
@@ -134,19 +134,19 @@ msgstr ""
 msgid "Ballot Statuses"
 msgstr ""
 
-#: results/templates/BallotsCells.vue:18
+#: results/templates/BallotsCell.vue:18
 msgid "You cannot confirm this ballot because you entered it"
 msgstr ""
 
-#: results/templates/BallotsCells.vue:34
+#: results/templates/BallotsCell.vue:34
 msgid "Add Ballot"
 msgstr ""
 
-#: results/templates/BallotsCells.vue:79
+#: results/templates/BallotsCell.vue:79
 msgid "Re-Edit"
 msgstr ""
 
-#: results/templates/BallotsCells.vue:81
+#: results/templates/BallotsCell.vue:81
 msgid "Review"
 msgstr ""
 

--- a/tabbycat/locale/es/LC_MESSAGES/djangojs.po
+++ b/tabbycat/locale/es/LC_MESSAGES/djangojs.po
@@ -137,19 +137,19 @@ msgstr ""
 msgid "Ballot Statuses"
 msgstr ""
 
-#: results/templates/BallotsCells.vue:18
+#: results/templates/BallotsCell.vue:18
 msgid "You cannot confirm this ballot because you entered it"
 msgstr ""
 
-#: results/templates/BallotsCells.vue:34
+#: results/templates/BallotsCell.vue:34
 msgid "Add Ballot"
 msgstr ""
 
-#: results/templates/BallotsCells.vue:79
+#: results/templates/BallotsCell.vue:79
 msgid "Re-Edit"
 msgstr ""
 
-#: results/templates/BallotsCells.vue:81
+#: results/templates/BallotsCell.vue:81
 msgid "Review"
 msgstr ""
 

--- a/tabbycat/locale/fr/LC_MESSAGES/djangojs.po
+++ b/tabbycat/locale/fr/LC_MESSAGES/djangojs.po
@@ -144,19 +144,19 @@ msgstr "Confirmé"
 msgid "Ballot Statuses"
 msgstr "Statuts de bulletins"
 
-#: results/templates/BallotsCells.vue:18
+#: results/templates/BallotsCell.vue:18
 msgid "You cannot confirm this ballot because you entered it"
 msgstr "Vous pouvez pas confirmer ce bulletin parce que vous l’avez saisi"
 
-#: results/templates/BallotsCells.vue:34
+#: results/templates/BallotsCell.vue:34
 msgid "Add Ballot"
 msgstr "Ajouter bulletin"
 
-#: results/templates/BallotsCells.vue:79
+#: results/templates/BallotsCell.vue:79
 msgid "Re-Edit"
 msgstr "Re-modifier"
 
-#: results/templates/BallotsCells.vue:81
+#: results/templates/BallotsCell.vue:81
 msgid "Review"
 msgstr "Réviser"
 

--- a/tabbycat/locale/ja/LC_MESSAGES/djangojs.po
+++ b/tabbycat/locale/ja/LC_MESSAGES/djangojs.po
@@ -138,19 +138,19 @@ msgstr ""
 msgid "Ballot Statuses"
 msgstr ""
 
-#: results/templates/BallotsCells.vue:18
+#: results/templates/BallotsCell.vue:18
 msgid "You cannot confirm this ballot because you entered it"
 msgstr ""
 
-#: results/templates/BallotsCells.vue:34
+#: results/templates/BallotsCell.vue:34
 msgid "Add Ballot"
 msgstr ""
 
-#: results/templates/BallotsCells.vue:79
+#: results/templates/BallotsCell.vue:79
 msgid "Re-Edit"
 msgstr ""
 
-#: results/templates/BallotsCells.vue:81
+#: results/templates/BallotsCell.vue:81
 msgid "Review"
 msgstr ""
 

--- a/tabbycat/locale/pt/LC_MESSAGES/djangojs.po
+++ b/tabbycat/locale/pt/LC_MESSAGES/djangojs.po
@@ -137,19 +137,19 @@ msgstr ""
 msgid "Ballot Statuses"
 msgstr ""
 
-#: results/templates/BallotsCells.vue:18
+#: results/templates/BallotsCell.vue:18
 msgid "You cannot confirm this ballot because you entered it"
 msgstr ""
 
-#: results/templates/BallotsCells.vue:34
+#: results/templates/BallotsCell.vue:34
 msgid "Add Ballot"
 msgstr ""
 
-#: results/templates/BallotsCells.vue:79
+#: results/templates/BallotsCell.vue:79
 msgid "Re-Edit"
 msgstr ""
 
-#: results/templates/BallotsCells.vue:81
+#: results/templates/BallotsCell.vue:81
 msgid "Review"
 msgstr ""
 


### PR DESCRIPTION
The 'BallotsCell.vue' template in results has cell pluralized.