### PR TITLE
Create basic default settings for REST

### DIFF
--- a/tabbycat/api/apps.py
+++ b/tabbycat/api/apps.py
@@ -1,0 +1,7 @@
+from django.apps import AppConfig
+from django.utils.translation import gettext_lazy as _
+
+
+class ApiConfig(AppConfig):
+    name = 'api'
+    verbose_name = _("Application Programming Interface")

--- a/tabbycat/api/serializers.py
+++ b/tabbycat/api/serializers.py
@@ -1,0 +1,66 @@
+from rest_framework import serializers
+
+from breakqual.models import BreakCategory
+from participants.models import Speaker, SpeakerCategory
+
+
+class BreakCategorySerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = BreakCategory
+        fields = ('name', 'slug', 'seq', 'break_size', 'is_general', 'priority', 'limit', 'rule')
+
+
+class SpeakerCategorySerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = SpeakerCategory
+        fields = ('name', 'slug', 'seq', 'limit', 'public')
+
+
+class BreakEligibilitySerializer(serializers.ModelSerializer):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields['team_set'] = serializers.PrimaryKeyRelatedField(
+            many=True,
+            queryset=kwargs['context']['tournament'].team_set.all()
+        )
+
+    class Meta:
+        model = BreakCategory
+        fields = ('slug', 'team_set')
+
+    def update(self, instance, validated_data):
+        teams = validated_data['team_set']
+
+        if self.partial:
+            # Add teams to category, don't remove any
+            self.instance.team_set.add(*teams)
+        else:
+            self.instance.team_set.set(teams)
+        return self.instance
+
+
+class SpeakerEligibilitySerializer(serializers.ModelSerializer):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields['speaker_set'] = serializers.PrimaryKeyRelatedField(
+            many=True,
+            queryset=Speaker.objects.filter(team__tournament=kwargs['context']['tournament'])
+        )
+
+    class Meta:
+        model = SpeakerCategory
+        fields = ('slug', 'speaker_set')
+
+    def update(self, instance, validated_data):
+        speakers = validated_data['speaker_set']
+
+        if self.partial:
+            # Add speakers to category, don't remove any
+            self.instance.speaker_set.add(*speakers)
+        else:
+            self.instance.speaker_set.set(speakers)
+        return self.instance

--- a/tabbycat/api/tests.py
+++ b/tabbycat/api/tests.py
@@ -1,0 +1,3 @@
+from django.test import TestCase
+
+# Create your tests here.

--- a/tabbycat/api/tests.py
+++ b/tabbycat/api/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/tabbycat/api/urls.py
+++ b/tabbycat/api/urls.py
@@ -2,20 +2,22 @@ from django.urls import include, path
 
 from . import views
 
