### PR TITLE
Remove URL parameter from team draw emails

### DIFF
--- a/tabbycat/notifications/utils.py
+++ b/tabbycat/notifications/utils.py
@@ -254,7 +254,7 @@ def team_speaker_email_generator(to, tournament_id):
     return emails
 
 
-def team_draw_email_generator(to, url, round_id):
+def team_draw_email_generator(to, round_id):
     emails = []
     round = Round.objects.get(id=round_id)
     tournament = round.tournament


### PR DESCRIPTION
Caused a TypeError when trying to send as URL was not in the "extra" fields. Removed the URL field entirely as it is less useful to teams than for adjudicators and it wasn't listed as available in the docs to begin with.