### PR TITLE
Reduce size of judge feedback drop-down

### DIFF
--- a/tabbycat/adjfeedback/forms.py
+++ b/tabbycat/adjfeedback/forms.py
@@ -305,7 +305,7 @@ def make_feedback_form_class_for_team(source, tournament, submission_fields, con
             # feedback expected only on orallist
             display = _("%(name)s (%(round)s — chair gave oral)")
         else:
-            display = _("%(name)s (%(round)s — chair rolled, this panellist gave oral)")
+            display = _("%(name)s (%(round)s — panellist gave oral as chair rolled)")
 
         display %= {'name': adj.name, 'round': debate.round.name, 'adjpos': ADJUDICATOR_POSITION_NAMES[pos]}
         return (value, display)


### PR DESCRIPTION
The drop-down to choose an adjudicator to give feedback contains all available applicable adjudicators, with positions. This commit makes the text shorter, removing the "chair rolled." This is for clarity between chairs and panelists when using phones, and drop-down items are scinded.