### PR TITLE
Specify sets of keys in results assertions

### DIFF
--- a/tabbycat/results/result.py
+++ b/tabbycat/results/result.py
@@ -463,8 +463,8 @@ class VotingDebateResult(BaseDebateResultWithSpeakers):
 
     def assert_loaded(self):
         super().assert_loaded()
-        assert set(self.debate.adjudicators.voting()) == set(self.scoresheets)
-        assert set(self.debateadjs) == set(self.scoresheets)
+        assert set(self.debate.adjudicators.voting()) == set(self.scoresheets.keys())
+        assert set(self.debateadjs.keys()) == set(self.scoresheets.keys())
         assert self.sides == ['aff', 'neg'], "VotingDebateResult can only be used for two-team formats."
 
     def is_complete(self):


### PR DESCRIPTION
When asserting a DebateResult is loaded, sets are created to determine the equality of all components. However, sets of elements of dicts cannot be the same as for lists (without each element a 2-tuple). It should only test the keys of the dicts. This commit resolves this confusion.

One of the problems mentioned in #1471.

Closes BACKEND-39C
Closes BACKEND-397