### PR TITLE
Use bulk query methods with draw creation

### DIFF
--- a/tabbycat/venues/allocator.py
+++ b/tabbycat/venues/allocator.py
@@ -2,6 +2,8 @@ import itertools
 import logging
 import random
 
+from draw.models import Debate
+
 from .models import VenueConstraint
 
 logger = logging.getLogger(__name__)
@@ -170,4 +172,4 @@ class VenueAllocator:
         for debate, venue in debate_venues.items():
             logger.debug("Saving %s for %s", venue, debate)
             debate.venue = venue
-            debate.save()
+        Debate.objects.bulk_update(debate_venues.keys(), ['venue'])


### PR DESCRIPTION
This commit replaces the one-by-one creation of `Debate` and `DebateTeam` objects with `.bulk_create`s by splitting the `_make_debates` (from pairings) loop in two, associating each pairing with a debate and iterating over that dict in the 2nd loop.

Afterwards, venue assignation is optimized by using `.bulk_update`.

Work on #676. 
Supersedes 102fc4afd84e6568279f7888077a8a5de6ba25bd.