### PR TITLE
Simplify database row count query

### DIFF
--- a/tabbycat/utils/mixins.py
+++ b/tabbycat/utils/mixins.py
@@ -107,8 +107,8 @@ class WarnAboutDatabaseUseMixin(ContextMixin):
 
     def get_database_row_count(self):
         cursor = connection.cursor()
-        cursor.execute("SELECT schemaname,relname,n_live_tup FROM pg_stat_user_tables ORDER BY n_live_tup DESC;")
-        return sum([row[2] for row in cursor.fetchall()])
+        cursor.execute("SELECT SUM(n_live_tup) FROM pg_stat_user_tables;")
+        return cursor.fetchone()[0]
 
     def get_context_data(self, **kwargs):
         if 'DATABASE_URL' in os.environ and self.request.user.is_authenticated:


### PR DESCRIPTION
The query to find the number of rows in the database (warn against limited database plans) had extra information and handling, which is not needed for the task. This commit changes the query to directly take the sum of the live tuples, without fetching the names or ordering.

The summation is no longer handled by Python either.