### PR TITLE
Update deploy_heroku.py script

### DIFF
--- a/deploy_heroku.py
+++ b/deploy_heroku.py
@@ -62,6 +62,8 @@ config_group.add_argument("--tab-cache-timeout", type=int, default=None, metavar
                           help="Set the tab page cache timeout to TIMEOUT")
 config_group.add_argument("--enable-debug", action="store_true", default=False,
                           help="Enable Django debug pages")
+config_group.add_argument("--time-zone", type=str, default="Australia/Melbourne",
+                          help="Time zone name from the IANA tz database")
 
 # Import tournament arguments are copied from importtournament.py, and should be
 # updated when these options in importtournament.py change.
@@ -171,12 +173,12 @@ heroku_url = match.group(2)
 
 # Add the redis add-ons (the heroku one needs a config flag)
 run_heroku_command(["addons:create", "heroku-redis:hobby-dev",
-                    "--maxmemory_policy", "allkeys-lru"])
+                    "--maxmemory_policy", "allkeys-lru", "--timeout", "1800"])
 
 # Set build packs
 run_heroku_command(["buildpacks:set", "https://github.com/heroku/heroku-buildpack-nginx.git"])
-run_heroku_command(["buildpacks:add", "--index", "1", "heroku/nodejs"])
-run_heroku_command(["buildpacks:add", "--index", "2", "heroku/python"])
+run_heroku_command(["buildpacks:add", "heroku/nodejs"])
+run_heroku_command(["buildpacks:add", "heroku/python"])
 
 # Set config variables
 secret_key = get_random_secret_key()
@@ -188,6 +190,8 @@ if args.slow_cache_timeout:
     command.append("PUBLIC_SLOW_CACHE_TIMEOUT=%d" % args.slow_cache_timeout)
 if args.tab_cache_timeout:
     command.append("TAB_PAGES_CACHE_TIMEOUT=%d" % args.tab_cache_timeout)
+if args.time_zone:
+    command.append("TIME_ZONE=%s" % args.time_zone)
 
 run_heroku_command(command)
 


### PR DESCRIPTION
* Removes the explicit ordering of buildpacks. I _think_ we used to specify order because the buildpacks would be added at the top. It appears Heroku has updated this so that it adds buildpacks at the bottom (which I find more intuitive), and also because indexing starts from 1, the current script ends up having them in the order: [nodejs, python, nginx], while the app.json file has [nginx, nodejs, python]. As far as I can tell, it doesn't seem to make a difference. Did it use to?
* Adds timeout argument for Heroku Redis
* Adds time zone argument

Mostly I'd like feedback on the buildpack ordering before merging.