### PR TITLE
Do not require venue selection for categories

### DIFF
--- a/tabbycat/venues/forms.py
+++ b/tabbycat/venues/forms.py
@@ -10,7 +10,7 @@ def venuecategoryform_factory(venues_queryset):
     class VenueCategoryForm(ModelForm):
 
         venues = ModelMultipleChoiceField(queryset=venues_queryset,
-            widget=SelectMultiple(attrs={'size': 10}))
+            widget=SelectMultiple(attrs={'size': 10}), required=False)
         venues.choices = venue_choices  # can't be passed as keyword argument
 
         class Meta:


### PR DESCRIPTION
This change sets the venues field in the venue category formset as not required, as a venue category might not have any applicable venues in the tournament (as there is no tournament field with categories).

Another option would be to associate venue categories with a tournament.