### PR TITLE
Results: Fix link to overview page

### DIFF
--- a/tabbycat/results/views.py
+++ b/tabbycat/results/views.py
@@ -344,7 +344,6 @@ class BaseBallotSetView(LogActionMixin, TournamentMixin, FormView):
 class AdministratorBallotSetMixin(AdministratorMixin):
     template_name = 'ballot_entry.html'
     tabroom = True
-    for_admin = True
 
     def get_success_url(self):
         return reverse_round('results-round-list', self.ballotsub.debate.round)

--- a/tabbycat/utils/mixins.py
+++ b/tabbycat/utils/mixins.py
@@ -50,6 +50,7 @@ class AdministratorMixin(UserPassesTestMixin, ContextMixin):
     """Mixin for views that are for administrators.
     Requires user to be a superuser."""
     view_role = "admin"
+    for_admin = True
 
     def get_context_data(self, **kwargs):
         kwargs["user_role"] = self.view_role


### PR DESCRIPTION
The old ballot entry page did not have `for_admin` set and so the "Back" button redirected to the assistant page. This commit sets `for_admin` as `True` for all views using `AdministratorMixin`.