### PR TITLE
Update PY compatibility note to >=3.6

### DIFF
--- a/deploy_heroku.py
+++ b/deploy_heroku.py
@@ -11,7 +11,7 @@ import sys
 try:
     from django.core.management.utils import get_random_secret_key
 except ImportError:
-    from secrets import SystemRandom
+    from random import SystemRandom
 
     def get_random_secret_key():
         chars = 'abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(-_=+)'


### PR DESCRIPTION
In deploy_heroku.py, it is said to be compatible with Python 3.4 and up, but was not since 223c98327cf7134c604393b600ac7f7f98211e5f (and the comment was not updated)