### PR TITLE
Remove deprecated standings from docs

### DIFF
--- a/docs/features/breaks.rst
+++ b/docs/features/breaks.rst
@@ -65,17 +65,6 @@ which is the default.
       teams who are in the top three teams from their
       institution are added to make *n* teams.
 
-  * - WADL division winners first (``wadl-div-first``)
-    - The division winners are taken first, then the best
-      teams who did not win their division are added to make
-      *n* teams.
-
-  * - WADL division winners guaranteed (``wadl-div-guaranteed``)
-    - The division winners are guaranteed to break, and the
-      best teams who did not win their division are added
-      to make *n* teams. (Teams are sorted in their original
-      rankings, unlike the "division winners first" rule.)
-
 .. note:: The break generators are somewhat more complex than described in the
   above table: among other things, they also handle cases where there is a tie
   for the last place in the break, and for those break categories marked

--- a/docs/features/standings-rules.rst
+++ b/docs/features/standings-rules.rst
@@ -41,10 +41,6 @@ metrics that will be shown in the team standings, but not used to rank teams.
       for wins, and differs only in column labelling. For BP, this is 3 points
       for a first, 2 for a second, 1 for a third and 0 for a fourth.
 
-  * - Points (2/1/0)
-    - How many points the team has, where teams earn 2 points for a win, 1 point
-      for a loss and 0 points for a forfeit.
-
   * - Total speaker score
     - The sum of all speaker scores attained in all debates.
 
@@ -116,11 +112,6 @@ metrics that will be shown in the team standings, but not used to rank teams.
       This metric can be specified multiple times. Each time who-beat-whom
       occurs, it applies to all the metrics earlier in the precedence than the
       occurrence in question.
-
-  * - Who-beat-whom (in divisions)
-    - As for who-beat-whom, but only compares for teams in the same division.
-      That is, the metric applies whenever there are exactly two teams from the
-      same division exactly tied.
 
 
 Speaker standings rules


### PR DESCRIPTION
The documentation of available standing metrics contained metrics that have been removed (2/1/0 points, w-b-w (divisions)) as part of division deprecation. This commit takes them out of the docs.