### PR TITLE
Use pre-commit for flake8 hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+exclude: locale/|^tabbycat/static/
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v2.4.0
+  hooks:
+  - id: trailing-whitespace
+  - id: end-of-file-fixer
+    exclude_types:
+    - csv
+    - svg
+  - id: check-yaml
+  - id: check-added-large-files
+- repo: https://gitlab.com/pycqa/flake8
+  rev: 3.7.9
+  hooks:
+  - id: flake8
+    additional_dependencies:
+    - flake8-import-order
+    - flake8-quotes
+    - pep8-naming
+    exclude: migrations/

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ matrix:
         - pg_lsclusters
         - createdb travisci -U postgres
       script:
-        - flake8 tabbycat
+        - pre-commit run --all-files
         - npm run lint
         - python tabbycat/manage.py test -v 2 --exclude-tag=selenium
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -34,6 +34,10 @@ Getting started with development
 
     $ pip install -r 'config/requirements_development.txt'
 
+- We use `pre-commit <https://pre-commit.com/>`_ to run code style checks (linters). To have them run as a git hook automatically before every commit::
+
+    $ pre-commit install
+
 - Our ``package.json`` provides a convenience command that runs a standard set of development tools simultaneously, such as the Django server and the automatic recompilation with live injecting of javascript and CSS. Once you have set ``USE_WEBPACK_SERVER=True`` in your ``settings_local.py`` you can then run this with::
 
     $ npm run serve
@@ -67,7 +71,7 @@ For the front end interface design there is a style guide available at "/style/"
 
 For python code, we use `flake8 <http://flake8.readthedocs.io>`_ to check for a non-strict series of style rules. Warnings will trigger a Travis CI build to fail. The entire codebase can be checked by using::
 
-    $ flake8 .
+    $ pre-commit run flake8 --all-files
 
 For stylesheets, we use `stylelint <https://stylelint.io>`_. The relevant code can be checked by using::
 

--- a/config/requirements_development.txt
+++ b/config/requirements_development.txt
@@ -5,11 +5,8 @@
 -r requirements_docs.txt
 -r requirements_heroku.txt
 
-# Linting
-flake8==3.7.*
-flake8-import-order==0.18.1                 # Flake plugin for import order
-flake8-quotes==2.1.*                        # Flake plugin for quotes
-pep8-naming==0.9.*                          # Flake plugin for naming conventions
+# Pre-commit hooks
+pre-commit
 
 # Tests
 selenium==3.141.*                           # Functional testing (in here for CI tests)


### PR DESCRIPTION
I noticed that flake8 now recommends using [pre-commit](https://pre-commit.com/) for git commit hooks:
https://flake8.pycqa.org/en/3.7.9/user/using-hooks.html

Since there's a config file, I thought I'd check whether it would make sense to commit this to the repo so that everyone's using the same one. The first commit just adds the config file; as I understand, a developer without pre-commit won't be affected by this. The second commit changes the pip requirements and CI script to use pre-commit instead of flake8.

To try this out, after checking out the branch:
```
# should install pre-commit
pip install -r config/requirements_development.txt

# will skip all tests because "no files to check"
pre-commit run
```

To get it to run as a git commit hook:
```
pre-commit install
```

If you run pre-commit on our existing code base, using
```
pre-commit run --all-files
```
you'll find that it fails and modifies a bunch of files, mostly for line endings. I've added the files that I don't think are appropriate to `exclude` in the .pre-commit-config.yaml configuration. The ones that remain are the ones that I'd be happy to have fixed in a commit, if we decide to use pre-commit.

Let me know what you think!
