### PR TITLE
Add strings to prohibited tournament slugs

### DIFF
--- a/tabbycat/tournaments/models.py
+++ b/tabbycat/tournaments/models.py
@@ -14,9 +14,9 @@ logger = logging.getLogger(__name__)
 
 
 PROHIBITED_TOURNAMENT_SLUGS = [
-    'jet', 'database', 'admin', 'accounts',   # System
+    'jet', 'database', 'admin', 'accounts', 'summernote',  # System
     'start', 'create', 'load-demo', # Setup Wizards
-    'draw', 'participants',  # Cross-Tournament app's view roots
+    'draw', 'notifications', 'archive', # Cross-Tournament app's view roots
     'favicon.ico', 'robots.txt',  # Files that must be at top level
     '__debug__', 'static', 'donations', 'style', 'i18n', 'jsi18n']  # Misc
 


### PR DESCRIPTION
For the notifications test page, summernote, and XML import, forecasting its use. Also removed the participant x-tournament string from the list.