### PR TITLE
Public scoresheets: Change get_object for get_queryset

### DIFF
--- a/tabbycat/results/views.py
+++ b/tabbycat/results/views.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.db import ProgrammingError
 from django.db.models import Count, Q
-from django.http import Http404, HttpResponseRedirect
+from django.http import HttpResponseRedirect
 from django.shortcuts import render
 from django.utils import timezone
 from django.utils.translation import gettext as _
@@ -563,19 +563,13 @@ class BasePublicBallotScoresheetsView(PublicTournamentPageMixin, SingleObjectFro
         else:
             return self.object.matchup
 
-    def get_object(self):
-        debate = self.model.objects.select_related(
+    def get_queryset(self):
+        return self.model.objects.select_related(
             'round'
-        ).prefetch_related(
-            'debateteam_set__team'
-        ).get(id=self.kwargs.get('pk'))
-        return debate
+        ).prefetch_related('debateteam_set__team')
 
     def get(self, request, *args, **kwargs):
-        try:
-            self.object = self.get_object()
-        except self.model.DoesNotExist:
-            raise Http404("Debate does not exist")
+        self.object = self.get_object()
 
         error = self.check_permissions()
         if error:
@@ -620,6 +614,9 @@ class PublicBallotScoresheetsView(BasePublicBallotScoresheetsView):
 
 class PrivateUrlBallotScoresheetView(RoundMixin, SingleObjectByRandomisedUrlMixin, BasePublicBallotScoresheetsView):
 
+    slug_url_kwarg = 'url_key'
+    slug_field = 'debateadjudicator__adjudicator__url_key'
+
     def is_page_enabled(self, tournament):
         return True
 
@@ -636,13 +633,8 @@ class PrivateUrlBallotScoresheetView(RoundMixin, SingleObjectByRandomisedUrlMixi
         kwargs['url_key'] = self.kwargs.get('url_key')
         return super().get_context_data(**kwargs)
 
-    def get_object(self):
-        d_adj = DebateAdjudicator.objects.select_related(
-            'debate'
-        ).prefetch_related(
-            'debate__debateteam_set__team'
-        ).get(debate__round=self.round, adjudicator__url_key=self.kwargs.get('url_key'))
-        return d_adj.debate
+    def get_queryset(self):
+        return self.model.objects.filter(round=self.round).prefetch_related('debateteam_set__team')
 
 
 class PublicBallotSubmissionIndexView(PublicTournamentPageMixin, VueTableTemplateView):


### PR DESCRIPTION
Using the get_queryset() method is more appropriate and avoids some error checking. For that, the model of the private URL scoresheet view has been changed to Debate and the slug retrieval changed.

Touch-up to 344544d and 50a008468.