### PR TITLE
Specify no relevant options for manual draw

### DIFF
--- a/tabbycat/draw/manager.py
+++ b/tabbycat/draw/manager.py
@@ -166,6 +166,9 @@ class RandomDrawManager(BaseDrawManager):
 class ManualDrawManager(BaseDrawManager):
     generator_type = "manual"
 
+    def get_relevant_options(self):
+        return []
+
 
 class PowerPairedDrawManager(BaseDrawManager):
     generator_type = "power_paired"


### PR DESCRIPTION
The manual draw-type did not override `get_relevant_options()` and so included some options when in two-team formats, causing a crash. This commit makes the draw manager return an empty list in that case.

@philipbelesky: Neither "Edit Sides/Matchups" (legacy and new interfaces) work when no teams are allocated, but fail differently. The legacy interface includes the draggable draw table but no teams, while its the opposite in the new interface (teams available but no table).