### PR TITLE
Re-work conditionals for names in registration card

### DIFF
--- a/tabbycat/participants/templates/team_registration_card.html
+++ b/tabbycat/participants/templates/team_registration_card.html
@@ -9,17 +9,19 @@
       </h4>
     </div>
 
-    {% if not use_code_names and team.short_name != team.long_name %}
+    {% with show_codes=team.code_name and pref.team_code_names != 'off' show_names=not use_code_names and team.short_name != team.long_name %}
       <div class="list-group-item">
-        <strong>{% if participant %}{% trans "Team name:" %}{% else %}{% trans "Full name:" %}{% endif %}</strong>
-        {{ team.long_name }}
-        {% if not use_code_names and team.code_name and pref.team_code_names != 'off' %}
+        {% if private_url or admin_page or show_names %}
+          <strong>{% if participant %}{% trans "Team name:" %}{% else %}{% trans "Full name:" %}{% endif %}</strong>
+          {{ team.long_name }} {% if pref.show_emoji and not show_codes %}({{ team.emoji }}){% endif %}
+        {% endif %}
+        {% if show_codes %}
           <br />
           <strong>{% trans "Code name:" %}</strong>
           {{ team.code_name }} {% if pref.show_emoji %}({{ team.emoji }}){% endif %}
         {% endif %}
       </div>
-    {% endif %}
+    {% endwith %}
 
     {% if pref.show_speakers_in_draw %}
       <div class="list-group-item">


### PR DESCRIPTION
There's no harm in showing the full name if the short name is shown, even when identical. That conditional is thus removed. Thus, it should show on private URL pages.

If one of the names cannot be shown, the emoji should be moved to the full name to still be shown.