### PR TITLE
Add checks for None institutions in up-down swap

### DIFF
--- a/docs/features/draw-generation.rst
+++ b/docs/features/draw-generation.rst
@@ -181,8 +181,6 @@ It's a bit more complicated than that, for two reasons:
 * History conflicts are prioritised over (*i.e.*, "worse than") institution conflicts. So it's fine to resolve a history conflict by creating an institution conflict, but not the vice versa.
 * Each swap obviously affects the debates around it, so it's not legal to have two adjacent swaps. (Otherwise, in theory, a team could "one down" all the way to the bottom of the draw!) So there is an optimization algorithm that finds the best combination of swaps, *i.e.* the one that minimises conflict, and if there are two profiles that have the same least conflict, then it chooses the one with fewer swaps.
 
-.. note:: Teams imported without an institutional affiliation are (for conflict avoidance purposes) considered to all be from the same institution and will trigger conflicts as described above. If this is a concern it can be assigning 'fake' institutions (i.e. *Swing 1*) to each unaffiliated team.
-
 .. _draw-pullup-restriction:
 
 Pullup restriction

--- a/tabbycat/draw/generator/one_up_one_down.py
+++ b/tabbycat/draw/generator/one_up_one_down.py
@@ -81,8 +81,8 @@ class OneUpOneDownSwapper(object):
         do the swap."""
         (a1, n1) = debate1
         (a2, n2) = debate2
-        inst = (a1.institution == n1.institution,
-                a2.institution == n2.institution)
+        inst = (a1.institution == n1.institution and a1.institution is not None,
+                a2.institution == n2.institution and a2.institution is not None)
         hist = (a1.seen(n1), a2.seen(n2))
 
         if not ((inst[0] or inst[1]) and self.avoid_institution) and \

--- a/tabbycat/draw/tests/test_one_up_one_down.py
+++ b/tabbycat/draw/tests/test_one_up_one_down.py
@@ -28,6 +28,15 @@ class TestOneUpOneDown(unittest.TestCase):
         self.assertEqual(result, self.draw(data))
         return self.draw(data)
 
+    def test_swap_inst_none(self):
+        data = (((1, None), (5, None)),
+                ((2, 'C'), (6, 'B')),
+                ((3, 'B'), (7, 'D')),
+                ((4, 'C'), (8, 'A')))
+        result = [(1, 5), (2, 6), (3, 7), (4, 8)]
+        self.assertEqual(result, self.draw(data))
+        return self.draw(data)
+
     def test_no_swap_inst(self):
         data = (((1, 'A'), (5, 'A')),
                 ((2, 'C'), (6, 'B')),


### PR DESCRIPTION
When swapping teams due to being from the same institution, unaffiliated teams (thus with None) were barred from meeting. This commit adds checks for this case.