### PR TITLE
Remove superfluous semi-colon

### DIFF
--- a/tabbycat/templates/graphs/BallotsGraph.vue
+++ b/tabbycat/templates/graphs/BallotsGraph.vue
@@ -85,7 +85,7 @@ function initChart (padding, data, total, setHeight) {
     .attr('transform', `translate(0,${height})`)
     .call(d3.axisBottom(x).tickFormat(d3.timeFormat('%H:%M')))
 
-  const yAxisTicks = y.ticks().filter(tick => Number.isInteger(tick));
+  const yAxisTicks = y.ticks().filter(tick => Number.isInteger(tick))
   g.append('g')
     .attr('class', 'axis axis--y')
     .call(d3.axisLeft(y).tickValues(yAxisTicks).tickFormat(d3.format('d')))


### PR DESCRIPTION
From my previous patch; the lint error didn't show up in testing.

I'm just too used to semi-colons!