### PR TITLE
Re-order error reporting venues

### DIFF
--- a/tabbycat/templates/500.html
+++ b/tabbycat/templates/500.html
@@ -18,9 +18,9 @@
 
   <div class="alert alert-warning mt-3" id="error-reporting" style="display: none;">
       <strong>Tab Directors:</strong>
-      If you're running this on Heroku, an error report has been sent to the developers of Tabbycat (unless you've disabled this or are running Tabbykitten). If you encounter this error repeatedly, please let us know by
+      If you're running this on Heroku, an error report has been sent to the developers of Tabbycat (unless you've disabled this or are running Tabbykitten). If you encounter this error repeatedly, please let us know by posting in our <a href="https://www.facebook.com/groups/tabbycat.debate/">Facebook group</a> (preferred) or by
       <a id="report-link" href="https://github.com/TabbycatDebate/tabbycat/issues/new/?title=Internal%20server%20error%20report&body=I%20hit%20an%20internal%20server%20error%20while%20trying%20to%20load%20this%20URL:%0A[please%20copy%20and%20paste%20the%20URL%20of%20the%20page%20here]%0A%0APlease%20describe%20what%20you%20were%20doing%20when%20the%20error%20happened,%20along%20with%20any%20other%20useful%20information:%0A&labels=error-report">
-      opening an issue on GitHub</a> (preferred) or by posting in our <a href="https://www.facebook.com/groups/tabbycat.debate/">Facebook group</a>, and we'll try our best to assist. Please be sure to include the URL of this page <span id="page-url"></span> in your post.
+      opening an issue on GitHub</a>, and we'll try our best to assist. Please be sure to include the URL of this page <span id="page-url"></span> in your post.
   </div>
 
   <script>


### PR DESCRIPTION
When a 500 (Internal Server) Error occurs, a page is displayed prompting
users to report the problem. It includes an order of precedence for the
best place to report. However, the specialities of the services are not
and cannot really be exposed for self-triage. Whereas GitHub tasks are
more for code issues, the Facebook group is more general. As non-code
(like hosting problems) are more common, the Facebook group should be
preferred.