### PR TITLE
Tournament endpoints and hyperlinked API

### DIFF
--- a/tabbycat/api/fields.py
+++ b/tabbycat/api/fields.py
@@ -1,0 +1,21 @@
+from rest_framework.relations import HyperlinkedIdentityField
+from rest_framework.reverse import reverse
+
+
+class TournamentHyperlinkedIdentityField(HyperlinkedIdentityField):
+
+    def get_url(self, obj, view_name, request, format):
+        lookup_value = getattr(obj, self.lookup_field)
+        kwargs = {
+            'tournament_slug': obj.tournament.slug,
+            self.lookup_url_kwarg: lookup_value,
+        }
+        return reverse(view_name, kwargs=kwargs, request=request, format=format)
+
+    def get_object(self, view_name, view_args, view_kwargs):
+        lookup_value = view_kwargs[self.lookup_url_kwarg]
+        lookup_kwargs = {
+            'tournament__slug': view_kwargs['tournament_slug'],
+            self.lookup_field: lookup_value,
+        }
+        return self.get_queryset().get(**lookup_kwargs)

--- a/tabbycat/api/serializers.py
+++ b/tabbycat/api/serializers.py
@@ -7,69 +7,56 @@ from tournaments.models import Tournament
 from .fields import TournamentHyperlinkedIdentityField
 
 
-class TournamentAtRootSerializer(serializers.HyperlinkedModelSerializer):
+class TournamentSerializer(serializers.ModelSerializer):
 
     url = serializers.HyperlinkedIdentityField(
         view_name='api-tournament-detail',
         lookup_field='slug', lookup_url_kwarg='tournament_slug')
 
-    class Meta:
-        model = Tournament
-        fields = ('name', 'short_name', 'slug', 'url', 'active')
+    class TournamentLinksSerializer(serializers.Serializer):
+        break_categories = serializers.HyperlinkedIdentityField(
+            view_name='api-breakcategory-list',
+            lookup_field='slug', lookup_url_kwarg='tournament_slug')
+        speaker_categories = serializers.HyperlinkedIdentityField(
+            view_name='api-speakercategory-list',
+            lookup_field='slug', lookup_url_kwarg='tournament_slug')
 
-
-class TournamentEndpointsSerializer(serializers.Serializer):
-
-    break_categories = serializers.HyperlinkedIdentityField(
-        view_name='api-breakcategory-list',
-        lookup_field='slug', lookup_url_kwarg='tournament_slug')
-    speaker_categories = serializers.HyperlinkedIdentityField(
-        view_name='api-speakercategory-list',
-        lookup_field='slug', lookup_url_kwarg='tournament_slug')
-
-
-class TournamentSerializer(serializers.ModelSerializer):
-
-    urls = TournamentEndpointsSerializer(source='*', read_only=True)
+    _links = TournamentLinksSerializer(source='*', read_only=True)
 
     class Meta:
         model = Tournament
-        fields = ('name', 'short_name', 'slug', 'seq', 'active', 'urls')
-
-
-class BreakCategoryEndpointsSerializer(serializers.Serializer):
-
-    eligibility = TournamentHyperlinkedIdentityField(
-        view_name='api-breakcategory-eligibility', lookup_field='slug')
+        fields = ('name', 'short_name', 'slug', 'seq', 'active', 'url', '_links')
 
 
 class BreakCategorySerializer(serializers.ModelSerializer):
 
+    class BreakCategoryLinksSerializer(serializers.Serializer):
+        eligibility = TournamentHyperlinkedIdentityField(
+            view_name='api-breakcategory-eligibility', lookup_field='slug')
+
     url = TournamentHyperlinkedIdentityField(
         view_name='api-breakcategory-detail', lookup_field='slug')
