### PR TITLE
Prefer django.test over unittest

### DIFF
--- a/tabbycat/draw/tests/test_bphungarian_parts.py
+++ b/tabbycat/draw/tests/test_bphungarian_parts.py
@@ -1,4 +1,4 @@
-import unittest
+from django.test import TestCase
 
 from ..generator.bphungarian import BPHungarianDrawGenerator
 from .utils import TestTeam
@@ -9,7 +9,7 @@ DUMMY_TEAMS = [TestTeam(1, 'A', side_history=[0, 0, 0, 0]),
                TestTeam(4, 'D', side_history=[0, 0, 0, 0])]
 
 
-class TestDefineRooms(unittest.TestCase):
+class TestDefineRooms(TestCase):
     """Tests the `_define_rooms_*` functions of BPHungarianDrawGenerator."""
 
     testdata = dict()

--- a/tabbycat/draw/tests/test_generator.py
+++ b/tabbycat/draw/tests/test_generator.py
@@ -1,7 +1,7 @@
-import unittest
+from collections import OrderedDict
 import copy
 
-from collections import OrderedDict
+from django.test import TestCase
 
 from .. import DrawFatalError, DrawGenerator, DrawUserError
 from ..generator.pairing import Pairing, ResultPairing
@@ -11,7 +11,7 @@ from .utils import TestTeam
 DUMMY_TEAMS = [TestTeam(1, 'A', allocated_side="aff"), TestTeam(2, 'B', allocated_side="neg")]
 
 
-class TestRandomDrawGenerator(unittest.TestCase):
+class TestRandomDrawGenerator(TestCase):
     """Basic unit test for random draws.
     Because it's random, you can't really do much to test it."""
 
@@ -40,7 +40,7 @@ class TestRandomDrawGenerator(unittest.TestCase):
                     self.assertEqual(pairing.flags, [])
 
 
-class TestPowerPairedDrawGeneratorParts(unittest.TestCase):
+class TestPowerPairedDrawGeneratorParts(TestCase):
     """Basic unit test for core functionality of power-paired draws.
     Nowhere near comprehensive."""
 
@@ -337,7 +337,7 @@ class TestPowerPairedDrawGeneratorParts(unittest.TestCase):
         self.one_up_one_down(data, expected)
 
 
-class TestPowerPairedDrawGenerator(unittest.TestCase):
+class TestPowerPairedDrawGenerator(TestCase):
     """Test the entire draw functions as a black box."""
 
     # Yep, I spent a lot of time constructing this realistic hypothetical
@@ -470,7 +470,7 @@ class TestPowerPairedDrawGenerator(unittest.TestCase):
                         self.assertEqual(actual.get_team_flags(actual.teams[0]), exp_neg_flags)
 
 
-class TestPowerPairedWithAllocatedSidesDrawGeneratorPartOddBrackets(unittest.TestCase):
+class TestPowerPairedWithAllocatedSidesDrawGeneratorPartOddBrackets(TestCase):
     """Basic unit test for core functionality of power-paired draws with allocated
     sides. Not comprehensive."""
 
@@ -719,7 +719,7 @@ class TestPowerPairedWithAllocatedSidesDrawGeneratorPartOddBrackets(unittest.Tes
             self.assertEqual(b2[0], {"aff": [], "neg": []})
 
 
-class TestPartialBreakRoundSplit(unittest.TestCase):
+class TestPartialBreakRoundSplit(TestCase):
 
     def test_split(self):
         self.assertRaises(AssertionError, partial_break_round_split, -1)
@@ -745,7 +745,7 @@ class TestPartialBreakRoundSplit(unittest.TestCase):
         self.assertEqual(partial_break_round_split(99), (35, 29))
 
 
-class BaseTestEliminationDrawGenerator(unittest.TestCase):
+class BaseTestEliminationDrawGenerator(TestCase):
 
     # (Team Name, Team Institution)
     team_data = [(1, 'A'), (2, 'B'), (3, 'A'), (4, 'B'), (5, 'C'), (6, 'D'),
@@ -827,7 +827,3 @@ class TestEliminationDrawGenerator(BaseTestEliminationDrawGenerator):
         self.ed = DrawGenerator("two", "elimination", teams, results=results)
         pairings = self.ed.generate()
         self.assertPairingsEqual(pairings, expected)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tabbycat/draw/tests/test_one_up_one_down.py
+++ b/tabbycat/draw/tests/test_one_up_one_down.py
@@ -1,10 +1,10 @@
-import unittest
+from django.test import TestCase
 
 from .utils import TestTeam
 from ..generator.one_up_one_down import OneUpOneDownSwapper
 
 
-class TestOneUpOneDown(unittest.TestCase):
+class TestOneUpOneDown(TestCase):
 
     @staticmethod
     def _1u1d_no_change(data):
@@ -144,6 +144,3 @@ class TestOneUpOneDown(unittest.TestCase):
             d.append((TestTeam(*data1), TestTeam(*data2)))
         r = OneUpOneDownSwapper(**options).run(d)
         return [(a.id, b.id) for (a, b) in r]
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tabbycat/results/tests/test_scoresheet.py
+++ b/tabbycat/results/tests/test_scoresheet.py
@@ -1,4 +1,4 @@
-import unittest
+from django.test import TestCase
 
 from ..scoresheet import (BPScoresheet, HighPointWinsRequiredScoresheet,
     LowPointWinsAllowedScoresheet, ResultOnlyScoresheet,
@@ -17,7 +17,7 @@ def on_all_testdata(test_fn):
     return foo
 
 
-class TestTwoTeamScoresheets(unittest.TestCase):
+class TestTwoTeamScoresheets(TestCase):
 
     sides = ['aff', 'neg']
 
@@ -125,7 +125,7 @@ class TestTwoTeamScoresheets(unittest.TestCase):
         self.assertRaises(AssertionError, scoresheet.set_declared_winner, 'hello')
 
 
-class TestBPScoresheets(unittest.TestCase):
+class TestBPScoresheets(TestCase):
 
     sides = ['og', 'oo', 'cg', 'co']
     positions = [1, 2]


### PR DESCRIPTION
This commit replaces the uses of `unittest` with `django.test` so that they run with the other tests.