### PR TITLE
Remove duplicate institution name

### DIFF
--- a/tabbycat/utils/tables.py
+++ b/tabbycat/utils/tables.py
@@ -543,8 +543,8 @@ class TabbycatTableBuilder(BaseTableBuilder):
                     adj_str = "<strong>" + adj_str + "</strong>"
                 adj_str += '</span>'
                 adjs_list.append(adj_str)
-            return "<div class='clearfix pt-1 pb-1 d-block d-md-none'> \
-                    </div><span class='d-none d-md-inline'>, </span>".join(adjs_list)
+            return ("<div class='clearfix pt-1 pb-1 d-block d-md-none'> "
+                    "</div><span class='d-none d-md-inline'>, </span>").join(adjs_list)
 
         def construct_popover(adjs_data):
             popover_data = []
@@ -552,12 +552,9 @@ class TabbycatTableBuilder(BaseTableBuilder):
                 descriptors = []
                 if a['position'] != AdjudicatorAllocation.POSITION_ONLY:
                     descriptors.append(self.ADJ_POSITION_NAMES[a['position']])
-                if a['adj'].institution is not None and (
-                        self.admin or self.tournament.pref('show_adjudicator_institutions')):
+                if (for_admin or self.tournament.pref('show_adjudicator_institutions')) and \
+                        a['adj'].institution is not None:
                     descriptors.append(a['adj'].institution.code)
-                if for_admin or self.tournament.pref('show_adjudicator_institutions'):
-                    if a['adj'].institution is not None:
-                        descriptors.append(a['adj'].institution.code)
                 if a.get('split', False):
                     descriptors.append("<span class='text-danger'>" + _("in minority") + "</span>")
                 text = a['adj'].name


### PR DESCRIPTION
This removes three lines added in https://github.com/TabbycatDebate/tabbycat/commit/bd1d7231a569ae9afc7ce5ff6e35f8e93c74f010#diff-39d5e7bd3528e2f207017c56d7c13024R558-R560, which I believe seem to cause adjudicator institutions appear twice:
![image](https://user-images.githubusercontent.com/1725499/85191935-93deee80-b275-11ea-9f6c-05c7336f56dc.png)

@philipbelesky, just checking I haven't missed anything / this doesn't mess up the work to expand the "show adjudicator institutions" option before?