### PR TITLE
jsi18n: Delete duplicate messages

### DIFF
--- a/tabbycat/locale/fr/LC_MESSAGES/djangojs.po
+++ b/tabbycat/locale/fr/LC_MESSAGES/djangojs.po
@@ -134,10 +134,6 @@ msgstr ""
 msgid "Independent"
 msgstr ""
 
-#: checkins/templates/PeopleStatusMixin.vue:
-msgid "Unaffiliated"
-msgstr ""
-
 #: checkins/templates/VenuesStatusMixin.vue:
 msgid "%1 (%2) with identifier of %3"
 msgstr ""
@@ -195,14 +191,17 @@ msgid "Chair for Panel of %1"
 msgstr ""
 
 #: printing/templates/PrintableBallotHeader.vue:
+#: printing/templates/PrintableDebateInfo.vue:
 msgid "Solo Chair"
 msgstr ""
 
 #: printing/templates/PrintableBallotHeader.vue:
+#: printing/templates/PrintableDebateInfo.vue:
 msgid "Panellist"
 msgstr ""
 
 #: printing/templates/PrintableBallotHeader.vue:
+#: printing/templates/PrintableDebateInfo.vue:
 msgid "Trainee"
 msgstr ""
 
@@ -259,10 +258,6 @@ msgid "3"
 msgstr ""
 
 #: printing/templates/PrintableDebateInfo.vue:
-msgid "%1:"
-msgstr ""
-
-#: printing/templates/PrintableDebateInfo.vue:
 msgid "tab entry"
 msgstr ""
 
@@ -271,6 +266,7 @@ msgid "tab check"
 msgstr ""
 
 #: printing/templates/PrintableDebateInfo.vue:
+#: checkins/templates/PeopleStatusMixin.vue:
 msgid "Unaffiliated"
 msgstr ""
 
@@ -291,18 +287,6 @@ msgid "Chair"
 msgstr ""
 
 #: printing/templates/PrintableDebateInfo.vue:
-msgid "Solo Chair"
-msgstr ""
-
-#: printing/templates/PrintableDebateInfo.vue:
-msgid "Panellist"
-msgstr ""
-
-#: printing/templates/PrintableDebateInfo.vue:
-msgid "Trainee"
-msgstr ""
-
-#: printing/templates/PrintableDebateInfo.vue:
 msgid "%1 (%2, %3)"
 msgstr ""
 
@@ -319,14 +303,11 @@ msgid "Did %1 deliver the adjudication?"
 msgstr ""
 
 #: printing/templates/PrintableFeedback.vue:
-msgid "Yes"
-msgstr ""
-
-#: printing/templates/PrintableFeedback.vue:
 msgid "No, I am submitting feedback on:"
 msgstr ""
 
 #: printing/templates/PrintableFeedbackQuestion.vue:
+#: printing/templates/PrintableFeedback.vue:
 msgid "Yes"
 msgstr ""
 


### PR DESCRIPTION
Causes failures in message compilation.

Quick warning to be careful not to include duplicate messages when synchronizing with Crowdin.