-    urls = BreakCategoryEndpointsSerializer(source='*', read_only=True)
+    _links = BreakCategoryLinksSerializer(source='*', read_only=True)
 
     class Meta:
         model = BreakCategory
         fields = ('name', 'slug', 'seq', 'break_size', 'is_general', 'priority',
-                  'limit', 'rule', 'url', 'urls')
-
-
-class SpeakerCategoryEndpointsSerializer(serializers.Serializer):
-
-    eligibility = TournamentHyperlinkedIdentityField(
-        view_name='api-speakercategory-eligibility', lookup_field='slug')
+                  'limit', 'rule', 'url', '_links')
 
 
 class SpeakerCategorySerializer(serializers.ModelSerializer):
 
+    class SpeakerCategoryLinksSerializer(serializers.Serializer):
+        eligibility = TournamentHyperlinkedIdentityField(
+            view_name='api-speakercategory-eligibility', lookup_field='slug')
+
     url = TournamentHyperlinkedIdentityField(
         view_name='api-speakercategory-detail', lookup_field='slug')
-    urls = SpeakerCategoryEndpointsSerializer(source='*', read_only=True)
+    _links = SpeakerCategoryLinksSerializer(source='*', read_only=True)
 
     class Meta:
         model = SpeakerCategory
-        fields = ('name', 'slug', 'seq', 'limit', 'public', 'url', 'urls')
+        fields = ('name', 'slug', 'seq', 'limit', 'public', 'url', '_links')
 
 
 class BreakEligibilitySerializer(serializers.ModelSerializer):

--- a/tabbycat/api/serializers.py
+++ b/tabbycat/api/serializers.py
@@ -2,6 +2,37 @@ from rest_framework import serializers
 
 from breakqual.models import BreakCategory
 from participants.models import Speaker, SpeakerCategory
+from tournaments.models import Tournament
+
+
+class TournamentAtRootSerializer(serializers.HyperlinkedModelSerializer):
+
+    url = serializers.HyperlinkedIdentityField(
+        view_name='api-tournament-detail',
+        lookup_field='slug', lookup_url_kwarg='tournament_slug')
+
+    class Meta:
+        model = Tournament
+        fields = ('name', 'short_name', 'slug', 'url', 'active')
+
+
+class TournamentEndpointsSerializer(serializers.Serializer):
+
+    break_categories = serializers.HyperlinkedIdentityField(
+        view_name='api-breakcategory-list',
+        lookup_field='slug', lookup_url_kwarg='tournament_slug')
+    speaker_categories = serializers.HyperlinkedIdentityField(
+        view_name='api-speakercategory-list',
+        lookup_field='slug', lookup_url_kwarg='tournament_slug')
+
+
+class TournamentSerializer(serializers.ModelSerializer):
+
+    urls = TournamentEndpointsSerializer(source='*', read_only=True)
+
+    class Meta:
+        model = Tournament
+        fields = ('name', 'short_name', 'slug', 'active', 'urls')
 
 
 class BreakCategorySerializer(serializers.ModelSerializer):

--- a/tabbycat/api/serializers.py
+++ b/tabbycat/api/serializers.py
@@ -4,6 +4,8 @@ from breakqual.models import BreakCategory
 from participants.models import Speaker, SpeakerCategory
 from tournaments.models import Tournament
 
+from .fields import TournamentHyperlinkedIdentityField
+
 
 class TournamentAtRootSerializer(serializers.HyperlinkedModelSerializer):
 
@@ -35,18 +37,39 @@ class TournamentSerializer(serializers.ModelSerializer):
         fields = ('name', 'short_name', 'slug', 'seq', 'active', 'urls')
 
 
+class BreakCategoryEndpointsSerializer(serializers.Serializer):
+
+    eligibility = TournamentHyperlinkedIdentityField(
+        view_name='api-breakcategory-eligibility', lookup_field='slug')
+
+
 class BreakCategorySerializer(serializers.ModelSerializer):
