### PR TITLE
Add break category highlighting in Edit Matchups

### DIFF
--- a/tabbycat/draw/templates/DraggableTeam.vue
+++ b/tabbycat/draw/templates/DraggableTeam.vue
@@ -1,5 +1,6 @@
 <template>
-  <draggable-item :drag-payload="dragPayload" :class="{ 'bg-dark text-white': isUnavailable }"
+  <draggable-item :drag-payload="dragPayload" :class="[{'bg-dark text-white': isUnavailable},
+                                                       highlightsCSS, conflictsCSS, hoverConflictsCSS]"
                   :enable-hover="true" :hover-item="hoverableData" :hover-type="hoverableType">
 
       <span slot="number" class="d-none"><span></span></span>

--- a/tabbycat/draw/views.py
+++ b/tabbycat/draw/views.py
@@ -803,11 +803,6 @@ class EditDebateTeamsView(DebateDragAndDropMixin, AdministratorMixin, TemplateVi
     page_title = gettext_lazy("Edit Matchups")
     prefetch_teams = False # Fetched in full as get_serialised
 
-    def get_extra_info(self):
-        info = super().get_extra_info()
-        info['highlights']['break'] = [] # TODO
-        return info
-
     def get_serialised_allocatable_items(self):
         # TODO: account for shared teams
         teams = Team.objects.filter(tournament=self.tournament).prefetch_related('speaker_set')


### PR DESCRIPTION
This commit adds the extra CSS to DraggableTeam like already done with DraggableAdjudicator and InlineTeam. I also removed the get_extra_info() method as the break category highlights is defined in the superclass.