### PR TITLE
Note having no institution on reg cards

### DIFF
--- a/tabbycat/participants/templates/adjudicator_registration_card.html
+++ b/tabbycat/participants/templates/adjudicator_registration_card.html
@@ -21,10 +21,14 @@
       </div>
     {% endif %}
 
-    {% if adjudicator.institution and pref.show_adjudicator_institutions or admin_page or private_url %}
+    {% if pref.show_adjudicator_institutions or admin_page or private_url %}
       <div class="list-group-item">
         <strong>{% trans "Institution:" %}</strong>
-        {{ adjudicator.institution.name }}
+        {% if adjudicator.institution %}
+          {{ adjudicator.institution.name }}
+        {% else %}
+          <span class="text-muted">{% trans "Unaffiliated" %}</span>
+        {% endif %}
         {% if adjudicator.institution.region %}
           <br />
           <strong>{% trans "Region:" %}</strong>

--- a/tabbycat/participants/templates/team_registration_card.html
+++ b/tabbycat/participants/templates/team_registration_card.html
@@ -59,10 +59,14 @@
       </div>
     {% endif %} {# pref.public_break_categories or admin_page #}
 
-    {% if team.institution and pref.show_team_institutions or admin_page or private_url %}
+    {% if pref.show_team_institutions or admin_page or private_url %}
       <div class="list-group-item">
         <strong>{% trans "Institution:" %}</strong>
-        {{ team.institution.name }}
+        {% if team.institution %}
+          {{ team.institution.name }}
+        {% else %}
+          <span class="text-muted">{% trans "Unaffiliated" %}</span>
+        {% endif %}
         {% if team.institution.region %}
           <br />
           <strong>{% trans "Region:" %}</strong>


### PR DESCRIPTION
This change adds "Unaffiliated" to the institution item on participants registration cards if the participant (adjudicator or team/speaker) has none set, instead of having no value shown.