### PR TITLE
Let NumberOfAdjudicators metric use other numbers

### DIFF
--- a/tabbycat/standings/teams.py
+++ b/tabbycat/standings/teams.py
@@ -248,7 +248,7 @@ class NumberOfAdjudicatorsMetricAnnotator(TeamScoreQuerySetMetricAnnotator):
     function = Sum
 
     def __init__(self, adjs_per_debate=3):
-        self.adjs_per_debate = 3
+        self.adjs_per_debate = adjs_per_debate
 
     def get_field(self):
         return (Cast('debateteam__teamscore__votes_given', FloatField()) /


### PR DESCRIPTION
This commit changes the initializer of the number of adjudicators metric so that it can use other values than 3 for the normal number of adjs.

This seems like an oversight, as the initializer was made with a default, but not passed to the attribute.