### PR TITLE
Add 'base score' migration

### DIFF
--- a/tabbycat/adjfeedback/migrations/0006_auto_20191109_1240.py
+++ b/tabbycat/adjfeedback/migrations/0006_auto_20191109_1240.py
@@ -6,7 +6,7 @@ from django.db import migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('participants', '0013_auto_20191109_1240'),
+        ('participants', '0013_rename_test_score'),
         ('tournaments', '0006_auto_20191109_1240'),
         ('adjfeedback', '0005_auto_20180928_1441'),
     ]

--- a/tabbycat/participants/migrations/0013_rename_test_score.py
+++ b/tabbycat/participants/migrations/0013_rename_test_score.py
@@ -15,4 +15,9 @@ class Migration(migrations.Migration):
             old_name='test_score',
             new_name='base_score',
         ),
+        migrations.AlterField(
+            model_name='adjudicator',
+            name='base_score',
+            field=models.FloatField(default=0, verbose_name='base score'),
+        ),
     ]


### PR DESCRIPTION
As not only the field is renamed but the verbose name changed. Forgot in the previous migration. Should it be squashed with the precedent migration?