### PR TITLE
Generalize adj score out of range messages

### DIFF
--- a/tabbycat/adjallocation/allocators/hungarian.py
+++ b/tabbycat/adjallocation/allocators/hungarian.py
@@ -48,8 +48,8 @@ class BaseHungarianAllocator(BaseAdjudicatorAllocator):
         ntoolarge = [adj._normalized_score > 5.0 for adj in adjudicators].count(True)
         if ntoolarge > 0:
             warning_msg = ngettext(
-                "%(count)s normalised score is larger than 5.0.",
-                "%(count)s normalised scores are larger than 5.0.",
+                "%(count)s score is larger than the maximum.",
+                "%(count)s scores are larger than the maximum.",
                 ntoolarge
             ) % {'count': ntoolarge}
             self.extra_messages += " " + warning_msg
@@ -57,8 +57,8 @@ class BaseHungarianAllocator(BaseAdjudicatorAllocator):
         ntoosmall = [adj._normalized_score < 0.0 for adj in adjudicators].count(True)
         if ntoosmall > 0:
             warning_msg = ngettext(
-                "%(count)s normalised score is smaller than 0.0.",
-                "%(count)s normalised scores are smaller than 0.0.",
+                "%(count)s score is smaller than the minimum.",
+                "%(count)s scores are smaller than the minimum",
                 ntoosmall
             ) % {'count': ntoosmall}
             self.extra_messages += " " + warning_msg


### PR DESCRIPTION
The messages for if an adjudicator has a normalized score greater than 5,0 or less than 0,0 now do not include irrelevant information. The fact the scores are normalized does not affect the user, as they are normalized on the user's adjudicator score range, which may not be [0:5]. The message would show when the scores are outside of the user's range anyways.

Just FYI, there are inconsistencies between American and British spelling for the term. Uncorrected here.