### PR TITLE
Send version of Tabbycat to Sentry

### DIFF
--- a/tabbycat/settings/heroku.py
+++ b/tabbycat/settings/heroku.py
@@ -6,6 +6,8 @@ import sentry_sdk
 from sentry_sdk.integrations.logging import LoggingIntegration
 from sentry_sdk.integrations.django import DjangoIntegration
 
+from .core import TABBYCAT_VERSION
+
 
 # ==============================================================================
 # Heroku
@@ -124,6 +126,7 @@ else:
             LoggingIntegration(event_level=logging.WARNING),
         ],
         send_default_pii=True,
+        release=TABBYCAT_VERSION,
     )
 
     # Override dictionary trimming so that all preferences will be included in Sentry reports


### PR DESCRIPTION
The release version was no longer being sent to Sentry on errors after the migration to the newer SDK. This is due to it searching for a `SENTRY_RELEASE` env variable. This change specifies the version in the initializer.