### PR TITLE
Un-mark error strings for translation

### DIFF
--- a/tabbycat/adjallocation/views.py
+++ b/tabbycat/adjallocation/views.py
@@ -248,11 +248,11 @@ class LegacyCreateAutoAllocation(LogActionMixin, LegacyAdjudicatorAllocationMixi
         round = self.round
         self.log_action()
         if round.draw_status == Round.STATUS_RELEASED:
-            info = _("Draw is already released, unrelease draw to redo auto-allocations.")
+            info = "Draw is already released, unrelease draw to redo auto-allocations."
             logger.warning(info)
             raise BadJsonRequestError(info)
         if round.draw_status != Round.STATUS_CONFIRMED:
-            info = _("Draw is not confirmed, confirm draw to run auto-allocations.")
+            info = "Draw is not confirmed, confirm draw to run auto-allocations."
             logger.warning(info)
             raise BadJsonRequestError(info)
 


### PR DESCRIPTION
A couple strings that were marked for translation never surface to users as they are passed into an exception. Having them marked sends the translated content to Sentry. (_e.g._ BACKEND-1BK)