### PR TITLE
Add selectors for adjudicator positions in draw emails

### DIFF
--- a/tabbycat/motions/views.py
+++ b/tabbycat/motions/views.py
@@ -12,7 +12,7 @@ from notifications.views import RoleColumnMixin, RoundTemplateEmailCreateView
 from participants.models import Speaker
 from tournaments.mixins import (CurrentRoundMixin, OptionalAssistantTournamentPageMixin,
                                 PublicTournamentPageMixin, RoundMixin, TournamentMixin)
-from utils.misc import redirect_round, reverse_round
+from utils.misc import redirect_round
 from utils.mixins import AdministratorMixin
 from utils.views import ModelFormSetView, PostOnlyRedirectView
 
@@ -152,8 +152,7 @@ class EmailMotionReleaseView(RoleColumnMixin, RoundTemplateEmailCreateView):
     subject_template = 'motion_email_subject'
     message_template = 'motion_email_message'
 
-    def get_success_url(self):
-        return reverse_round('draw-display', self.round)
+    round_redirect_pattern_name = 'draw-display'
 
     def get_default_send_queryset(self):
         return Speaker.objects.filter(team__round_availabilities__round=self.round, email__isnull=False).exclude(email__exact="")

--- a/tabbycat/participants/views.py
+++ b/tabbycat/participants/views.py
@@ -165,8 +165,7 @@ class EmailTeamRegistrationView(TournamentTemplateEmailCreateView):
     subject_template = 'team_email_subject'
     message_template = 'team_email_message'
 
-    def get_success_url(self):
-        return reverse_tournament('participants-list', self.tournament)
+    tournament_redirect_pattern_name = 'participants-list'
 
     def get_queryset(self):
         return Speaker.objects.filter(team__tournament=self.tournament).select_related('team').prefetch_related('team__speaker_set')

--- a/tabbycat/privateurls/views.py
+++ b/tabbycat/privateurls/views.py
@@ -147,8 +147,7 @@ class EmailRandomisedUrlsView(RoleColumnMixin, TournamentTemplateEmailCreateView
     subject_template = 'url_email_subject'
     message_template = 'url_email_message'
 
-    def get_success_url(self):
-        return reverse_tournament('privateurls-list', self.tournament)
+    tournament_redirect_pattern_name = 'privateurls-list'
 
     def get_extra(self):
         extra = super().get_extra()

--- a/tabbycat/standings/views.py
+++ b/tabbycat/standings/views.py
@@ -18,7 +18,7 @@ from participants.models import Speaker, SpeakerCategory, Team
 from results.models import SpeakerScore, TeamScore
 from tournaments.mixins import PublicTournamentPageMixin, RoundMixin, SingleObjectFromTournamentMixin, TournamentMixin
 from tournaments.models import Round
-from utils.misc import reverse_round, reverse_tournament
+from utils.misc import reverse_tournament
 from utils.mixins import AdministratorMixin
 from utils.tables import TabbycatTableBuilder
 from utils.views import VueTableTemplateView
@@ -676,8 +676,7 @@ class EmailTeamStandingsView(RoundTemplateEmailCreateView):
     subject_template = 'team_points_email_subject'
     message_template = 'team_points_email_message'
 
-    def get_success_url(self):
-        return reverse_round('tournament-complete-round-check', self.round)
+    round_redirect_pattern_name = 'tournament-complete-round-check'
 
     def get_queryset(self):
         return Speaker.objects.filter(team__tournament=self.tournament)


### PR DESCRIPTION
This commit adds three selectors in the Email Adjudicators' Draw view, for chairs/panellists/trainees, which can be used to give different instructions to these classes. To do so, type "type" in the checkboxes has been generalized.

In addition, the `get_success_url()` has been simplified to just the pattern with the `get_redirect_url()` of the Tournament/Round mixins doing the rest.