### PR TITLE
Replace "open-source" by "source-available"

### DIFF
--- a/docs/guide/tournament-logistics.rst
+++ b/docs/guide/tournament-logistics.rst
@@ -8,7 +8,7 @@ Unlike the rest of our documentation, this section does not deal with particular
 
 Whilst it aims for general relevance, we should note that this guide is relatively opinionated and mostly written from the perspective of people whose primary experience is tabbing at Australasian tournaments using Tabbycat. That said, we welcome feedback and additions that can account for different format and regional considerations. In the future, if the guide becomes more general and more extensive, it could be spun off into a separate project.
 
-.. note:: As with the rest of our documentation, this page is open-source and we welcome :ref:`feedback and contributions <contributing>`. Note also that we've formatted this guide a single page to reduce clutter, but the sub-sections in the sidebar can be used to help navigate across sections.
+.. note:: As with the rest of our documentation, this page is source-available and we welcome :ref:`feedback and contributions <contributing>`. Note also that we've formatted this guide a single page to reduce clutter, but the sub-sections in the sidebar can be used to help navigate across sections.
 
 Planning and Preparation
 ========================

--- a/tabbycat/templates/base.html
+++ b/tabbycat/templates/base.html
@@ -11,11 +11,11 @@
 
   {% if tournament %}
     {% blocktrans trimmed with tournament_name=tournament.short_name asvar meta_description %}
-      The tab for {{ tournament_name }} runs on Tabbycat, an open-source tab system for a variety of parliamentary debating formats
+      The tab for {{ tournament_name }} runs on Tabbycat, a source-available tab system for a variety of parliamentary debating formats
     {% endblocktrans %}
   {% else %}
     {% blocktrans trimmed asvar meta_description %}
-      This tab runs on Tabbycat, an open-source tab system for a variety of parliamentary debating formats
+      This tab runs on Tabbycat, a source-available tab system for a variety of parliamentary debating formats
     {% endblocktrans %}
   {% endif %}
   <meta name="description" content="{{ meta_description }}" />

--- a/tabbycat/templates/footer.html
+++ b/tabbycat/templates/footer.html
@@ -18,7 +18,7 @@
         </h6>
         <p class="text-muted">
           {% blocktrans trimmed %}
-            Tabbycat is an open-source project developed by volunteers, and is free to use for tabbing non-profit, non-fundraising tournaments.
+            Tabbycat is a source-available project developed by volunteers, and is free to use for tabbing non-profit, non-fundraising tournaments.
           {% endblocktrans %}
           {% if tournament and tournament.billable_teams > 0 %}
             {% blocktrans trimmed with amount=tournament.billable_teams %}


### PR DESCRIPTION
This is a distinction between the current licensing scheme being non-libre, but the source code and development being done openly. This change reflects the README which states it is not open-source (yet). Open-source is a subset of source-available.

Should be reverted with #1028.