### PR TITLE
Move post-compile script to release tasks

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -5,3 +5,4 @@
 
 web: honcho -f ProcfileMulti start
 worker: python manage.py runworker notifications adjallocation venues
+release: bash bin/release-tasks.sh

--- a/bin/release-tasks.sh
+++ b/bin/release-tasks.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-echo "-----> I'm post-compile hook"
+echo "-----> I'm the release tasks script"
 cd ./tabbycat/
 
 echo "-----> Running database migration"
@@ -17,4 +17,4 @@ npm run build
 echo "-----> Running static files compilation"
 python manage.py collectstatic --noinput -v 0
 
-echo "-----> Post-compile done"
+echo "-----> Release tasks done"


### PR DESCRIPTION
See:
https://devcenter.heroku.com/articles/release-phase#specifying-release-phase-tasks
https://help.heroku.com/GDQ74SU2/django-migrations

This currently fails due to an npm thing, I don't know if @philipbelesky could take a guess as to why? It runs at a different time to when the post-compile hook ran (it runs after the release is "done", not before), so I imagine that might be having an impact, or maybe it's getting confused about where the `node_modules` directory is. 🤔