### PR TITLE
Unapprove translations when source changes

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -2,9 +2,11 @@ files: [
  {
   "source" : "/tabbycat/**/locale/en/LC_MESSAGES/*.po",
   "translation" : "/tabbycat/**/locale/%two_letters_code%/LC_MESSAGES/%original_file_name%",
+  "update_option" : "update_as_unapproved",
  },
  {
   "source" : "/docs/locale/en/LC_MESSAGES/**/*.po",
   "translation" : "/docs/locale/%two_letters_code%/LC_MESSAGES/**/%original_file_name%",
+  "update_option" : "update_as_unapproved",
  }
 ]


### PR DESCRIPTION
This commit sets Crowdin to merely un-approve translated strings if the source string changes, instead of removing the string.

This is important as strings may not need to be re-translated on regards of the English, like for terminology changes that may not affect other languages.