### PR TITLE
API: Add extra steps to object creation

### DIFF
--- a/tabbycat/participants/admin.py
+++ b/tabbycat/participants/admin.py
@@ -132,7 +132,7 @@ class TeamAdmin(admin.ModelAdmin):
 
     def formfield_for_choice_field(self, db_field, request, **kwargs):
         if db_field.name == 'emoji' and kwargs.get("initial") is None:
-            kwargs["initial"] = pick_unused_emoji()
+            kwargs["initial"] = pick_unused_emoji()[0]
         return super().formfield_for_choice_field(db_field, request, **kwargs)
 
     def formfield_for_manytomany(self, db_field, request, **kwargs):

--- a/tabbycat/participants/emoji.py
+++ b/tabbycat/participants/emoji.py
@@ -29,7 +29,7 @@ def pick_unused_emoji():
     no emoji are left, it returns `None`."""
     from .models import Team
     used_emoji = Team.objects.filter(emoji__isnull=False).values_list('emoji', flat=True)
-    unused_emoji = [e[0] for e in EMOJI_RANDOM_OPTIONS if e[0] not in used_emoji]
+    unused_emoji = [e for e in EMOJI_RANDOM_OPTIONS if e[0] not in used_emoji]
 
     try:
         return random.choice(unused_emoji)


### PR DESCRIPTION
Instead of directly creating objects within the create() methods of model serializers, this commit changes to use the super-class method, or to defer to the proper serializer (for speakers in teams).

These methods are now also used to implement creation procedures, such as adding the home institution conflict, setting code name/emoji if not set, and adding general break categories.

In addition, more fields have been added to adjudicators.