### PR TITLE
Notifications Status: Add cell value if recipient is null

### DIFF
--- a/tabbycat/notifications/models.py
+++ b/tabbycat/notifications/models.py
@@ -40,7 +40,12 @@ class SentMessage(models.Model):
         verbose_name_plural = _("sent messages")
 
     def __str__(self):
-        return "%s: %s" % (self.recipient.name, self.notification.get_event_display())
+        name = self.message_id
+        if self.recipient is not None:
+            name = self.recipient.name
+        elif self.email is not None:
+            name = self.email
+        return "%s: %s" % (name, self.notification.get_event_display())
 
 
 class BulkNotification(models.Model):


### PR DESCRIPTION
Recipients to a SentMessage can be null, which may cause a key error when trying to access their attributes. This happens in the email status view. A check is added for this case.

Closes BACKEND-24J