### PR TITLE
Simulaterounds: Prevent last substantive speaker from being reply

### DIFF
--- a/tabbycat/results/dbutils.py
+++ b/tabbycat/results/dbutils.py
@@ -94,7 +94,7 @@ def add_result(debate, submitter_type, user, discarded=False, confirmed=False,
                 result.set_ghost(side, i, False)
 
             if t.reply_position is not None:
-                reply_speaker = random.randint(0, t.last_substantive_position-1) if reply_random else 0
+                reply_speaker = random.randint(0, t.last_substantive_position-2) if reply_random else 0
                 result.set_speaker(side, t.reply_position, speakers[reply_speaker])
                 result.set_ghost(side, t.reply_position, False)
 

--- a/tabbycat/results/dbutils.py
+++ b/tabbycat/results/dbutils.py
@@ -57,8 +57,7 @@ def fill_scoresheet_randomly(scoresheet, tournament):
             scoresheet.set_score(side, pos, score)
 
 
-def add_result(debate, submitter_type, user, discarded=False, confirmed=False,
-                  min_score=72, max_score=78, reply_random=False):
+def add_result(debate, submitter_type, user, discarded=False, confirmed=False, reply_random=False):
     """Adds a ballot set to a debate.
 
     ``debate`` is the Debate to which the ballot set should be added.

--- a/tabbycat/results/management/commands/generateresults.py
+++ b/tabbycat/results/management/commands/generateresults.py
@@ -35,12 +35,6 @@ class GenerateResultsCommandMixin:
         status.add_argument("-c", "--confirmed", action="store_true",
                             help="Make added ballot sets confirmed")
 
-        parser.add_argument("-m", "--min-score", type=float,
-                            help="Minimum speaker score (for substantive)",
-                            default=72)
-        parser.add_argument("-M", "--max-score", type=float,
-                            help="Maximum speaker score (for substantive)",
-                            default=78)
         parser.add_argument("--reply-random", action="store_true",
                             help="Choose reply speaker at random (rather than always use first speaker",
                             default=False)
@@ -62,8 +56,6 @@ class GenerateResultsCommandMixin:
             "user"          : cls._get_user(options),
             "discarded"     : options["discarded"],
             "confirmed"     : options["confirmed"],
-            "min_score"     : options["min_score"],
-            "max_score"     : options["max_score"],
             "reply_random"  : options["reply_random"],
         }
 


### PR DESCRIPTION
This commit reduces the choices of the reply speaker when using the `simulaterounds` command. The bug was caused by a mixup of the 0-indexed array and 1-indexed speaker positions.