### PR TITLE
Codeclimate: Remove non-existing file from config

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -33,7 +33,6 @@ engines:
     enabled: true
     exclude_paths:
       - "tabbycat/draw/generator/*.py"
-      - "tabbycat/adjallocation/munkres.py"
     config:
       threshold: "C"
 ratings:


### PR DESCRIPTION
Why is Ruby and PHP types listed; they are not used here.
Also, what is `.coveragerc` for?