### PR TITLE
Add API endpoints for tournament preferences

### DIFF
--- a/tabbycat/api/urls.py
+++ b/tabbycat/api/urls.py
@@ -1,6 +1,12 @@
+from django.conf.urls import url
 from django.urls import include, path
 
+from rest_framework.routers import SimpleRouter
+
 from . import views
+
+pref_router = SimpleRouter()
+pref_router.register('preferences', views.TournamentPreferenceViewSet)
 
 list_methods = {'get': 'list', 'post': 'create'}
 detail_methods = {'get': 'retrieve', 'post': 'update', 'delete': 'destroy'}
@@ -37,6 +43,7 @@ urlpatterns = [
                     name='api-speakercategory-eligibility'),
             ])),
         ])),
+        url('', include(pref_router.urls)),  # Preferences
     ])),
 
 ]

--- a/tabbycat/api/views.py
+++ b/tabbycat/api/views.py
@@ -1,7 +1,10 @@
+from dynamic_preferences.api.viewsets import PerInstancePreferenceViewSet
+from dynamic_preferences.api.serializers import PreferenceSerializer
 from rest_framework.generics import RetrieveUpdateAPIView
 from rest_framework.viewsets import ModelViewSet
 from rest_framework.permissions import IsAdminUser
 
+from options.models import TournamentPreferenceModel
 from tournaments.mixins import TournamentMixin
 
 from . import serializers
@@ -24,6 +27,14 @@ class TournamentAPIMixin(TournamentMixin):
 
 class AdministratorAPIMixin:
     permission_classes = [IsAdminUser]
+
+
+class TournamentPreferenceViewSet(TournamentMixin, AdministratorAPIMixin, PerInstancePreferenceViewSet):
+    queryset = TournamentPreferenceModel.objects.all()
+    serializer_class = PreferenceSerializer
+
+    def get_related_instance(self):
+        return self.tournament
 
 
 class BreakCategoryViewSet(TournamentAPIMixin, AdministratorAPIMixin, ModelViewSet):


### PR DESCRIPTION
These endpoints are provided by django_dynamic_preferences and allows for retrieval and bulk editing of the preferences.