### PR TITLE
Include round and room as ballot subtitle

### DIFF
--- a/tabbycat/results/templates/public_enter_results.html
+++ b/tabbycat/results/templates/public_enter_results.html
@@ -10,12 +10,6 @@
 {% endblocktrans %}{% endblock %}
 {% block extra-head %}<meta name="robots" content="noindex" />{% endblock %}
 
-{% block sub-title %}
-  {% blocktrans trimmed with round=debate.round.name room=debate.venue.display_name %}
-    {{ round }} @ {{ room }}
-  {% endblocktrans %}
-{% endblock %}
-
 {% block page-alerts %}
 
   {% if form.scoresheets|length > 1 %}

--- a/tabbycat/results/views.py
+++ b/tabbycat/results/views.py
@@ -247,6 +247,10 @@ class BaseBallotSetView(LogActionMixin, TournamentMixin, FormView):
             kwargs['debate_name'] = _(" vs ").join(self.debate.get_team(side).short_name for side in sides)
         else:
             kwargs['debate_name'] = _(" vs ").join(self.debate.get_team(side).code_name for side in sides)
+        kwargs['page_subtitle'] = _("%(round)s @ %(room)s") % {
+            'round': self.debate.round.name,
+            'room': getattr(self.debate.venue, 'display_name', _("N/A")),
+        }
 
         kwargs['iron'] = self.debate.debateteam_set.annotate(iron=Count('team__debateteam__speakerscore',
             filter=Q(team__debateteam__debate__round=self.debate.round.prev) & Q(team__debateteam__speakerscore__ghost=True),


### PR DESCRIPTION
To mirror the public ballot submission page showing that information.

Resolves #1472.