### PR TITLE
Add pluralization for adj score < 0 warning

### DIFF
--- a/tabbycat/adjallocation/allocators/hungarian.py
+++ b/tabbycat/adjallocation/allocators/hungarian.py
@@ -57,7 +57,11 @@ class BaseHungarianAllocator(BaseAdjudicatorAllocator):
             logger.warning(warning_msg)
         ntoosmall = [adj._normalized_score < 0.0 for adj in adjudicators].count(True)
         if ntoosmall > 0:
-            warning_msg = _("%(count)s normalised scores are smaller than 0.0.") % {'counts': ntoosmall}
+            warning_msg = ngettext(
+                "%(count)s normalised score is smaller than 0.0.",
+                "%(count)s normalised scores are smaller than 0.0.",
+                ntoosmall
+            ) % {'count': ntoosmall}
             self.extra_messages += " " + warning_msg
             logger.warning(warning_msg)
 


### PR DESCRIPTION
In the hungarian adj allocator, there are warning messages if there are adjudicators with normalized scores greater than 5.0 or lower than 0.0. The message for greater than 5 is localizable, but the latter was not.

This patch adds pluralization and fixes the type on the key message.

Closes BACKEND-238