+
+    url = TournamentHyperlinkedIdentityField(
+        view_name='api-breakcategory-detail', lookup_field='slug')
+    urls = BreakCategoryEndpointsSerializer(source='*', read_only=True)
 
     class Meta:
         model = BreakCategory
-        fields = ('name', 'slug', 'seq', 'break_size', 'is_general', 'priority', 'limit', 'rule')
+        fields = ('name', 'slug', 'seq', 'break_size', 'is_general', 'priority',
+                  'limit', 'rule', 'url', 'urls')
+
+
+class SpeakerCategoryEndpointsSerializer(serializers.Serializer):
+
+    eligibility = TournamentHyperlinkedIdentityField(
+        view_name='api-speakercategory-eligibility', lookup_field='slug')
 
 
 class SpeakerCategorySerializer(serializers.ModelSerializer):
 
+    url = TournamentHyperlinkedIdentityField(
+        view_name='api-speakercategory-detail', lookup_field='slug')
+    urls = SpeakerCategoryEndpointsSerializer(source='*', read_only=True)
+
     class Meta:
         model = SpeakerCategory
-        fields = ('name', 'slug', 'seq', 'limit', 'public')
+        fields = ('name', 'slug', 'seq', 'limit', 'public', 'url', 'urls')
 
 
 class BreakEligibilitySerializer(serializers.ModelSerializer):

--- a/tabbycat/api/serializers.py
+++ b/tabbycat/api/serializers.py
@@ -32,7 +32,7 @@ class TournamentSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Tournament
-        fields = ('name', 'short_name', 'slug', 'active', 'urls')
+        fields = ('name', 'short_name', 'slug', 'seq', 'active', 'urls')
 
 
 class BreakCategorySerializer(serializers.ModelSerializer):

--- a/tabbycat/api/urls.py
+++ b/tabbycat/api/urls.py
@@ -17,9 +17,13 @@ urlpatterns = [
         views.APIRootView.as_view(),
         name='api-root'),
 