+list_methods = {'get': 'list', 'post': 'create'}
+detail_methods = {'get': 'retrieve', 'post': 'update', 'delete': 'destroy'}
 
 urlpatterns = [
 
-    path('t/<slug:tournament_slug>/', include([
-        path('r/<int:round_seq>/', include([
+    path('<slug:tournament_slug>/', include([
+        path('<int:round_seq>/', include([
         ])),
 
         path('breakcategory/', include([
             path('',
-                views.BreakCategoryViewSet.as_view({'get': 'list', 'post': 'create'}),
+                views.BreakCategoryViewSet.as_view(list_methods),
                 name='api-breakcategory-list'),
             path('<slug:slug>/', include([
                 path('',
-                    views.BreakCategoryViewSet.as_view({'get': 'retrieve', 'post': 'update', 'delete': 'destroy'}),
+                    views.BreakCategoryViewSet.as_view(detail_methods),
                     name='api-breakcategory-detail'),
                 path('eligibility/',
                     views.BreakEligibilityView.as_view(),
@@ -24,11 +26,11 @@ urlpatterns = [
         ])),
         path('speakercategory/', include([
             path('',
-                views.SpeakerCategoryViewSet.as_view({'get': 'list', 'post': 'create'}),
+                views.SpeakerCategoryViewSet.as_view(list_methods),
                 name='api-speakercategory-list'),
             path('<slug:slug>/', include([
                 path('',
-                    views.SpeakerCategoryViewSet.as_view({'get': 'retrieve', 'post': 'update', 'delete': 'destroy'}),
+                    views.SpeakerCategoryViewSet.as_view(detail_methods),
                     name='api-speakercategory-detail'),
                 path('eligibility/',
                     views.SpeakerEligibilityView.as_view(),

--- a/tabbycat/api/urls.py
+++ b/tabbycat/api/urls.py
@@ -1,0 +1,14 @@
+from django.urls import include, path
+
+from . import views
+
+
+urlpatterns = [
+
+    path('<slug:tournament_slug>/', include([
+        path('<int:round_seq>/', include([
+        ])),
+
+    ])),
+
+]

--- a/tabbycat/api/urls.py
+++ b/tabbycat/api/urls.py
@@ -5,10 +5,36 @@ from . import views
 
 urlpatterns = [
 
-    path('<slug:tournament_slug>/', include([
-        path('<int:round_seq>/', include([
+    path('t/<slug:tournament_slug>/', include([
+        path('r/<int:round_seq>/', include([
         ])),
 
+        path('breakcategory/', include([
+            path('',
+                views.BreakCategoryViewSet.as_view({'get': 'list', 'post': 'create'}),
+                name='api-breakcategory-list'),
+            path('<slug:slug>/', include([
+                path('',
+                    views.BreakCategoryViewSet.as_view({'get': 'retrieve', 'post': 'update', 'delete': 'destroy'}),
+                    name='api-breakcategory-detail'),
+                path('eligibility/',
+                    views.BreakEligibilityView.as_view(),
+                    name='api-breakcategory-eligibility'),
+            ])),
+        ])),
+        path('speakercategory/', include([
+            path('',
+                views.SpeakerCategoryViewSet.as_view({'get': 'list', 'post': 'create'}),
+                name='api-speakercategory-list'),
+            path('<slug:slug>/', include([
+                path('',
+                    views.SpeakerCategoryViewSet.as_view({'get': 'retrieve', 'post': 'update', 'delete': 'destroy'}),
+                    name='api-speakercategory-detail'),
+                path('eligibility/',
+                    views.SpeakerEligibilityView.as_view(),
+                    name='api-speakercategory-eligibility'),
+            ])),
+        ])),
     ])),
 
 ]

--- a/tabbycat/api/urls.py
+++ b/tabbycat/api/urls.py
@@ -11,7 +11,7 @@ urlpatterns = [
         path('<int:round_seq>/', include([
         ])),
 
-        path('breakcategory/', include([
+        path('break-categories/', include([
             path('',
                 views.BreakCategoryViewSet.as_view(list_methods),
                 name='api-breakcategory-list'),
@@ -24,7 +24,7 @@ urlpatterns = [
                     name='api-breakcategory-eligibility'),
             ])),
         ])),
-        path('speakercategory/', include([
+        path('speaker-categories/', include([
             path('',
                 views.SpeakerCategoryViewSet.as_view(list_methods),
                 name='api-speakercategory-list'),

--- a/tabbycat/api/views.py
+++ b/tabbycat/api/views.py
@@ -1,0 +1,3 @@
+from django.shortcuts import render
+
+# Create your views here.

--- a/tabbycat/api/views.py
+++ b/tabbycat/api/views.py
@@ -1,3 +1,46 @@
-from django.shortcuts import render
+from rest_framework.generics import RetrieveUpdateAPIView
+from rest_framework.viewsets import ModelViewSet
+from rest_framework.permissions import IsAdminUser
 
-# Create your views here.
+from tournaments.mixins import TournamentMixin
+
+from . import serializers
+
+
+class TournamentAPIMixin(TournamentMixin):
+    tournament_field = 'tournament'
+
+    def perform_create(self, serializer):
+        serializer.save(**{self.tournament_field: self.tournament})
+
+    def get_queryset(self):
+        return self.serializer_class.Meta.model.objects.filter(**{self.tournament_field: self.tournament})
+
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        context['tournament'] = self.tournament
+        return context
+
+
+class AdministratorAPIMixin:
+    permission_classes = [IsAdminUser]
+
+
+class BreakCategoryViewSet(TournamentAPIMixin, AdministratorAPIMixin, ModelViewSet):
+    serializer_class = serializers.BreakCategorySerializer
+    lookup_field = 'slug'
+
+
+class SpeakerCategoryViewSet(TournamentAPIMixin, AdministratorAPIMixin, ModelViewSet):
+    serializer_class = serializers.SpeakerCategorySerializer
+    lookup_field = 'slug'
+
+
+class BreakEligibilityView(TournamentAPIMixin, AdministratorAPIMixin, RetrieveUpdateAPIView):
+    serializer_class = serializers.BreakEligibilitySerializer
+    lookup_field = 'slug'
+
+
+class SpeakerEligibilityView(TournamentAPIMixin, AdministratorAPIMixin, RetrieveUpdateAPIView):
+    serializer_class = serializers.SpeakerEligibilitySerializer
+    lookup_field = 'slug'

--- a/tabbycat/settings/core.py
+++ b/tabbycat/settings/core.py
@@ -122,6 +122,7 @@ INSTALLED_APPS = (
     'formtools',
     'statici18n', # Compile js translations as static file; saving requests
     'polymorphic',
+    'rest_framework',
 )
 
 ROOT_URLCONF = 'urls'
@@ -284,4 +285,21 @@ CHANNEL_LAYERS = {
 
 DYNAMIC_PREFERENCES = {
     'REGISTRY_MODULE': 'preferences',
+}
+
+# ==============================================================================
+# REST Framework
+# ==============================================================================
+
+REST_FRAMEWORK = {
+    'DEFAULT_RENDERER_CLASSES': [
+        'rest_framework.renderers.JSONRenderer',
+    ],
+    'DEFAULT_PARSER_CLASSES': [
+        'rest_framework.parsers.JSONParser',
+    ],
+    'DEFAULT_AUTHENTICATION_CLASSES': [
+        'rest_framework.authentication.BasicAuthentication',
+    ],
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
 }

--- a/tabbycat/settings/development.example
+++ b/tabbycat/settings/development.example
@@ -76,3 +76,9 @@ if ENABLE_DEBUG_TOOLBAR:
 # ==============================================================================
 
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+
+# ==============================================================================
+# REST Framework (Browse through APIs)
+# ==============================================================================
+
+REST_FRAMEWORK['DEFAULT_RENDERER_CLASSES'] += ['rest_framework.renderers.BrowsableAPIRenderer',]

--- a/tabbycat/tournaments/models.py
+++ b/tabbycat/tournaments/models.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 PROHIBITED_TOURNAMENT_SLUGS = [
     'jet', 'database', 'admin', 'accounts', 'summernote',  # System
     'start', 'create', 'load-demo', # Setup Wizards
-    'draw', 'notifications', 'archive', # Cross-Tournament app's view roots
+    'tournament', 'notifications', 'archive', 'api', # Cross-Tournament app's view roots
     'favicon.ico', 'robots.txt',  # Files that must be at top level
     '__debug__', 'static', 'donations', 'style', 'i18n', 'jsi18n']  # Misc
 

--- a/tabbycat/urls.py
+++ b/tabbycat/urls.py
@@ -74,6 +74,10 @@ urlpatterns = [
     # Notifications
     path('notifications/',
         include('notifications.urls')),
+
+    # API
+    path('api/v1/',
+        include('api.urls')),
 ]
 
 if settings.DEBUG and settings.ENABLE_DEBUG_TOOLBAR:  # Only serve debug toolbar when on DEBUG


### PR DESCRIPTION
This commit adds REST as an installed application and defines some settings such as the serializer format and authentification.

It also enables a browsable API view in the development settings profile.

The commit also includes a proof-of-concept of the discussion on #1343 using speaker/break categories.