### PR TITLE
Enable Crowdin translation of djangojs.po

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,3 +1,3 @@
 files:
-  - source: /tabbycat/**/locale/en/LC_MESSAGES/django.po
+  - source: /tabbycat/**/locale/en/LC_MESSAGES/*.po
     translation: /tabbycat/**/locale/%two_letters_code%/LC_MESSAGES/%original_file_name%


### PR DESCRIPTION
For this, translation sources has another wildcard, that for the filename, which is normally "django" but sometimes something else, still `.po`.