### PR TITLE
Check for duplicate allocations in scoresheet view

### DIFF
--- a/tabbycat/results/templates/privateurl_ballot_set_error.html
+++ b/tabbycat/results/templates/privateurl_ballot_set_error.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+{% load debate_tags i18n %}
+
+{% block page-title %}{% trans "Ballot Not Available" %}{% endblock %}
+{% block head-title %}
+  <h2><span class="emoji">😾</span> {% trans "Ballot Not Available" %}</h2>
+{% endblock %}
+
+{% block extra-head %}<meta name="robots" content="noindex" />{% endblock %}
+
+{% block page-alerts %}
+  {% blocktrans trimmed with name=adjudicator.name asvar p1 %}
+    The page is provided to allow you, <strong>{{ name }}</strong>, to verify
+    your own scoresheet.
+    <strong>You must not share this URL with anyone.</strong>
+    Sharing the URL will allow others to access <strong>all</strong> actions
+    from your personal landing page.
+  {% endblocktrans %}
+  {% include "components/explainer-card.html" with type="warning" %}
+{% endblock %}
+
+{% block content %}
+  <div class="card">
+    <div class="card-body">
+      {{ message }}
+      {% tournamenturl 'privateurls-person-index' adjudicator.url_key as url %}
+      {% blocktrans trimmed %}
+        <a href="{{ url }}">Back to your private landing page.</a>
+      {% endblocktrans %}
+    </div>
+  </div>
+{% endblock %}

--- a/tabbycat/results/views.py
+++ b/tabbycat/results/views.py
@@ -556,6 +556,7 @@ class BasePublicBallotScoresheetsView(PublicTournamentPageMixin, SingleObjectFro
     public_page_preference = 'ballots_released'
     tournament_field_name = 'round__tournament'
     template_name = 'public_ballot_set.html'
+    error_template_name = 'public_ballot_set_error.html'
 
     def matchup_description(self):
         if use_team_code_names(self.tournament, False):
@@ -568,6 +569,16 @@ class BasePublicBallotScoresheetsView(PublicTournamentPageMixin, SingleObjectFro
             'round'
         ).prefetch_related('debateteam_set__team')
 
+    def response_error(self, error):
+        status, message = error
+        return self.response_class(
+            request=self.request,
+            template=[self.error_template_name],
+            context={'message': message},
+            using=self.template_engine,
+            status=status,
+        )
+
     def get(self, request, *args, **kwargs):
         try:
             self.object = self.get_object()
@@ -577,14 +588,7 @@ class BasePublicBallotScoresheetsView(PublicTournamentPageMixin, SingleObjectFro
             error = self.check_permissions()
 
         if error:
-            status, message = error
-            return self.response_class(
-                request=self.request,
-                template=['public_ballot_set_error.html'],
-                context={'message': message},
-                using=self.template_engine,
-                status=status,
-            )
+            return self.response_error(error)
 
         return super().get(self, request, *args, **kwargs)
 
@@ -619,6 +623,7 @@ class PublicBallotScoresheetsView(BasePublicBallotScoresheetsView):
 class PrivateUrlBallotScoresheetView(RoundMixin, SingleObjectByRandomisedUrlMixin, BasePublicBallotScoresheetsView):
 
     template_name = 'privateurl_ballot_set.html'
+    error_template_name = 'privateurl_ballot_set_error.html'
     slug_url_kwarg = 'url_key'
     slug_field = 'debateadjudicator__adjudicator__url_key'
 
@@ -635,10 +640,18 @@ class PrivateUrlBallotScoresheetView(RoundMixin, SingleObjectByRandomisedUrlMixi
         kwargs['motion'] = ballot.motion
         kwargs['result'] = ballot.result
         kwargs['use_code_names'] = use_team_code_names(self.tournament, False)
-
         kwargs['adjudicator'] = Adjudicator.objects.get(url_key=self.kwargs.get('url_key'))
-
         return super().get_context_data(**kwargs)
+
+    def response_error(self, error):
+        status, message = error
+        return self.response_class(
+            request=self.request,
+            template=[self.error_template_name],
+            context={'message': message, 'adjudicator': Adjudicator.objects.get(url_key=self.kwargs.get('url_key'))},
+            using=self.template_engine,
+            status=status,
+        )
 
     def get_queryset(self):
         return self.model.objects.filter(round=self.round).prefetch_related('debateteam_set__team')


### PR DESCRIPTION
This commit makes public scoresheet views check whether there are multiple adjudicator allocations in a round. This can happen in private URL views as it filters per adjudicator and round.

Fixes #1229.