### PR TITLE
Create view to create/edit break categories

### DIFF
--- a/docs/features/breaks.rst
+++ b/docs/features/breaks.rst
@@ -74,7 +74,7 @@ which is the default.
 Setting up break categories and rounds
 ======================================
 
-For each break category in your tournament, you need to do three things:
+For each break category in your tournament, you need to do two things:
 
   1. Create (and name) a break category
   2. Create break rounds for the category
@@ -83,12 +83,15 @@ For each break category in your tournament, you need to do three things:
 If you only have one break category (open) and you create your tournament using
 the "Create New Tournament" page, simply enter the number of teams in the break
 (*e.g.*, 8 if you're breaking to quarterfinals). Tabbycat will create the break
-category and break rounds for you. You'll still need to set the eligibility of
-teams though, as in (3) below. For any further break categories, you'll need to
-do all three steps yourself.
+category and break rounds for you. For any further break categories, you'll need
+to go to the **Breaks** item in the left-hand menu for a particular tournament
+and then click **Break Categories**. Fill out the forms for the number of new
+break categories and save. Rounds will be created automatically. You'll still
+need to set the eligibility of teams though, as in (3) below.
 
 If you create your tournament using the `importtournament` command or in **Edit
-Database**, you'll need to do all three steps above yourself.
+Database**, you'll need to do all three steps above yourself. You may also want
+to edit the break rounds (2) to change their names.
 
 1. Creating break categories
 ----------------------------
@@ -124,13 +127,14 @@ following fields correctly:
 Once a break category has been created it will not have any teams eligible for
 it, even if it was marked as "Is general". To edit the eligibility of teams for
 any break round go to the **Breaks** item in the left-hand menu for a particular
-tournament and then click **Edit Eligiblity**.
+tournament and then click **Team Eligiblity**.
 
 Here you can select "all" or "none" to toggle all team eligiblities or edit them
 using the tick boxes. Once you **save** it should return you to the main break
 page which will display the number of teams marked eligible.
 
-.. note:: Adjudicators can be marked as "breaking" on the **Feedback** page; clicking **Adjudicators** on the breaks page will take you straight there.
+.. note:: Adjudicators can be marked as "breaking" on the **Feedback** page;
+  clicking **Adjudicators** on the breaks page will take you straight there.
 
 Generating the break
 ====================

--- a/tabbycat/breakqual/models.py
+++ b/tabbycat/breakqual/models.py
@@ -1,3 +1,5 @@
+import math
+
 from django.db import models
 from django.core.validators import MinValueValidator
 from django.utils.translation import gettext_lazy as _
@@ -60,6 +62,13 @@ class BreakCategory(models.Model):
         """Returns a QuerySet of BreakingTeam instances representing teams who
         will actually compete in the elimination round series."""
         return self.breakingteam_set.filter(break_rank__isnull=False)
+
+    @property
+    def num_break_rounds(self):
+        if self.tournament.pref('teams_in_debate') == 'bp':
+            return math.ceil(math.log2(self.break_size / 2))
+        else:
+            return math.ceil(math.log2(self.break_size))
 
 
 class BreakingTeam(models.Model):

--- a/tabbycat/breakqual/templates/break_categories_edit.html
+++ b/tabbycat/breakqual/templates/break_categories_edit.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+{% load add_field_css debate_tags i18n %}
+
+{% block head-title %}<span class="emoji">👑</span>{% trans "Break Categories" %}{% endblock %}
+{% block page-title %}{% trans "Break Categories" %}{% endblock %}
+
+{% block page-subnav-sections %}
+  {% include "breakqual_subnav.html" %}
+{% endblock %}
+
+{% block content %}
+
+  <div class="card text-info border-info">
+    {# Translators: Translate "ESL" to the acronym "<target language> as a second/foreign language", not the translation of "English as a second language". #}
+    <div class="card-body">
+      {% tournamenturl 'breakqual-edit-eligibility' as eligibility_url %}
+      {% blocktrans trimmed %}
+        Break categories allow category-specific break rounds,
+        <i>e.g.</i>, for novice or ESL categories. On this page, you can define
+        what break categories exist. After you've defined the categories, the
+        break rounds will be automatically generated, and you can set team
+        eligibility on the <a href="{{ eligibility_url }}">Eligibility</a> page.
+      {% endblocktrans %}
+      {% url 'admin:breakqual_breakcategory_changelist' as edit_db_url %}
+      {% blocktrans trimmed %}
+        If you want to delete break categories, use the <a href="{{ edit_db_url }}" class="alert-link">Edit Database</a> area.
+      {% endblocktrans %}
+    </div>
+  </div>
+
+  {% trans "Save Break Categories" as save_text %}
+  {% include "components/formset.html" with double=True %}
+
+{% endblock content %}

--- a/tabbycat/breakqual/templates/breaking_index.html
+++ b/tabbycat/breakqual/templates/breaking_index.html
@@ -25,9 +25,14 @@
 {% endblock %}
 
 {% block page-subnav-actions %}
-  <a class="btn btn-primary" href="{% tournamenturl 'breakqual-edit-eligibility' %}">
-    {% trans "Edit Teams' Eligibility" %}
-  </a>
+  <div class="btn-group btn-group">
+    <a class="btn btn-outline-primary" href="{% tournamenturl 'break-categories-edit' %}">
+      {% trans "Break Categories" %}
+    </a>
+    <a class="btn btn-outline-primary" href="{% tournamenturl 'breakqual-edit-eligibility' %}">
+      {% trans "Team Eligibility" %}
+    </a>
+  </div>
 {% endblock %}
 
 {% block content %}

--- a/tabbycat/breakqual/urls_admin.py
+++ b/tabbycat/breakqual/urls_admin.py
@@ -23,4 +23,7 @@ urlpatterns = [
     path('eligibility/update',
         views.UpdateEligibilityEditView.as_view(),
         name='breakqual-update-eligibility'),
+    path('categories/',
+        views.EditBreakCategoriesView.as_view(),
+        name='break-categories-edit'),
 ]

--- a/tabbycat/breakqual/utils.py
+++ b/tabbycat/breakqual/utils.py
@@ -1,8 +1,11 @@
+import itertools
 import logging
 
-from django.db.models import Count, Q, Sum
+from django.db.models import Count, Max, Q, Sum
+from django.utils.translation import gettext_lazy as _
 
 from standings.teams import TeamStandingsGenerator
+from tournaments.models import Round
 
 from .liveness import liveness_bp, liveness_twoteam
 
@@ -119,3 +122,63 @@ def calculate_live_thresholds(bc, tournament, round):
     logger.info("Liveness in %s R%d/%d with break size %d, %d teams: safe at %d, dead at %d",
         tournament.short_name, round.seq, total_rounds, bc.break_size, total_teams, safe, dead)
     return safe, dead
+
+
+BREAK_ROUND_NAMES = [
+    # Translators: abbreviation for "grand final"
+    (_("Grand Final"), _("GF")),
+    # Translators: abbreviation for "semifinals"
+    (_("Semifinals"), _("SF")),
+    # Translators: abbreviation for "quarterfinals"
+    (_("Quarterfinals"), _("QF")),
+    # Translators: abbreviation for "octofinals"
+    (_("Octofinals"), _("OF")),
+    # Translators: abbreviation for "double-octofinals"
+    (_("Double-Octofinals"), _("DOF")),
+    # Translators: abbreviation for "triple-octofinals"
+    (_("Triple-Octofinals"), _("TOF")),
+]
+
+
+def get_break_category_round_names(bc):
+    return [
+        # Translators: abbreviation for "finals" - first character of category name
+        (_("%s Finals") % (bc.name), _("%sF") % (bc.name[:1])),
+        # Translators: abbreviation for "semifinals" - first character of category name
+        (_("%s Semifinals") % (bc.name), _("%sSF") % (bc.name[:1])),
+        # Translators: abbreviation for "quarterfinals" - first character of category name
+        (_("%s Quarterfinals") % (bc.name), _("%sQF") % (bc.name[:1])),
+        # Translators: abbreviation for "octofinals" - first character of category name
+        (_("%s Octofinals") % (bc.name), _("%sOF") % (bc.name[:1])),
+        # Translators: abbreviation for "double-octofinals" - first character of category name
+        (_("%s Double-Octofinals") % (bc.name), _("%sDOF") % (bc.name[:1])),
+        # Translators: abbreviation for "triple-octofinals" - first character of category name
+        (_("%s Triple-Octofinals") % (bc.name), _("%sTOF") % (bc.name[:1])),
+    ]
+
+
+def auto_make_break_rounds(bc, tournament=None, prefix=False):
+    if tournament is None:
+        tournament = bc.tournament
+
+    num_rounds = tournament.round_set.all().aggregate(Max('seq'))['seq__max']
+    round_names = get_break_category_round_names(bc) if prefix else BREAK_ROUND_NAMES
+
+    # Translators: "UBR" stands for "unknown break round" (used as a fallback when we don't know what it's called)
+    unknown_round = (_("Unknown %s break round") % (bc.name), _("U%sBR") % (bc.name[:1])) if prefix \
+        else (_("Unknown break round"), _("UBR"))
+
+    break_rounds = itertools.chain(round_names, itertools.repeat(unknown_round))
+
+    for i, (name, abbr) in zip(range(bc.num_break_rounds), break_rounds):
+        Round(
+            tournament=tournament,
+            break_category=bc,
+            seq=num_rounds+bc.num_break_rounds-i,
+            stage=Round.STAGE_ELIMINATION,
+            name=name,
+            abbreviation=abbr,
+            draw_type=Round.DRAW_ELIMINATION,
+            feedback_weight=0.5,
+            silent=True,
+        ).save()

--- a/tabbycat/tournaments/forms.py
+++ b/tabbycat/tournaments/forms.py
@@ -1,5 +1,3 @@
-import math
-
 from django.forms.fields import IntegerField
 from django.forms.models import ModelChoiceIterator
 from django.forms import CharField, ChoiceField, Form, ModelChoiceField, ModelForm
@@ -10,11 +8,12 @@ from django_summernote.widgets import SummernoteWidget
 
 from adjfeedback.models import AdjudicatorFeedbackQuestion
 from breakqual.models import BreakCategory
+from breakqual.utils import auto_make_break_rounds
 from options.preferences import TournamentStaff
 from options.presets import all_presets, get_preferences_data, presets_for_form, public_presets_for_form
 
 from .models import Round, Tournament
-from .utils import auto_make_break_rounds, auto_make_rounds
+from .utils import auto_make_rounds
 
 
 class TournamentStartForm(ModelForm):
@@ -127,11 +126,7 @@ class TournamentConfigureForm(ModelForm):
         open_break = BreakCategory.objects.filter(tournament=t, is_general=True).first()
         # Check there aren't already break rounds (i.e. when importing demos)
         if open_break and not t.break_rounds().exists():
-            if t.pref('teams_in_debate') == 'bp':
-                num_break_rounds = math.ceil(math.log2(open_break.break_size / 2))
-            else:
-                num_break_rounds = math.ceil(math.log2(open_break.break_size))
-            auto_make_break_rounds(t, num_break_rounds, open_break)
+            auto_make_break_rounds(open_break, t, False)
 
 
 class RoundWithCompleteOptionChoiceIterator(ModelChoiceIterator):

--- a/tabbycat/tournaments/utils.py
+++ b/tabbycat/tournaments/utils.py
@@ -1,7 +1,5 @@
-import itertools
 import logging
 
-from django.db.models import Max
 from django.utils.encoding import force_text
 from django.utils.translation import gettext_lazy as _
 from django.utils.translation import gettext, pgettext_lazy
@@ -9,21 +7,6 @@ from django.utils.translation import gettext, pgettext_lazy
 from .models import Round
 
 logger = logging.getLogger(__name__)
-
-BREAK_ROUND_NAMES = [
-    # Translators: abbreviation for "grand final"
-    (_("Grand Final"), _("GF")),
-    # Translators: abbreviation for "semifinals"
-    (_("Semifinals"), _("SF")),
-    # Translators: abbreviation for "quarterfinals"
-    (_("Quarterfinals"), _("QF")),
-    # Translators: abbreviation for "octofinals"
-    (_("Octofinals"), _("OF")),
-    # Translators: abbreviation for "double-octofinals"
-    (_("Double-Octofinals"), _("DOF")),
-    # Translators: abbreviation for "triple-octofinals"
-    (_("Triple-Octofinals"), _("TOF")),
-]
 
 SIDE_NAMES = {
     'aff-neg': {
@@ -100,29 +83,6 @@ def auto_make_rounds(tournament, num_rounds):
             draw_type=Round.DRAW_RANDOM if (i == 1) else Round.DRAW_POWERPAIRED,
             feedback_weight=min((i-1)*0.1, 0.5),
             silent=(i == num_rounds),
-        ).save()
-
-
-def auto_make_break_rounds(tournament, num_break, break_category):
-    """Makes the number of break rounds specified. This is intended as a
-    convenience function. For anything more complicated, a more advanced import
-    method should be used."""
-
-    num_prelim = tournament.prelim_rounds().aggregate(Max('seq'))['seq__max']
-    # Translators: "UBR" stands for "unknown break round" (used as a fallback when we don't know what it's called)
-    break_rounds = itertools.chain(BREAK_ROUND_NAMES, itertools.repeat((_("Unknown break round"), _("UBR"))))
-
-    for i, (name, abbr) in zip(range(num_break), break_rounds):
-        Round(
-            tournament=tournament,
-            break_category=break_category,
-            seq=num_prelim+num_break-i,
-            stage=Round.STAGE_ELIMINATION,
-            name=name,
-            abbreviation=abbr,
-            draw_type=Round.DRAW_ELIMINATION,
-            feedback_weight=0.5,
-            silent=True,
         ).save()
 
 


### PR DESCRIPTION
This commit adds a new interface to create and edit break categories, modelled on the creation of speaker categories. While traditionally done in the database area, the creation of break categories has more steps than just creating a model object, so is best done interactively.

When creating a break category, rounds are now automatically created for the number of teams breaking, using the same method for the open break rounds as in tournament creation. In order to have the appropriate round names, the round names have the category name, and the abbreviation has the first letter of it.

A method for modifying existing objects has been also subclass-ed for future use (if need to delete/append new rounds due to a change in break size).

The documentation has also been updated to reflect this new procedure.

Closes #1335.