### PR TITLE
Group adjudicators in feedback by round

### DIFF
--- a/tabbycat/adjfeedback/forms.py
+++ b/tabbycat/adjfeedback/forms.py
@@ -3,6 +3,7 @@ import logging
 
 from django import forms
 from django.core.exceptions import ValidationError
+from django.db.models import Exists, OuterRef, Prefetch
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy
 from django.utils.translation import gettext as _
@@ -240,17 +241,25 @@ def make_feedback_form_class_for_adj(source, tournament, submission_fields, conf
 
     def adj_choice(adj, debate, pos):
         value = '%d-%d' % (debate.id, adj.id)
-        # Translators: e.g. "Megan Pearson (Round 2 chair)", with round="Round 2", adjpos="chair"
-        display = _("%(name)s (%(adjpos)s)") % {'name': adj.name, 'adjpos': ADJUDICATOR_POSITION_NAMES[pos]}
+        # Translators: e.g. "Megan Pearson (chair)", with adjpos="chair"
+        display = _("Submitted - ") if adj.submitted else ""
+        display += _("%(name)s (%(adjpos)s)") % {'name': adj.name, 'adjpos': ADJUDICATOR_POSITION_NAMES[pos]}
         return (value, display)
 
+    adjfeedback_query = AdjudicatorFeedback.objects.filter(
+        source_adjudicator__adjudicator=source, source_adjudicator__debate=OuterRef('debate'),
+        adjudicator=OuterRef('adjudicator'), confirmed=True
+    )
     debateadjs = DebateAdjudicator.objects.filter(
         debate__round__tournament=tournament, adjudicator=source,
         debate__round__seq__lte=tournament.current_round.seq,
         debate__round__stage=Round.STAGE_PRELIMINARY
-    ).order_by('-debate__round__seq').prefetch_related(
-        'debate__debateadjudicator_set__adjudicator'
-    ).select_related('debate__round')
+    ).order_by('-debate__round__seq').select_related('debate__round').prefetch_related(
+        Prefetch(
+            'debate__debateadjudicator_set',
+            queryset=DebateAdjudicator.objects.all().select_related('adjudicator').annotate(submitted=Exists(adjfeedback_query))
+        )
+    )
 
     if include_unreleased_draws:
         debateadjs = debateadjs.filter(debate__round__draw_status__in=[Round.STATUS_CONFIRMED, Round.STATUS_RELEASED])
@@ -296,16 +305,17 @@ def make_feedback_form_class_for_team(source, tournament, submission_fields, con
     def adj_choice(adj, debate, pos):
         value = '%d-%d' % (debate.id, adj.id)
 
+        display = _("Submitted - ") if adj.submitted else ""
         if pos == AdjudicatorAllocation.POSITION_ONLY:
-            display = _("%(name)s")
+            display += _("%(name)s")
         elif tournament.pref('feedback_from_teams') == 'all-adjs':
-            # Translators: e.g. "Megan Pearson (Round 3 panellist)", with round="Round 3", adjpos="panellist"
-            display = _("%(name)s (%(adjpos)s)")
+            # Translators: e.g. "Megan Pearson (panellist)", with round="Round 3", adjpos="panellist"
+            display += _("%(name)s (%(adjpos)s)")
         elif pos == AdjudicatorAllocation.POSITION_CHAIR:
             # feedback expected only on orallist
-            display = _("%(name)s (chair gave oral)")
+            display += _("%(name)s (chair gave oral)")
         else:
-            display = _("%(name)s (panellist gave oral as chair rolled)")
+            display += _("%(name)s (panellist gave oral as chair rolled)")
 
         display %= {'name': adj.name, 'adjpos': ADJUDICATOR_POSITION_NAMES[pos]}
         return (value, display)
@@ -315,7 +325,16 @@ def make_feedback_form_class_for_team(source, tournament, submission_fields, con
         debateteam__team=source, round__silent=False,
         round__seq__lte=tournament.current_round.seq,
         round__stage=Round.STAGE_PRELIMINARY
-    ).order_by('-round__seq').prefetch_related('debateadjudicator_set__adjudicator')
+    ).order_by('-round__seq').prefetch_related(Prefetch(
+        'debateadjudicator_set',
+        queryset=DebateAdjudicator.objects.all().select_related('adjudicator').annotate(submitted=Exists(
+            AdjudicatorFeedback.objects.filter(
+                source_team__team=source, source_team__debate=OuterRef('debate'),
+                adjudicator=OuterRef('adjudicator'), confirmed=True
+            )
+        ))
+    ))
+
     if include_unreleased_draws:
         debates = debates.filter(round__draw_status__in=[Round.STATUS_CONFIRMED, Round.STATUS_RELEASED])
     else:
@@ -323,6 +342,10 @@ def make_feedback_form_class_for_team(source, tournament, submission_fields, con
 
     choices = [(None, _("-- Adjudicators --"))]
     for debate in debates:
+        # Need to associate the submission status to Adjudicator objects
+        # so that they pass to the AdjudicatorAllocation
+        for da in debate.debateadjudicator_set.all():
+            da.adjudicator.submitted = da.submitted
         if tournament.pref('feedback_from_teams') == 'all-adjs':
             das = debate.adjudicators.with_positions()
         else:

--- a/tabbycat/adjfeedback/utils.py
+++ b/tabbycat/adjfeedback/utils.py
@@ -6,6 +6,7 @@ from django.db.models import Count, Prefetch, Q
 from adjallocation.allocation import AdjudicatorAllocation
 from adjallocation.models import DebateAdjudicator
 from adjfeedback.models import AdjudicatorFeedback
+from options.preferences import FeedbackPaths
 
 logger = logging.getLogger(__name__)
 
@@ -34,6 +35,16 @@ def expected_feedback_targets(debateadj, feedback_paths=None, debate=None):
 
     if feedback_paths is None:
         feedback_paths = debateadj.debate.round.tournament.pref('feedback_paths')
+    if feedback_paths not in [o[0] for o in FeedbackPaths.choices]:
+        logger.error("Unrecognised preference: %s", feedback_paths)
+
+    # Need to associate the feedback submission status with the Adjudicator object
+    # directly to be passed onto AdjudicatorAllocation. Must use debateadj to assure
+    # the prefetch is available.
+    if hasattr(debateadj.debate.debateadjudicator_set.first(), 'submitted'):
+        for dadj in debateadj.debate.debateadjudicator_set.all():
+            dadj.adjudicator.submitted = dadj.submitted
+
     if debate is None:
         debate = debateadj.debate
     adjudicators = debate.adjudicators
@@ -48,9 +59,6 @@ def expected_feedback_targets(debateadj, feedback_paths=None, debate=None):
             targets = []
     else:
         targets = []
-
-    if feedback_paths not in ['all-adjs', 'with-p-on-c', 'minimal']:
-        logger.error("Unrecognised preference: %s", feedback_paths)
 
     return targets
 


### PR DESCRIPTION
This commit further reduces the width of the adjudicator selection in feedback forms by placing the round name as a grouping rather than inline.

Thinking of adding further information in whether feedback has already been provided, to avoid duplicates. This will come in a later commit.

Relates to #1352.3
Relates to #812