### PR TITLE
Re-implement debate postponement

### DIFF
--- a/tabbycat/draw/models.py
+++ b/tabbycat/draw/models.py
@@ -20,7 +20,7 @@ class DebateManager(models.Manager):
 
 class Debate(models.Model):
     STATUS_NONE = 'N'
-    STATUS_POSTPONED = 'P' # obsolete
+    STATUS_POSTPONED = 'P'
     STATUS_DRAFT = 'D'
     STATUS_CONFIRMED = 'C'
     STATUS_CHOICES = (

--- a/tabbycat/results/templates/ResultsStats.vue
+++ b/tabbycat/results/templates/ResultsStats.vue
@@ -31,6 +31,11 @@
                  data-toggle="tooltip" :title="statuses.draft + ' ' + gettext('Unconfirmed')">
               <i data-feather="circle"></i>&nbsp;&nbsp;{{ statuses.draft }}
             </div>
+            <div class="progress-bar bg-warning" role="progressbar"
+                 :style="{ width: statusWidths.postponed }"
+                 data-toggle="tooltip" :title="statuses.postponed + ' ' + gettext('Postponed')">
+              <i data-feather="check"></i>&nbsp;&nbsp;{{ statuses.postponed }}
+            </div>
             <div class="progress-bar bg-success" role="progressbar"
                  :style="{ width: statusWidths.confirmed }"
                  data-toggle="tooltip" :title="statuses.confirmed + ' ' + gettext('Confirmed')">
@@ -66,6 +71,7 @@ export default {
       return {
         none: this.widthForType(this.statuses.none, this.statuses),
         draft: this.widthForType(this.statuses.draft, this.statuses),
+        postponed: this.widthForType(this.statuses.postponed, this.statuses),
         confirmed: this.widthForType(this.statuses.confirmed, this.statuses),
       }
     },

--- a/tabbycat/results/templates/ResultsTablesContainer.vue
+++ b/tabbycat/results/templates/ResultsTablesContainer.vue
@@ -95,6 +95,7 @@ export default {
       return {
         none: this.sumForType(this.debates, 'status', 'N'),
         draft: this.sumForType(this.debates, 'status', 'D'),
+        postponed: this.sumForType(this.debates, 'status', 'P'),
         confirmed: this.sumForType(this.debates, 'status', 'C'),
       }
     },

--- a/tabbycat/results/templates/debate_postponement_form.html
+++ b/tabbycat/results/templates/debate_postponement_form.html
@@ -1,0 +1,11 @@
+{% load debate_tags i18n %}
+{% if debate.result_status == debate.STATUS_POSTPONED %}
+  {% trans "Postponed" %}
+{% else %}
+  <form method="POST" action="{% roundurl 'results-postpone-debate' debate.round debate.id %}" class='text-secondary'>
+    {% csrf_token %}
+    <button type="submit" class="btn btn-link text-muted p-0">
+      <small>{% trans "Postpone" %}</small>
+    </button>
+  </form>
+{% endif %}

--- a/tabbycat/results/urls_admin.py
+++ b/tabbycat/results/urls_admin.py
@@ -8,6 +8,11 @@ urlpatterns = [
         views.AdminResultsEntryForRoundView.as_view(),
         name='results-round-list'),
 
+    # Inline Actions
+    path('round/<int:round_seq>/postpone/<int:debate_id>/',
+        views.PostponeDebateView.as_view(),
+        name='results-postpone-debate'),
+
     # Ballots
     path('ballots/<int:pk>/edit/',
         views.AdminEditBallotSetView.as_view(),

--- a/tabbycat/results/utils.py
+++ b/tabbycat/results/utils.py
@@ -20,6 +20,8 @@ def get_status_meta(debate):
         return "circle", "text-info", 2, _("Ballot is Unconfirmed")
     elif debate.result_status == Debate.STATUS_CONFIRMED:
         return "check", "text-success", 3, _("Ballot is Confirmed")
+    elif debate.result_status == Debate.STATUS_POSTPONED:
+        return "pause", "", 4, _("Debate was Postponed")
     else:
         raise ValueError('Debate has no discernable status')
 

--- a/tabbycat/tournaments/mixins.py
+++ b/tabbycat/tournaments/mixins.py
@@ -236,11 +236,7 @@ class RoundMixin(RoundFromUrlMixin, TournamentMixin):
         # Override if self.round_redirect_pattern_name is specified,
         # otherwise just pass down the chain
         if self.round_redirect_pattern_name:
-            try:
-                return reverse_round(self.round_redirect_pattern_name,
-                                     self.round, args=args, kwargs=kwargs)
-            except NoReverseMatch:
-                pass
+            return reverse_round(self.round_redirect_pattern_name, self.round, args=args, kwargs=kwargs)
         return super().get_redirect_url(*args, **kwargs)
 
 

--- a/tabbycat/utils/tables.py
+++ b/tabbycat/utils/tables.py
@@ -2,6 +2,7 @@ import logging
 import warnings
 
 from django.contrib.humanize.templatetags.humanize import ordinal
+from django.template.loader import render_to_string
 from django.utils.encoding import force_text
 from django.utils.translation import gettext as _
 from django.utils.translation import ngettext
@@ -936,6 +937,11 @@ class TabbycatTableBuilder(BaseTableBuilder):
             } for i in range(1, len(side_abbrs)+1)]
 
         self.add_columns(results_header, results_data)
+
+    def add_debate_postponement_column(self, debates):
+        col_data = [render_to_string('debate_postponement_form.html', {'debate': d}) for d in debates]
+        header = {'key': 'postpone', 'title': _("Postpone")}
+        self.add_column(header, col_data)
 
     def add_standings_results_columns(self, standings, rounds, show_ballots):
 


### PR DESCRIPTION
In brief, debate postponement is to signal that a ballot should get re-checked or is not vital to the creation of the next round, and so you can advance to the next round with postponed debates.

Debates can be postponed with or without a ballot; to postpone without results, each debate will have a button on the results page in order to postpone the debate. They can only be un-postponed by adding results, and in the assistant view, it is automatic. The button will work if there are results, as the status could be used to indicate that the ballot should be re-checked.

Postponing a debate activates the ballot status consumer, which updates the table.

A similar feature was previously available with divisions, but was recently removed.

Fixes #534, with this change as a necessary "guard."
Fixes #1283

Not quite ready; want to make the table buttons update with the consumer, similarly to the icons.