### PR TITLE
Revert "Add translated strings in 60827d"

### DIFF
--- a/tabbycat/locale/ar/LC_MESSAGES/djangojs.po
+++ b/tabbycat/locale/ar/LC_MESSAGES/djangojs.po
@@ -151,10 +151,6 @@ msgid "Uncategorised"
 msgstr ""
 
 #: checkins/templates/VenuesStatusMixin.vue:
-msgid "No Category"
-msgstr ""
-
-#: checkins/templates/VenuesStatusMixin.vue:
 msgid "Priority %1"
 msgstr ""
 

--- a/tabbycat/locale/es/LC_MESSAGES/djangojs.po
+++ b/tabbycat/locale/es/LC_MESSAGES/djangojs.po
@@ -151,10 +151,6 @@ msgid "Uncategorised"
 msgstr ""
 
 #: checkins/templates/VenuesStatusMixin.vue:
-msgid "No Category"
-msgstr ""
-
-#: checkins/templates/VenuesStatusMixin.vue:
 msgid "Priority %1"
 msgstr ""
 

--- a/tabbycat/locale/fr/LC_MESSAGES/djangojs.po
+++ b/tabbycat/locale/fr/LC_MESSAGES/djangojs.po
@@ -151,10 +151,6 @@ msgid "Uncategorised"
 msgstr "Non catégorisé"
 
 #: checkins/templates/VenuesStatusMixin.vue:
-msgid "No Category"
-msgstr ""
-
-#: checkins/templates/VenuesStatusMixin.vue:
 msgid "Priority %1"
 msgstr "Priorité %1"
 


### PR DESCRIPTION
This reverts commit 0f2fd96c60eba02117c481aeb1a18d2013ca5659.

It is important to only update the English source file for translations as to not incur merge conflicts on `l10n_develop`.