### PR TITLE
Fix escaping of apostrophe in translatable string

### DIFF
--- a/tabbycat/adjfeedback/templates/feedback_card.html
+++ b/tabbycat/adjfeedback/templates/feedback_card.html
@@ -87,7 +87,7 @@
         {% endblocktrans %}
       </span>
       <span class="float-right" data-toggle="tooltip"
-            title="{% trans 'Unconfirmed feedback is not counted as having been submitted and does not affect this adjudicator\'s score.' %}">
+            title="{% trans "Unconfirmed feedback is not counted as having been submitted and does not affect this adjudicator's score." %}">
         <form method="POST" action="{% tournamenturl 'adjfeedback-confirm-feedback' feedback.id %}" class='text-secondary'>
           {% csrf_token %}
           <input type="hidden" name="next" value="{{ request.path }}">
@@ -97,7 +97,7 @@
         </form>
       </span>
       <span class="float-right" data-toggle="tooltip"
-            title="{% trans 'Ignored feedback is counted as having been submitted, but does not affect this adjudicator\'s score.' %}">
+            title="{% trans "Ignored feedback is counted as having been submitted, but does not affect this adjudicator's score." %}">
         <form method="POST" action="{% tournamenturl 'adjfeedback-ignore-feedback' feedback.id %}" class='text-secondary'>
           {% csrf_token %}
           <input type="hidden" name="next" value="{{ request.path }}">


### PR DESCRIPTION
Switched the use of single quotes to double quotes, which do not affect the quotes of the outside HTML attribute.