### PR TITLE
Create VenueCategorySerializer for checkins

### DIFF
--- a/tabbycat/utils/serializers.py
+++ b/tabbycat/utils/serializers.py
@@ -6,7 +6,7 @@ from rest_framework.renderers import JSONRenderer
 from adjallocation.models import DebateAdjudicator
 from draw.models import Debate
 from participants.serializers import AdjudicatorSerializer, TeamSerializer
-from venues.models import Venue
+from venues.models import Venue, VenueCategory
 
 
 def django_rest_json_render(data):
@@ -33,12 +33,21 @@ class VueDraggableItemMixin(serializers.Serializer):
         fields = ('vue_is_locked', 'vue_last_modified', 'available')
 
 
+class VenueCategorySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = VenueCategory
+        fields = ('id', 'name', 'description')
+
+
 class VenueSerializer(serializers.ModelSerializer):
     """ Like the below class this cant live in venue/serializers as they depend
     on the DebateSerializerMixin """
+
+    categories = VenueCategorySerializer(many=True, source='venuecategory_set')
+
     class Meta:
         model = Venue
-        fields = ('id', 'name', 'display_name')
+        fields = ('id', 'name', 'display_name', 'priority', 'categories')
 
 
 class DebateSerializerMixin(serializers.ModelSerializer):


### PR DESCRIPTION
The Venue Checkin Statuses page has been broken for some time because the serializer for the venue categories of each venue was culled with the transition towards the REST framework's serialization for objects.

This commit adds the 'categories' field to the VenueSerializer by creating a new VenueCategorySerializer.