### PR TITLE
Revert standings email template to use "wins"

### DIFF
--- a/tabbycat/options/preferences.py
+++ b/tabbycat/options/preferences.py
@@ -1380,7 +1380,7 @@ class PointsEmailSubjectLine(StringPreference):
     help_text = _("The subject line for emails sent to speakers with their team points.")
     verbose_name = _("Team points subject line")
     name = 'team_points_email_subject'
-    default = "{{ TEAM }}'s current points after {{ ROUND }}: {{ POINTS }}"
+    default = "{{ TEAM }}'s current wins after {{ ROUND }}: {{ POINTS }}"
 
 
 @tournament_preferences_registry.register
@@ -1389,7 +1389,7 @@ class PointsEmailMessageBody(LongStringPreference):
     verbose_name = _("Team points message")
     name = 'team_points_email_message'
     default = ("<p>Hi {{ USER }},</p>"
-        "After {{ ROUND }}, your team ({{ TEAM }}) currently has <strong>{{ POINTS }}</strong> points in the {{ TOURN }}.</p>"
+        "After {{ ROUND }}, your team ({{ TEAM }}) currently has <strong>{{ POINTS }}</strong> wins in the {{ TOURN }}.</p>"
         "<p>Current Standings: <a href='{{ URL }}'>{{ URL }}</a></p>")
 
 

--- a/tabbycat/options/presets.py
+++ b/tabbycat/options/presets.py
@@ -135,8 +135,8 @@ class BritishParliamentaryPreferences(PreferencesPreset):
     # UI Options
     ui_options__show_team_institutions         = False
     ui_options__show_adjudicator_institutions  = True
-    # Email Sending
-    team_points_email_subject                  = 'Your current number of points after {{ ROUND }} for {{ TEAM }} ({{ TOURN }}): {{ POINTS }}'
+    # Email Sending - replace "wins" by "points"
+    team_points_email_subject                  = "{{ TEAM }}'s current points after {{ ROUND }}: {{ POINTS }}"
     team_points_email_message                  = ("<p>Hi {{ USER }},</p>",
         "<p>Your team ({{ TEAM }}) currently has <strong>{{ POINTS }}</strong> points in the {{ TOURN }}.",
         "<p>Current Standings: {{ URL }}</p>")


### PR DESCRIPTION
Instead of "points," which is more applicable in BP. It was changed incompletely in 270230c8aa6c1973f04d6d436f681478652ddfa1. The subject length change is kept but expanded to the BP preset.

A hotfix patch could be provided to include the missing `ROUND` variable. The variable is present in `develop` with the refactored notification system.