### PR TITLE
Rename "Maine Coon" to "Maine"

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Change Log
 ==========
 
-2.4.0 (Maine Coon)
+2.4.0 (Maine)
 ---------
 *Release date: ?*
 

--- a/tabbycat/settings/core.py
+++ b/tabbycat/settings/core.py
@@ -27,7 +27,7 @@ LEAGUE = bool(int(os.environ['LEAGUE'])) if 'LEAGUE' in os.environ else False
 # ==============================================================================
 
 TABBYCAT_VERSION = '2.4.0a'
-TABBYCAT_CODENAME = 'M'
+TABBYCAT_CODENAME = 'Maine'
 READTHEDOCS_VERSION = 'v2.4.0'
 
 # ==============================================================================


### PR DESCRIPTION
The term "coon" in the cat breed could be seen as a racial slur, and so, as a precaution against this jarring association, has been lopped to just the state name, of which the cat breed is associated. The GitHub milestone has also been renamed.