+    path('create/',
+        views.TournamentCreateView.as_view(),
+        name='api-tournament-create'),
+
     path('<slug:tournament_slug>/', include([
         path('',
-            views.TournamentRootView.as_view(),
+            views.TournamentDetailView.as_view(),
             name='api-tournament-detail'),
 
         path('<int:round_seq>/', include([

--- a/tabbycat/api/urls.py
+++ b/tabbycat/api/urls.py
@@ -13,7 +13,15 @@ detail_methods = {'get': 'retrieve', 'post': 'update', 'delete': 'destroy'}
 
 urlpatterns = [
 
+    path('',
+        views.APIRootView.as_view(),
+        name='api-root'),
+
     path('<slug:tournament_slug>/', include([
+        path('',
+            views.TournamentRootView.as_view(),
+            name='api-tournament-detail'),
+
         path('<int:round_seq>/', include([
         ])),
 

--- a/tabbycat/api/urls.py
+++ b/tabbycat/api/urls.py
@@ -17,45 +17,57 @@ urlpatterns = [
         views.APIRootView.as_view(),
         name='api-root'),
 
-    path('create/',
-        views.TournamentCreateView.as_view(),
-        name='api-tournament-create'),
+    path('tournaments/', include([
 
-    path('<slug:tournament_slug>/', include([
         path('',
-            views.TournamentDetailView.as_view(),
-            name='api-tournament-detail'),
+            views.TournamentViewSet.as_view(list_methods),
+            name='api-tournament-list'),
 
-        path('<int:round_seq>/', include([
-        ])),
+        path('<slug:tournament_slug>/', include([
 
-        path('break-categories/', include([
             path('',
-                views.BreakCategoryViewSet.as_view(list_methods),
-                name='api-breakcategory-list'),
-            path('<slug:slug>/', include([
-                path('',
-                    views.BreakCategoryViewSet.as_view(detail_methods),
-                    name='api-breakcategory-detail'),
-                path('eligibility/',
-                    views.BreakEligibilityView.as_view(),
-                    name='api-breakcategory-eligibility'),
+                views.TournamentViewSet.as_view(detail_methods),
+                name='api-tournament-detail'),
+
+            path('rounds/', include([
+                path('<int:round_seq>/', include([
+                ])),
             ])),
-        ])),
-        path('speaker-categories/', include([
-            path('',
-                views.SpeakerCategoryViewSet.as_view(list_methods),
-                name='api-speakercategory-list'),
-            path('<slug:slug>/', include([
+
+            path('break-categories/', include([
+
                 path('',
-                    views.SpeakerCategoryViewSet.as_view(detail_methods),
-                    name='api-speakercategory-detail'),
-                path('eligibility/',
-                    views.SpeakerEligibilityView.as_view(),
-                    name='api-speakercategory-eligibility'),
+                    views.BreakCategoryViewSet.as_view(list_methods),
+                    name='api-breakcategory-list'),
+
+                path('<slug:slug>/', include([
+                    path('',
+                        views.BreakCategoryViewSet.as_view(detail_methods),
+                        name='api-breakcategory-detail'),
+                    path('eligibility/',
+                        views.BreakEligibilityView.as_view(),
+                        name='api-breakcategory-eligibility'),
+                ])),
+
             ])),
+            path('speaker-categories/', include([
+
+                path('',
+                    views.SpeakerCategoryViewSet.as_view(list_methods),
+                    name='api-speakercategory-list'),
+
+                path('<slug:slug>/', include([
+                    path('',
+                        views.SpeakerCategoryViewSet.as_view(detail_methods),
+                        name='api-speakercategory-detail'),
+                    path('eligibility/',
+                        views.SpeakerEligibilityView.as_view(),
+                        name='api-speakercategory-eligibility'),
+                ])),
+            ])),
+
+            url('', include(pref_router.urls)),  # Preferences
         ])),
-        url('', include(pref_router.urls)),  # Preferences
     ])),
 
 ]

--- a/tabbycat/api/views.py
+++ b/tabbycat/api/views.py
@@ -1,10 +1,11 @@
 from dynamic_preferences.api.viewsets import PerInstancePreferenceViewSet
 from dynamic_preferences.api.serializers import PreferenceSerializer
-from rest_framework.generics import GenericAPIView, RetrieveUpdateAPIView
 from rest_framework.views import APIView
+from rest_framework.generics import CreateAPIView, GenericAPIView, RetrieveUpdateAPIView
 from rest_framework.viewsets import ModelViewSet
 from rest_framework.permissions import IsAdminUser
 from rest_framework.response import Response
+from rest_framework.reverse import reverse
 
 from options.models import TournamentPreferenceModel
 from tournaments.models import Tournament
@@ -42,10 +43,21 @@ class APIRootView(AdministratorAPIMixin, GenericAPIView):
     def get(self, request, format=None):
         queryset = self.filter_queryset(self.get_queryset())
         serializer = self.get_serializer(queryset, many=True)
-        return Response({"tournaments": serializer.data})
+        tournaments_create_url = reverse('api-tournament-create', request=request, format=format)
+        return Response({
+            "tournaments": serializer.data,
+            "urls": {"create_tournament": tournaments_create_url}
+        })
 
 
-class TournamentRootView(RetrieveUpdateAPIView):
+class TournamentCreateView(CreateAPIView):
+    queryset = Tournament.objects.all()
+    serializer_class = serializers.TournamentSerializer
+    lookup_field = 'slug'
+    lookup_url_kwarg = 'tournament_slug'
+
+
+class TournamentDetailView(RetrieveUpdateAPIView):
     # Don't use TournamentAPIMixin here, it's not filtering objects by tournament.
     queryset = Tournament.objects.all()
     serializer_class = serializers.TournamentSerializer

--- a/tabbycat/api/views.py
+++ b/tabbycat/api/views.py
@@ -1,10 +1,13 @@
 from dynamic_preferences.api.viewsets import PerInstancePreferenceViewSet
 from dynamic_preferences.api.serializers import PreferenceSerializer
-from rest_framework.generics import RetrieveUpdateAPIView
+from rest_framework.generics import GenericAPIView, RetrieveUpdateAPIView
+from rest_framework.views import APIView
 from rest_framework.viewsets import ModelViewSet
 from rest_framework.permissions import IsAdminUser
+from rest_framework.response import Response
 
 from options.models import TournamentPreferenceModel
+from tournaments.models import Tournament
 from tournaments.mixins import TournamentMixin
 
 from . import serializers
@@ -27,6 +30,27 @@ class TournamentAPIMixin(TournamentMixin):
 
 class AdministratorAPIMixin:
     permission_classes = [IsAdminUser]
+
+
+class APIRootView(AdministratorAPIMixin, GenericAPIView):
+    name = "API Root"
+    queryset = Tournament.objects.all()
+    serializer_class = serializers.TournamentAtRootSerializer
+    lookup_field = 'slug'
+    lookup_url_kwarg = 'tournament_slug'
+
+    def get(self, request, format=None):
+        queryset = self.filter_queryset(self.get_queryset())
+        serializer = self.get_serializer(queryset, many=True)
+        return Response({"tournaments": serializer.data})
+
+
+class TournamentRootView(RetrieveUpdateAPIView):
+    # Don't use TournamentAPIMixin here, it's not filtering objects by tournament.
+    queryset = Tournament.objects.all()
+    serializer_class = serializers.TournamentSerializer
+    lookup_field = 'slug'
+    lookup_url_kwarg = 'tournament_slug'
 
 
 class TournamentPreferenceViewSet(TournamentMixin, AdministratorAPIMixin, PerInstancePreferenceViewSet):

--- a/tabbycat/tournaments/mixins.py
+++ b/tabbycat/tournaments/mixins.py
@@ -49,7 +49,7 @@ class TournamentFromUrlMixin:
     tournament_redirect_pattern_name = None
 
     def get_url_kwargs(self):
-        raise NotImplementedError
+        return self.kwargs
 
     @property
     def tournament(self):
@@ -80,9 +80,6 @@ class TournamentMixin(TabbycatPageTitlesMixin, TournamentFromUrlMixin):
     regular expression. They should then call `self.tournament` to
     retrieve the tournament.
     """
-    def get_url_kwargs(self):
-        return self.kwargs
-
     def get_redirect_url(self, *args, **kwargs):
         # Override if self.tournament_redirect_pattern_name is specified,
         # otherwise just pass down the chain


### PR DESCRIPTION
I extended on @tienne-B's work in #1342, and added an API root and endpoints for tournaments to make it more compliant with the HATEOAS part of REST API guidelines.

One question raised by the existing structure, also touched on briefly in #1342, is where tournaments are located. Here are a few observations:

- The most _conventional_ naming would go:
    - **api/v1/tournaments** to list and create tournaments
    - **api/v1/tournaments/SLUG** to detail and update tournaments
- If we instead go **/api/v1/SLUG**, as we have currently, then the list of tournaments might more naturally go at the API root.
- Tournaments are so central to how we think about our data structures that it might actually be more intuitive to put the list at the API root, breaking REST API naming conventions. I've done this for now.
    - However, putting the list of tournaments at the API root means we can't really do pagination effectively, because pagination only really makes sense for list views.
    - On the other hand, maybe we should just never paginate this, and instead assume that there will never be enough tournaments on a site to paginate?
- We have to have a tournament creation endpoint somewhere, and the most conventional place is at "/tournaments". But if we're going to break this convention, maybe we should go the whole way and match the "/create/" URL that we have in the human user interface? I've done this for now.

Relates to #1301, #1343.

Ping @jacklishufan