### PR TITLE
Mark private URL explainer as a warning

### DIFF
--- a/tabbycat/privateurls/templates/public_url_landing.html
+++ b/tabbycat/privateurls/templates/public_url_landing.html
@@ -11,9 +11,6 @@
   {% if object.speaker %}
     {% blocktrans trimmed with team=object.speaker.team.short_name %}({{ team }}){% endblocktrans %}
   {% endif %}
-  {% if object.speaker %}
-
-  {% endif %}
 {% endblock %}
 
 {% block page-alerts %}
@@ -24,7 +21,7 @@
     feedback for your debates. You may bookmark this page and return here after each
     debate for the available actions.
   {% endblocktrans %}
-  {% include "components/explainer-card.html" with type="info" %}
+  {% include "components/explainer-card.html" with type="warning" %}
 
 {% endblock %}
 

--- a/tabbycat/results/templates/privateurl_ballot_set.html
+++ b/tabbycat/results/templates/privateurl_ballot_set.html
@@ -9,8 +9,7 @@
     your own scoresheet.
     <strong>You must not share this URL with anyone.</strong>
     Sharing the URL will allow others to access <strong>all</strong> actions
-    from your personal landing page. Also, allowing others to see your
-    scoresheet may be a violation of tournament policies.
+    from your personal landing page.
   {% endblocktrans %}
   {% include "components/explainer-card.html" with type="warning" %}
 {% endblock %}


### PR DESCRIPTION
The private URL landing page contains an explainer of the page with a warning about unauthorized access. Other pages, such as the private URL view of scoresheets, have similar warnings. This commit standardizes the type of the messages, changing 'info' to 'warning' on landing pages in line with scoresheets.

This commit also removes the note about tournament rules in the scoresheets as it is redundant with the explication why sharing the credential is bad, without resorting to authority.

Also removed an unused if statement.

I am also kinda against the "and/or" construction as the operator "or" does include the set covered by "and," but it's just my logician side, and I haven't replaced its usage in private URLs in this commit.