### PR TITLE
Show missed speeches message if limit is 0

### DIFF
--- a/tabbycat/standings/templates/speaker_standings.html
+++ b/tabbycat/standings/templates/speaker_standings.html
@@ -28,7 +28,7 @@
     {% endblocktrans %}
   {% endif %}
 
-  {% if pref.standings_missed_debates > 0 %}
+  {% if pref.standings_missed_debates >= 0 %}
     {% blocktrans trimmed with count=pref.standings_missed_debates asvar p2 %}
       Speakers can miss up to {{ count }} debates before they are omitted from
       the speaker tab.
@@ -44,7 +44,7 @@
   {% endblocktrans %}
   {% include "components/explainer-card.html" with type="info" %}
 
-  {% if 'count' not in pref.speaker_standings_precedence and 'count' not in pref.speaker_standings_extra_metrics and pref.standings_missed_debates > 0 %}
+  {% if 'count' not in pref.speaker_standings_precedence and 'count' not in pref.speaker_standings_extra_metrics and pref.standings_missed_debates >= 0 %}
     {% blocktrans trimmed asvar message %}
       Enforcing the limit on the number of missed debates requires the "number
       of speeches given" metric to be included in the speaker standings

--- a/tabbycat/standings/views.py
+++ b/tabbycat/standings/views.py
@@ -292,7 +292,7 @@ class BaseSubstantiveSpeakerStandingsView(BaseSpeakerStandingsView):
 
         # 'count' is necessary to enforce the 'missed debates' limit, so add it if necessary.
         # There's also an alert in the speaker_standings.html template to explain this.
-        if self.tournament.pref('standings_missed_debates') >= 0 and 'count' not in extra_metrics:
+        if self.tournament.pref('standings_missed_debates') >= 0 and 'count' not in metrics and 'count' not in extra_metrics:
             extra_metrics.append('count')
 
         return metrics, extra_metrics


### PR DESCRIPTION
The filter for the number of speeches a speaker can miss and still be in the tab has a default of -1 to include all speakers. The choice of 0 (can't miss any debate) is a valid option, but was unaccounted for in the messages about the option.

This changes the comparisons to greater than *or equal to* 0.