### PR TITLE
Add sort property to break eligibility table

### DIFF
--- a/tabbycat/breakqual/views.py
+++ b/tabbycat/breakqual/views.py
@@ -302,6 +302,7 @@ class EditTeamEligibilityView(AdministratorMixin, TournamentMixin, VueTableTempl
         for sc in speaker_categories:
             table.add_column({'title': _('%s Speakers') % sc.name, 'key': sc.name}, [{
                 'text': getattr(team, 'nspeakers_%s' % sc.slug, 'N/A'),
+                'sort': getattr(team, 'nspeakers_%s' % sc.slug, 0),
                 'tooltip': ngettext(
                     'Team has %(nspeakers)s speaker with the %(category)s speaker category assigned',
                     'Team has %(nspeakers)s speakers with the %(category)s speaker category assigned',


### PR DESCRIPTION
For the number of speakers in categories per team, the text is stored as text, which may get sorted incorrectly. An integer is used with the new specific 'sort' property of the cells in the columns.

Should fix #1469.