### PR TITLE
Rewrite draw strength annotator to query for opponents directly

### DIFF
--- a/tabbycat/standings/metrics.py
+++ b/tabbycat/standings/metrics.py
@@ -100,7 +100,7 @@ class QuerySetMetricAnnotator(BaseMetricAnnotator):
     def get_annotated_queryset(self, queryset, column_name, round=None):
         """Returns a QuerySet annotated with the metric given."""
         annotation = self.get_annotation(round=round)
-        logger.info("Annotation in %s: %s", self.__class__.__name__, str(annotation.as_sql))
+        logger.info("Annotation in %s: %s", self.__class__.__name__, str(annotation))
         return queryset.annotate(**{column_name: annotation}).distinct()
 
     def annotate_with_queryset(self, queryset, standings, round=None):


### PR DESCRIPTION
Previously, this relied on the populate_opponents() method in draw/prefetch.py, which is designed to produce a single opponent per DebateTeam given to it (mainly for use in two-team formats). This doesn't work in BP (see #1071). Furthermore, draw strength doesn't require information on individual debate teams, it just requires a list of all opponents seen by a team, which can be queried more directly.

Fixes #1071