### PR TITLE
i18n: Use humanize for cardinals

### DIFF
--- a/tabbycat/locale/fr/LC_MESSAGES/djangojs.po
+++ b/tabbycat/locale/fr/LC_MESSAGES/djangojs.po
@@ -247,18 +247,6 @@ msgid "Neg Veto"
 msgstr ""
 
 #: printing/templates/PrintableDebateInfo.vue:
-msgid "1"
-msgstr ""
-
-#: printing/templates/PrintableDebateInfo.vue:
-msgid "2"
-msgstr ""
-
-#: printing/templates/PrintableDebateInfo.vue:
-msgid "3"
-msgstr ""
-
-#: printing/templates/PrintableDebateInfo.vue:
 msgid "%1:"
 msgstr ""
 
@@ -367,63 +355,7 @@ msgid "Circle the last digit of the %1's score:"
 msgstr ""
 
 #: printing/templates/PrintableTeamScores.vue:
-msgid "0"
-msgstr ""
-
-#: printing/templates/PrintableTeamScores.vue:
-msgid "1"
-msgstr ""
-
-#: printing/templates/PrintableTeamScores.vue:
-msgid "2"
-msgstr ""
-
-#: printing/templates/PrintableTeamScores.vue:
-msgid "3"
-msgstr ""
-
-#: printing/templates/PrintableTeamScores.vue:
-msgid "4"
-msgstr ""
-
-#: printing/templates/PrintableTeamScores.vue:
-msgid "5"
-msgstr ""
-
-#: printing/templates/PrintableTeamScores.vue:
-msgid "6"
-msgstr ""
-
-#: printing/templates/PrintableTeamScores.vue:
-msgid "7"
-msgstr ""
-
-#: printing/templates/PrintableTeamScores.vue:
-msgid "8"
-msgstr ""
-
-#: printing/templates/PrintableTeamScores.vue:
-msgid "9"
-msgstr ""
-
-#: printing/templates/PrintableTeamScores.vue:
 msgid "Circle Rank:"
-msgstr ""
-
-#: printing/templates/PrintableTeamScores.vue:
-msgid "1st"
-msgstr ""
-
-#: printing/templates/PrintableTeamScores.vue:
-msgid "2nd"
-msgstr ""
-
-#: printing/templates/PrintableTeamScores.vue:
-msgid "3rd"
-msgstr ""
-
-#: printing/templates/PrintableTeamScores.vue:
-msgid "4th"
 msgstr ""
 
 #: printing/templates/PrintableTeamScores.vue:

--- a/tabbycat/motions/templates/motion_statistics_bp_prelim.html
+++ b/tabbycat/motions/templates/motion_statistics_bp_prelim.html
@@ -1,4 +1,4 @@
-{% load i18n l10n debate_tags %}
+{% load humanize i18n l10n debate_tags %}
 
 <div class="col-sm-12">
 
@@ -85,35 +85,12 @@
                  style="width: {{ percentage|unlocalize }}%" data-toggle="tooltip"
                  title="{{ tooltip_text }}">
               {% if count > 0 %}
-                {% if points == 3 %}
-                  <span class="d-none d-md-inline">
-                    {% trans "1st" %}
-                  </span>
-                  <span class="d-inline d-md-none">
-                    {% trans "1" context "used when there isn't enough space to display '1st'" %}
-                  </span>
-                {% elif points == 2 %}
-                  <span class="d-none d-md-inline">
-                    {% trans "2nd" %}
-                  </span>
-                  <span class="d-inline d-md-none">
-                    {% trans "2" context "used when there isn't enough space to display '2nd'" %}
-                  </span>
-                {% elif points == 1 %}
-                  <span class="d-none d-md-inline">
-                    {% trans "3rd" %}
-                  </span>
-                  <span class="d-inline d-md-none">
-                    {% trans "3" context "used when there isn't enough space to display '3rd'" %}
-                  </span>
-                {% else %}
-                  <span class="d-none d-md-inline">
-                    {% trans "4th" %}
-                  </span>
-                  <span class="d-inline d-md-none">
-                    {% trans "4" context "used when there isn't enough space to display '4th'" %}
-                  </span>
-                {% endif %}
+                <span class="d-none d-md-inline">
+                  {{ 4|subtract:points|ordinal }}
+                </span>
+                <span class="d-inline d-md-none">
+                  {{ 4|subtract:points }}
+                </span>
               {% endif %}
             </div>
 

