### PR TITLE
Fix logic inversion for draw display links

### DIFF
--- a/tabbycat/draw/templates/draw_display_admin.html
+++ b/tabbycat/draw/templates/draw_display_admin.html
@@ -271,7 +271,7 @@
 
       {% trans "(for the briefing room)" as briefing_room_subtext %}
 
-      {% if not round.is_current or tournament.current_rounds|length == 1 %}
+      {% if round.is_current %}
 
         {% tournamenturl 'draw-display-current-rounds-by-venue' as url %}
         {% trans "Display Draw ordered by Venue" as text %}


### PR DESCRIPTION
If the draw was not current (i.e. completed), it would only show "Display" links for current rounds.

Also removed the or statement for if there is only one active round, as that active round might not be the current one.

Fixes #1239.