### PR TITLE
Update pip dependencies

### DIFF
--- a/config/requirements_core.txt
+++ b/config/requirements_core.txt
@@ -3,7 +3,7 @@
 # Django
 Django==2.2.4
 django-appconf==1.0.3                   # Helper for handling app configs
-git+https://github.com/EliotBerriot/django-dynamic-preferences.git@66dcbfbf # Settings management
+django-dynamic-preferences==1.7.1       # Settings management
 django-extensions==2.2.1                # For the generate secret command
 django-formtools==2.1                   # Form wizards
 django-ipware==2.1.0                    # IP Address logging
@@ -16,12 +16,9 @@ django-statici18n==1.8.3                # Compile translations files as static f
 django-summernote==0.8.11.4             # WYSIWYG editor
 munkres==1.1.2                          # Algorithm for adjudicator allocation
 dj-cmd==1.0                             # Provides the dj command alias
-sentry-sdk==0.11.0                      # Client for Sentry error tracking
 
 # Database
 psycopg2-binary==2.8.3                  # For Django to talk to postgres
-sqlparse==0.3.0                         # Parsing SQL statements
-dj-database-url==0.5.0                  # To obtain the Heroku service's database URL
 
 # Channels
 channels==2.2.0                         # Channels; also includes the Daphne server

--- a/config/requirements_development.txt
+++ b/config/requirements_development.txt
@@ -14,9 +14,7 @@ pep8-naming==0.8.*                          # Flake plugin for naming convention
 # Tests
 selenium==3.141.*                           # Functional testing (in here for CI tests)
 
-# Translation
-transifex-client==0.13.*                    # Translations
-
 # Debug
 django-debug-toolbar==2.0.*
-django-debug-toolbar-request-history==0.0.11 # Debug POSTs/AJAX
+# django-debug-toolbar-request-history==0.0.11 # Debug POSTs/AJAX
+git+https://github.com/djsutho/django-debug-toolbar-request-history.git@django-debug-toolbar-2

--- a/config/requirements_heroku.txt
+++ b/config/requirements_heroku.txt
@@ -14,3 +14,4 @@ django-redis==4.10.0                    # Use redis for cache (on heroku; local 
 # Misc
 sendgrid==6.0.5                         # Email service of choice on Heroku
 scout-apm==2.1.0                        # Performance monitoring
+sentry-sdk==0.11.0                      # Client for Sentry error tracking


### PR DESCRIPTION
This commit updates the dependency lists to reflect the current need.

These actions have been taken:
- Moved sentry-sdk to Heroku
  Sentry does not seem to be used locally, so is Heroku-specific.
- Removed specific commit requirement from django-dynamic-preferences
  As the commit in question is included in the version I used: 1.7.1
- Removed dj-database-url from core requirements
  As duplicated in Heroku requirements
- Removed sqlparse
  Unused as Django's queries are mostly used instead
- Change branch for django-debug-toolbar-request-history
  For development, as the master branch is incompatible with the debug-toolbar v2.
- (Removed transifex-client)