--- a/tabbycat/printing/templates/PrintableBallot.vue
+++ b/tabbycat/printing/templates/PrintableBallot.vue
@@ -12,7 +12,8 @@
 
     <printable-scoresheet v-if="kind === 'Scoresheet'"
       :ballot="ballot"
-      :round-info="roundInfo"></printable-scoresheet>
+      :round-info="roundInfo"
+      :ordinals="ordinals"></printable-scoresheet>
 
     <printable-feedback v-if="kind === 'Feedback'"
       :ballot="ballot"
@@ -28,7 +29,7 @@ import PrintableFeedback from './PrintableFeedback.vue'
 import PrintableScoresheet from './PrintableScoresheet.vue'
 
 export default {
-  props: ['ballot', 'kind', 'roundInfo'],
+  props: ['ballot', 'kind', 'roundInfo', 'ordinals'],
   components: {
     PrintableBallotHeader,
     PrintableDebateInfo,

--- a/tabbycat/printing/templates/PrintableDebateInfo.vue
+++ b/tabbycat/printing/templates/PrintableDebateInfo.vue
@@ -95,7 +95,7 @@
           <div class="d-flex"
                v-if="roundInfo.motions.length === 0 || roundInfo.hideMotions">
             <div class="flex-fill db-fill-in strong mr-3 pt-3 mt-2"
-                 v-for="choice_type in [gettext('1'), gettext('2'), gettext('3'), ]"
+                 v-for="choice_type in ['1', '2', '3', ]"
                  v-text="tct('%s:', [choice_type])"></div>
           </div>
         </div>

--- a/tabbycat/printing/templates/PrintableScoresheet.vue
+++ b/tabbycat/printing/templates/PrintableScoresheet.vue
@@ -2,17 +2,17 @@
   <div class="db-flex-column db-flex-item-1">
 
     <section class="db-margins-m db-flex-row db-flex-item-7">
-      <printable-team-scores :dt="ballot.debateTeams[0]" :round-info="roundInfo">
+      <printable-team-scores :dt="ballot.debateTeams[0]" :round-info="roundInfo" :ordinals="ordinals">
       </printable-team-scores>
       <div class="db-item-gutter"></div>
-      <printable-team-scores :dt="ballot.debateTeams[1]" :round-info="roundInfo">
+      <printable-team-scores :dt="ballot.debateTeams[1]" :round-info="roundInfo" :ordinals="ordinals">
       </printable-team-scores>
     </section>
     <section class="db-margins-m db-flex-row db-flex-item-7" v-if="roundInfo.isBP">
-      <printable-team-scores :dt="ballot.debateTeams[2]" :round-info="roundInfo">
+      <printable-team-scores :dt="ballot.debateTeams[2]" :round-info="roundInfo" :ordinals="ordinals">
       </printable-team-scores>
       <div class="db-item-gutter"></div>
-      <printable-team-scores :dt="ballot.debateTeams[3]" :round-info="roundInfo">
+      <printable-team-scores :dt="ballot.debateTeams[3]" :round-info="roundInfo" :ordinals="ordinals">
       </printable-team-scores>
     </section>
 
@@ -49,7 +49,7 @@
 import PrintableTeamScores from './PrintableTeamScores.vue'
 
 export default {
-  props: ['ballot', 'roundInfo'],
+  props: ['ballot', 'roundInfo', 'ordinals'],
   components: { PrintableTeamScores },
 }
 </script>

--- a/tabbycat/printing/templates/PrintableTeamScores.vue
+++ b/tabbycat/printing/templates/PrintableTeamScores.vue
@@ -30,16 +30,7 @@
         <div class="db-flex-item-2 db-padding-horizontal text-secondary"
              v-text="tct('Circle the last digit of the %s\'s score:', [pos])"></div>
         <div class="db-flex-item-3 d-flex">
-          <div class="flex-fill text-center"><span class="db-circle" v-text="gettext('0')"></span></div>
-          <div class="flex-fill text-center"><span class="db-circle" v-text="gettext('1')"></span></div>
-          <div class="flex-fill text-center"><span class="db-circle" v-text="gettext('2')"></span></div>
-          <div class="flex-fill text-center"><span class="db-circle" v-text="gettext('3')"></span></div>
-          <div class="flex-fill text-center"><span class="db-circle" v-text="gettext('4')"></span></div>
-          <div class="flex-fill text-center"><span class="db-circle" v-text="gettext('5')"></span></div>
-          <div class="flex-fill text-center"><span class="db-circle" v-text="gettext('6')"></span></div>
-          <div class="flex-fill text-center"><span class="db-circle" v-text="gettext('7')"></span></div>
-          <div class="flex-fill text-center"><span class="db-circle" v-text="gettext('8')"></span></div>
-          <div class="flex-fill text-center"><span class="db-circle" v-text="gettext('9')"></span></div>
+          <div class="flex-fill text-center" v-for="(n, i) in 10"><span class="db-circle">{{ i }}</span></div>
         </div>
       </div>
 
@@ -49,17 +40,8 @@
       <template v-if="roundInfo.isBP">
         <div class="db-flex-item-2 align-items-center d-flex small db-padding-horizontal" v-text="gettext('Circle Rank:')"></div>
         <div class="db-flex-item-6 db-flex-row">
-          <div class="flex-grow-1 db-align-vertical-center db-align-horizontal-center">
-            <span class="db-circle text-monospace" v-text="gettext('1st')"></span>
-          </div>
-          <div class="flex-grow-1 db-align-vertical-center db-align-horizontal-center">
-            <span class="db-circle text-monospace" v-text="gettext('2nd')"></span>
-          </div>
-          <div class="flex-grow-1 db-align-vertical-center db-align-horizontal-center">
-            <span class="db-circle text-monospace" v-text="gettext('3rd')"></span>
-          </div>
-          <div class="flex-grow-1 db-align-vertical-center db-align-horizontal-center">
-            <span class="db-circle text-monospace" v-text="gettext('4th')"></span>
+          <div class="flex-grow-1 db-align-vertical-center db-align-horizontal-center" v-for="ord in ordinals">
+            <span class="db-circle text-monospace" v-html="ord"></span>
           </div>
         </div>
         <div class="db-flex-item-1"><!-- Spacing --></div>
@@ -79,16 +61,7 @@
       <div class="db-flex-item-2 db-padding-horizontal text-secondary"
            v-text="gettext('Circle the last digit of the team\'s total:')"></div>
       <div class="db-flex-item-3 d-flex">
-        <div class="flex-fill text-center"><span class="db-circle" v-text="gettext('0')"></span></div>
-        <div class="flex-fill text-center"><span class="db-circle" v-text="gettext('1')"></span></div>
-        <div class="flex-fill text-center"><span class="db-circle" v-text="gettext('2')"></span></div>
-        <div class="flex-fill text-center"><span class="db-circle" v-text="gettext('3')"></span></div>
-        <div class="flex-fill text-center"><span class="db-circle" v-text="gettext('4')"></span></div>
-        <div class="flex-fill text-center"><span class="db-circle" v-text="gettext('5')"></span></div>
-        <div class="flex-fill text-center"><span class="db-circle" v-text="gettext('6')"></span></div>
-        <div class="flex-fill text-center"><span class="db-circle" v-text="gettext('7')"></span></div>
-        <div class="flex-fill text-center"><span class="db-circle" v-text="gettext('8')"></span></div>
-        <div class="flex-fill text-center"><span class="db-circle" v-text="gettext('9')"></span></div>
+        <div class="flex-fill text-center" v-for="(n, i) in 10"><span class="db-circle">{{ i }}</span></div>
       </div>
     </div>
 
@@ -102,6 +75,7 @@ export default {
   props: {
     dt: Object,
     roundInfo: Object,
+    ordinals: Array,
   },
   computed: {
     team: function () {

--- a/tabbycat/printing/templates/scoresheet_list.html
+++ b/tabbycat/printing/templates/scoresheet_list.html
@@ -1,5 +1,5 @@
 {% extends "printables_list.html" %}
-{% load i18n l10n %}
+{% load humanize i18n l10n %}
 
 {% block header %}
   <div class="row d-print-none p-3 d-flex justify-content-between">
@@ -24,7 +24,8 @@
       <div class="db-page-holder">
   		  <main role="main" class="db-page db-flex-column db-page-landscape">
           <printable-ballot :ballot="ballot" :kind="'Scoresheet'"
-                            :round-info="roundInfo"></printable-ballot>
+                            :round-info="roundInfo"
+                            :ordinals="ordinals"></printable-ballot>
         </main>
       </div>
     </template>
@@ -109,6 +110,7 @@
       },
       // From Django
       ballots: {{ ballots|safe }},
+      ordinals: {{ ordinals|safe }},
     }
   </script>
   {{ block.super }}

--- a/tabbycat/printing/views.py
+++ b/tabbycat/printing/views.py
@@ -4,6 +4,7 @@ import qrcode
 from qrcode.image import svg
 
 from django.db.models import Q
+from django.contrib.humanize.templatetags.humanize import ordinal
 from django.utils.translation import gettext as _
 from django.views.generic.base import TemplateView
 
@@ -267,6 +268,7 @@ class BasePrintScoresheetsView(RoundMixin, TemplateView):
 
     def get_context_data(self, **kwargs):
         kwargs['ballots'] = json.dumps(self.get_ballots_dicts())
+        kwargs['ordinals'] = [ordinal(i) for i in range(1, 5)]
         motions = self.round.motion_set.order_by('seq')
         kwargs['motions'] = json.dumps([{'seq': m.seq, 'text': m.text} for m in motions])
         kwargs['use_team_code_names'] = use_team_code_names(self.tournament, False)

--- a/tabbycat/results/utils.py
+++ b/tabbycat/results/utils.py
@@ -2,6 +2,7 @@ import logging
 from itertools import combinations
 
 from django.db.models import Count
+from django.contrib.humanize.templatetags.humanize import ordinal
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy
 
@@ -158,18 +159,6 @@ def populate_identical_ballotsub_lists(ballotsubs):
         ballotsub.identical_ballotsub_versions.sort()
 
 
-_ORDINALS = {
-    1: gettext_lazy("1st"),
-    2: gettext_lazy("2nd"),
-    3: gettext_lazy("3rd"),
-    4: gettext_lazy("4th"),
-    5: gettext_lazy("5th"),
-    6: gettext_lazy("6th"),
-    7: gettext_lazy("7th"),
-    8: gettext_lazy("8th"),
-}
-
-
 _BP_POSITION_NAMES = [
     # Translators: Abbreviation for Prime Minister
     [gettext_lazy("PM"),
@@ -207,6 +196,6 @@ def side_and_position_names(tournament):
     else:
         for side in sides:
             positions = [_("Reply") if pos == tournament.reply_position
-                else _ORDINALS[pos]
+                else ordinal(pos)
                 for pos in tournament.positions]
             yield side, positions

--- a/tabbycat/utils/tables.py
+++ b/tabbycat/utils/tables.py
@@ -1,6 +1,7 @@
 import logging
 import warnings
 
+from django.contrib.humanize.templatetags.humanize import ordinal
 from django.utils import formats
 from django.utils.encoding import force_text
 from django.utils.translation import gettext as _
@@ -434,7 +435,7 @@ class TabbycatTableBuilder(BaseTableBuilder):
                 cell['popover']['title'] = _("No result for debate")
         else:
             cell = self._result_cell_class_four(ts.points, cell)
-            places = {0: _("4th"), 1: _("3rd"), 2: _("2nd"), 3: _("1st")}
+            places = {n: ordinal(n) for n in range(0, 4)}
             if ts.points is not None:
                 place = places.get(ts.points, "??")
                 cell['text'] = place

--- a/tabbycat/utils/templatetags/debate_tags.py
+++ b/tabbycat/utils/templatetags/debate_tags.py
@@ -230,9 +230,9 @@ def percentage(number_a, number_b):
         return 0
 
 
-@register.simple_tag
-def subtract(number_a, number_b):
-    return number_a - number_b # Used in Feedback Overview
+@register.filter
+def subtract(value, arg):
+    return value - arg # Used in BP Motion Stats
 
 
 @register.filter(name='abbreviatename')


### PR DESCRIPTION
This commit uses the django.contribs humanize module to get the ordinal form of numbers when used in apps.

Also, numeral forms of numbers have been removed from localization as number translation does not seem prevalent and is not supported by the rest of Django.