### PR TITLE
Partially rework record pages

### DIFF
--- a/tabbycat/participants/admin.py
+++ b/tabbycat/participants/admin.py
@@ -117,7 +117,7 @@ class TeamAdmin(admin.ModelAdmin):
     form = TeamForm
     list_display = ('long_name', 'short_name', 'emoji', 'institution',
                     'tournament')
-    search_fields = ('reference', 'short_name', 'institution__name',
+    search_fields = ('reference', 'short_name', 'code_name', 'institution__name',
                      'institution__code', 'tournament__name')
     list_filter = ('tournament', 'institution', 'break_categories')
     inlines = (SpeakerInline, TeamSideAllocationInline, VenueConstraintInline,

--- a/tabbycat/participants/templates/adjudicator_registration_card.html
+++ b/tabbycat/participants/templates/adjudicator_registration_card.html
@@ -22,7 +22,7 @@
     {% endif %}
 
     {% if pref.show_adjudicator_institutions or admin_page or private_url %}
-      <div class="list-group-item">
+      <div class="list-group-item {% if not pref.show_adjudicator_institutions %}list-group-item-dark{% endif %}">
         <div>
           <strong>{% trans "Institution:" %}</strong>
           {% if adjudicator.institution %}
@@ -45,7 +45,7 @@
     {% endif %}
 
     {% if admin_page %}
-      <div class="list-group-item">
+      <div class="list-group-item list-group-item-dark">
         <div>
           <strong>{% trans "Institutional Conflicts:" %}</strong>
           {% for ic in adjudicator.adjudicatorinstitutionconflict_set.all %}
@@ -76,7 +76,7 @@
         </div>
       </div>
 
-      <div class="list-group-item">
+      <div class="list-group-item list-group-item-dark">
         <strong>{% trans "Room Constraints:" %}</strong>
         {% for vc in adjudicator.venue_constraints.all %}
           {{ vc.category }}{% if not forloop.last %}{% trans ", " %}{% endif %}

--- a/tabbycat/participants/templates/adjudicator_registration_card.html
+++ b/tabbycat/participants/templates/adjudicator_registration_card.html
@@ -51,7 +51,7 @@
           {% for ic in adjudicator.adjudicatorinstitutionconflict_set.all %}
             {{ ic.institution.name }}{% if not forloop.last %}{% trans "; " %}{% endif %}
           {% empty %}
-            <span class="text-muted">{% trans "None" %}</span>
+            {% trans "None" %}
           {% endfor %}
         </div>
         <div>
@@ -59,7 +59,7 @@
           {% for tc in adjudicator.adjudicatorteamconflict_set.all %}
             {% team_record_link tc.team admin_page tournament False %}{% if not forloop.last %}{% trans ", " %}{% endif %}
           {% empty %}
-            <span class="text-muted">{% trans "None" %}</span>
+            {% trans "None" %}
           {% endfor %}
         </div>
         <div>
@@ -71,7 +71,7 @@
               {{ adj.name }}{% if not forloop.last %}{% trans ", " %}{% endif %}
             {% endif %}
           {% empty %}
-            <span class="text-muted">{% trans "None" %}</span>
+            {% trans "None" %}
           {% endfor %}
         </div>
       </div>
@@ -81,7 +81,7 @@
         {% for vc in adjudicator.venue_constraints.all %}
           {{ vc.category }}{% if not forloop.last %}{% trans ", " %}{% endif %}
         {% empty %}
-          <span class="text-muted">{% trans "None" %}</span>
+          {% trans "None" %}
         {% endfor %}
       </div>
 

--- a/tabbycat/participants/templates/adjudicator_registration_card.html
+++ b/tabbycat/participants/templates/adjudicator_registration_card.html
@@ -23,16 +23,19 @@
 
     {% if pref.show_adjudicator_institutions or admin_page or private_url %}
       <div class="list-group-item">
-        <strong>{% trans "Institution:" %}</strong>
-        {% if adjudicator.institution %}
-          {{ adjudicator.institution.name }}
-        {% else %}
-          <span class="text-muted">{% trans "Unaffiliated" %}</span>
-        {% endif %}
+        <div>
+          <strong>{% trans "Institution:" %}</strong>
+          {% if adjudicator.institution %}
+            {{ adjudicator.institution.name }}
+          {% else %}
+            <span class="text-muted">{% trans "Unaffiliated" %}</span>
+          {% endif %}
+        </div>
         {% if adjudicator.institution.region %}
-          <br />
-          <strong>{% trans "Region:" %}</strong>
-          {{ adjudicator.institution.region.name }}
+          <div>
+            <strong>{% trans "Region:" %}</strong>
+            {{ adjudicator.institution.region.name }}
+          </div>
         {% endif %}
       </div>
     {% else %}
@@ -43,22 +46,24 @@
 
     {% if admin_page %}
       <div class="list-group-item">
-
+        <div>
           <strong>{% trans "Institutional Conflicts:" %}</strong>
           {% for ic in adjudicator.adjudicatorinstitutionconflict_set.all %}
             {{ ic.institution.name }}{% if not forloop.last %}{% trans "; " %}{% endif %}
           {% empty %}
             <span class="text-muted">{% trans "None" %}</span>
           {% endfor %}
-
-          <strong><br>{% trans "Team Conflicts:" %}</strong>
+        </div>
+        <div>
+          <strong>{% trans "Team Conflicts:" %}</strong>
           {% for tc in adjudicator.adjudicatorteamconflict_set.all %}
             {% team_record_link tc.team admin_page tournament False %}{% if not forloop.last %}{% trans ", " %}{% endif %}
           {% empty %}
             <span class="text-muted">{% trans "None" %}</span>
           {% endfor %}
-
-          <strong><br>{% trans "Adjudicator Conflicts:" %}</strong>
+        </div>
+        <div>
+          <strong>{% trans "Adjudicator Conflicts:" %}</strong>
           {% for adj in adjadj_conflicts %}
             {% if pref.public_record %}
               <a href="{% adj_record_link adj admin_page tournament %}">{{ adj.name }}</a>{% if not forloop.last %}{% trans ", " %}{% endif %}
@@ -68,7 +73,7 @@
           {% empty %}
             <span class="text-muted">{% trans "None" %}</span>
           {% endfor %}
-
+        </div>
       </div>
 
       <div class="list-group-item">

--- a/tabbycat/participants/templates/adjudicator_registration_card.html
+++ b/tabbycat/participants/templates/adjudicator_registration_card.html
@@ -22,7 +22,7 @@
     {% endif %}
 
     {% if pref.show_adjudicator_institutions or admin_page or private_url %}
-      <div class="list-group-item {% if not pref.show_adjudicator_institutions %}list-group-item-dark{% endif %}">
+      <div class="list-group-item {% if not pref.show_adjudicator_institutions %}list-group-item-secondary{% endif %}">
         <div>
           <strong>{% trans "Institution:" %}</strong>
           {% if adjudicator.institution %}
@@ -45,7 +45,7 @@
     {% endif %}
 
     {% if admin_page %}
-      <div class="list-group-item list-group-item-dark">
+      <div class="list-group-item list-group-item-secondary">
         <div>
           <strong>{% trans "Institutional Conflicts:" %}</strong>
           {% for ic in adjudicator.adjudicatorinstitutionconflict_set.all %}
@@ -76,7 +76,7 @@
         </div>
       </div>
 
-      <div class="list-group-item list-group-item-dark">
+      <div class="list-group-item list-group-item-secondary">
         <strong>{% trans "Room Constraints:" %}</strong>
         {% for vc in adjudicator.venue_constraints.all %}
           {{ vc.category }}{% if not forloop.last %}{% trans ", " %}{% endif %}

--- a/tabbycat/participants/templates/current_round/common.html
+++ b/tabbycat/participants/templates/current_round/common.html
@@ -48,7 +48,7 @@
 
 {# Motions #}
 {% if pref.public_motions or admin_page %}
-  <div class="list-group-item">
+  <div class="list-group-item {% if not pref.public_motions or not current_round.motions_released %}list-group-item-dark{% endif %}">
     {% if current_round.motions_released or admin_page %}
       {% if not current_round.motions_released %}
         <em>{% trans "Motions are not released to public." %}</em><br />

--- a/tabbycat/participants/templates/current_round/round_adj.html
+++ b/tabbycat/participants/templates/current_round/round_adj.html
@@ -1,7 +1,7 @@
 {% load debate_tags participant_link i18n %}
 
 {# Position, teams and room #}
-<div class="list-group-item lead {% if draw_released %}active{% endif %}">
+<div class="list-group-item lead {% if draw_released %}active{% else %}list-group-item-dark{% endif %}">
 
   {# (Two-team formats) #}
   {% if pref.teams_in_debate == 'two' %}

--- a/tabbycat/participants/templates/current_round/round_team.html
+++ b/tabbycat/participants/templates/current_round/round_team.html
@@ -4,7 +4,7 @@
 
 {# (Two-team formats) #}
 {% if pref.teams_in_debate == 'two' %}
-  <div class="list-group-item lead {% if draw_released %}active{% endif %}">
+  <div class="list-group-item lead {% if draw_released %}active{% else %}list-group-item-dark{% endif %}">
   {% team_record_link debateteam.opponent.team admin_page tournament as opponent %}
 
   {% if debate.sides_confirmed %}
@@ -34,7 +34,7 @@
 {% elif pref.teams_in_debate == 'bp' %}
 
   {% if debate.sides_confirmed %}
-    <div class="list-group-item lead {% if draw_released %}active{% endif %}">
+    <div class="list-group-item {% if draw_released %}lead active{% else %}list-group-item-dark{% endif %}">
     {% if grammatical_person == "3" %}
       {% blocktrans trimmed with team=team_short_name side=debateteam.get_side_name room=debate.venue.display_name|default:venue_tba %}
         {{ team }} is debating as the <strong>{{ side }}</strong> team.
@@ -50,7 +50,7 @@
 {% endif %}
 
 {# Room #}
-<div class="list-group-item lead {% if draw_released %}active{% endif %}">
+<div class="list-group-item lead {% if draw_released %}active{% else %}list-group-item-dark{% endif %}">
   {% if grammatical_person == "3" %}
     {% if debate.venue.url %}
       {% blocktrans trimmed with team=team_short_name room=debate.venue.display_name|default:venue_tba url=debate.venue.url %}

--- a/tabbycat/participants/templates/feedback_progress_panel.html
+++ b/tabbycat/participants/templates/feedback_progress_panel.html
@@ -2,24 +2,24 @@
 {# This snippet is used as part of the team_record.html and adjudicator_record.html templates. #}
 
 
-<div class="card mt-3">
+<div class="card mt-4">
 
   <div class="list-group list-group-flush">
 
-    <div class="list-group-item">
+    <div class="list-group-item {% if not pref.feedback_progress %}list-group-item-secondary{% endif %}">
       <h4 class="card-title mb-0">{% trans "Feedback Returns" %}</h4>
     </div>
 
     {% for tracker in feedback_progress.trackers %}
       {% if tracker.fulfilled %}
-        <div class="list-group-item text-success">
+        <div class="list-group-item {% if not pref.feedback_progress %}list-group-item-secondary{% endif %} text-success">
           <span class="badge badge-secondary">{{ tracker.round.name }}</span>
           {% blocktrans trimmed with adjudicator=tracker.submission.adjudicator.name %}
             Has submitted feedback for <strong>{{ adjudicator }}</strong>
           {% endblocktrans %}
         </div>
       {% elif tracker.expected and tracker.count == 0 %}
-        <div class="list-group-item text-danger">
+        <div class="list-group-item {% if not pref.feedback_progress %}list-group-item-secondary{% endif %} text-danger">
           <span class="badge badge-secondary">{{ tracker.round.name }}</span>
           {% if tracker.acceptable_targets|length > 1 %}
             {% blocktrans trimmed with adjudicators=tracker.acceptable_target_names|join:", " %}
@@ -33,7 +33,7 @@
           {% endif %}
         </div>
       {% elif tracker.expected %}
-        <div class="list-group-item text-warning">
+        <div class="list-group-item {% if not pref.feedback_progress %}list-group-item-secondary{% endif %} text-warning">
           <span class="badge badge-secondary">{{ tracker.round.name }}</span>
           <i data-feather="info"></i>
           {% trans "More feedback submissions than expected for this debate:" %}
@@ -42,16 +42,15 @@
           {% endfor %}
         </div>
       {% else %} {# if not tracker.fulfilled and not tracker.expected #}
-        <div class="list-group-item text-warning">
+        <div class="list-group-item {% if not pref.feedback_progress %}list-group-item-secondary{% endif %} text-warning">
           <span class="badge badge-secondary">{{ tracker.round.name }}</span>
-          <i data-feather="info"></i>
           {% blocktrans trimmed with adjudicator=tracker.submission.adjudicator.name %}
             Unexpected feedback submission for <strong>{{ adjudicator }}</strong>
           {% endblocktrans %}
         </div>
       {% endif %}
     {% empty %}
-      <div class="list-group-item">
+      <div class="list-group-item {% if not pref.feedback_progress %}list-group-item-secondary{% endif %}">
         <em>{% blocktrans trimmed with name=participant_name %}
           {{ name }} doesn't have any feedback to submit.
         {% endblocktrans %}</em>

--- a/tabbycat/participants/templates/team_registration_card.html
+++ b/tabbycat/participants/templates/team_registration_card.html
@@ -55,7 +55,7 @@
         {% for speaker in team.speakers %}
           {{ speaker.name }}{% if not forloop.last %}{% trans ", " %}{% endif %}
         {% empty %}
-          <span class="text-muted">{% trans "None" %}</span>
+          {% trans "None" %}
         {% endfor %}
       </div>
     {% endif %}
@@ -67,7 +67,7 @@
           {% for category in team.break_categories.all %}
             {{ category.name }}{% if not forloop.last %}{% trans ", " %}{% endif %}
           {% empty %}
-            <span class="text-muted">{% trans "None" %}</span>
+            {% trans "None" %}
           {% endfor %}
         </div>
         {% if participant %}
@@ -76,7 +76,7 @@
             {% for category in participant.categories.all %}
               {{ category.name }}{% if not forloop.last %}{% trans ", " %}{% endif %}
             {% empty %}
-              <span class="text-muted">{% trans "None" %}</span>
+              {% trans "None" %}
             {% endfor %}
           </div>
         {% endif %}
@@ -110,7 +110,7 @@
           {% for ic in team.teaminstitutionconflict_set.all %}
             {{ ic.institution.name }}{% if not forloop.last %}{% trans "; " %}{% endif %}
           {% empty %}
-            <span class="text-muted">{% trans "None" %}</span>
+            {% trans "None" %}
           {% endfor %}
         </div>
 
@@ -119,7 +119,7 @@
           {% for ac in team.adjudicatorteamconflict_set.all %}
             {{ ac.adjudicator.name }}{% if not forloop.last %}{% trans ", " %}{% endif %}
           {% empty %}
-            <span class="text-muted">{% trans "None" %}</span>
+            {% trans "None" %}
           {% endfor %}
         </div>
 
@@ -130,7 +130,7 @@
         {% for vc in team.venue_constraints.all %}
           {{ vc.category }}{% if not forloop.last %}{% trans ", " %}{% endif %}
         {% empty %}
-          <span class="text-muted">{% trans "None" %}</span>
+          {% trans "None" %}
         {% endfor %}
       </div>
 

--- a/tabbycat/participants/templates/team_registration_card.html
+++ b/tabbycat/participants/templates/team_registration_card.html
@@ -10,17 +10,38 @@
     </div>
 
       <div class="list-group-item">
-        {% if not use_code_names and team.short_name != team.long_name or private_url or admin_page %}
-          <strong>{% if participant %}{% trans "Team name:" %}{% else %}{% trans "Full name:" %}{% endif %}</strong>
-          {{ team.long_name }}
-            {% if not team.code_name or pref.team_code_names == 'off' %}
-              {% if pref.show_emoji %}({{ team.emoji }}){% endif %}
-            {% endif %}
+        {% if not use_code_names or private_url or admin_page %}
+          {% if team.short_name == team.long_name %}
+            <div>
+              <strong>{% trans "Team name:" %}</strong>
+              {{ team.long_name }}
+            </div>
+          {% else %}
+            <div>
+              <strong>{% trans "Full team name:" %}</strong>
+              {{ team.long_name }}
+            </div>
+            <div>
+              <strong>{% trans "Short team name:" %}</strong>
+              {{ team.short_name }}
+            </div>
+          {% endif %}
         {% endif %}
-        {% if team.code_name and pref.team_code_names != 'off' %}
-          <br />
-          <strong>{% trans "Code name:" %}</strong>
-          {{ team.code_name }} {% if pref.show_emoji %}({{ team.emoji }}){% endif %}
+        {% if pref.team_code_names != 'off' %}
+          <div>
+            <strong>{% trans "Code name:" %}</strong>
+            {% if team.code_name %}
+              {{ team.code_name }}
+            {% else %}
+              <span class="text-muted">{% trans "No code name assigned" %}</span>
+            {% endif %}
+          </div>
+        {% endif %}
+        {% if pref.show_emoji %}
+          <div>
+            <strong>{% trans "Emoji:" %}</strong>
+            {{ team.emoji }}
+          </div>
         {% endif %}
       </div>
 
@@ -37,36 +58,42 @@
 
     {% if pref.public_break_categories or admin_page or private_url %}
       <div class="list-group-item">
-        <strong>{% trans "Eligible for break categories:" %}</strong>
-        {% for category in team.break_categories.all %}
-          {{ category.name }}{% if not forloop.last %}{% trans ", " %}{% endif %}
-        {% empty %}
-          <span class="text-muted">{% trans "None" %}</span>
-        {% endfor %}
-        {% if participant %}
-          <br />
-          <strong>{% trans "Speaker categories:" %}</strong>
-          {% for category in participant.categories.all %}
+        <div>
+          <strong>{% trans "Eligible for break categories:" %}</strong>
+          {% for category in team.break_categories.all %}
             {{ category.name }}{% if not forloop.last %}{% trans ", " %}{% endif %}
           {% empty %}
             <span class="text-muted">{% trans "None" %}</span>
           {% endfor %}
+        </div>
+        {% if participant %}
+          <div>
+            <strong>{% trans "Speaker categories:" %}</strong>
+            {% for category in participant.categories.all %}
+              {{ category.name }}{% if not forloop.last %}{% trans ", " %}{% endif %}
+            {% empty %}
+              <span class="text-muted">{% trans "None" %}</span>
+            {% endfor %}
+          </div>
         {% endif %}
       </div>
-    {% endif %} {# pref.public_break_categories or admin_page #}
+    {% endif %}
 
     {% if pref.show_team_institutions or admin_page or private_url %}
       <div class="list-group-item">
-        <strong>{% trans "Institution:" %}</strong>
-        {% if team.institution %}
-          {{ team.institution.name }}
-        {% else %}
-          <span class="text-muted">{% trans "Unaffiliated" %}</span>
-        {% endif %}
+        <div>
+          <strong>{% trans "Institution:" %}</strong>
+          {% if team.institution %}
+            {{ team.institution.name }}
+          {% else %}
+            <span class="text-muted">{% trans "Unaffiliated" %}</span>
+          {% endif %}
+        </div>
         {% if team.institution.region %}
-          <br />
-          <strong>{% trans "Region:" %}</strong>
-          {{ team.institution.region.name }}
+          <div>
+            <strong>{% trans "Region:" %}</strong>
+            {{ team.institution.region.name }}
+          </div>
         {% endif %}
       </div>
     {% endif %}
@@ -74,19 +101,23 @@
     {% if admin_page %}
       <div class="list-group-item">
 
-        <strong>{% trans "Institutional Conflicts:" %}</strong>
-        {% for ic in team.teaminstitutionconflict_set.all %}
-          {{ ic.institution.name }}{% if not forloop.last %}{% trans "; " %}{% endif %}
-        {% empty %}
-          <span class="text-muted">{% trans "None" %}</span>
-        {% endfor %}
+        <div>
+          <strong>{% trans "Institutional Conflicts:" %}</strong>
+          {% for ic in team.teaminstitutionconflict_set.all %}
+            {{ ic.institution.name }}{% if not forloop.last %}{% trans "; " %}{% endif %}
+          {% empty %}
+            <span class="text-muted">{% trans "None" %}</span>
+          {% endfor %}
+        </div>
 
-        <strong><br>{% trans "Adjudicator Conflicts:" %}</strong>
-        {% for ac in team.adjudicatorteamconflict_set.all %}
-          {{ ac.adjudicator.name }}{% if not forloop.last %}{% trans ", " %}{% endif %}
-        {% empty %}
-          <span class="text-muted">{% trans "None" %}</span>
-        {% endfor %}
+        <div>
+          <strong>{% trans "Adjudicator Conflicts:" %}</strong>
+          {% for ac in team.adjudicatorteamconflict_set.all %}
+            {{ ac.adjudicator.name }}{% if not forloop.last %}{% trans ", " %}{% endif %}
+          {% empty %}
+            <span class="text-muted">{% trans "None" %}</span>
+          {% endfor %}
+        </div>
 
       </div>
 

--- a/tabbycat/participants/templates/team_registration_card.html
+++ b/tabbycat/participants/templates/team_registration_card.html
@@ -57,7 +57,7 @@
     {% endif %}
 
     {% if pref.public_break_categories or admin_page or private_url %}
-      <div class="list-group-item">
+      <div class="list-group-item {% if not pref.public_break_categories %} list-group-item-dark{% endif %}">
         <div>
           <strong>{% trans "Eligible for break categories:" %}</strong>
           {% for category in team.break_categories.all %}
@@ -80,7 +80,7 @@
     {% endif %}
 
     {% if pref.show_team_institutions or admin_page or private_url %}
-      <div class="list-group-item">
+      <div class="list-group-item {% if not pref.show_team_institutions %} list-group-item-dark{% endif %}">
         <div>
           <strong>{% trans "Institution:" %}</strong>
           {% if team.institution %}
@@ -99,7 +99,7 @@
     {% endif %}
 
     {% if admin_page %}
-      <div class="list-group-item">
+      <div class="list-group-item list-group-item-dark">
 
         <div>
           <strong>{% trans "Institutional Conflicts:" %}</strong>
@@ -121,7 +121,7 @@
 
       </div>
 
-      <div class="list-group-item">
+      <div class="list-group-item list-group-item-dark">
         <strong>{% trans "Room Constraints:" %}</strong>
         {% for vc in team.venue_constraints.all %}
           {{ vc.category }}{% if not forloop.last %}{% trans ", " %}{% endif %}

--- a/tabbycat/participants/templates/team_registration_card.html
+++ b/tabbycat/participants/templates/team_registration_card.html
@@ -61,7 +61,7 @@
     {% endif %}
 
     {% if pref.public_break_categories or admin_page or private_url %}
-      <div class="list-group-item {% if not pref.public_break_categories %} list-group-item-dark{% endif %}">
+      <div class="list-group-item {% if not pref.public_break_categories %} list-group-item-secondary{% endif %}">
         <div>
           <strong>{% trans "Eligible for break categories:" %}</strong>
           {% for category in team.break_categories.all %}
@@ -84,7 +84,7 @@
     {% endif %}
 
     {% if pref.show_team_institutions or admin_page or private_url %}
-      <div class="list-group-item {% if not pref.show_team_institutions %} list-group-item-dark{% endif %}">
+      <div class="list-group-item {% if not pref.show_team_institutions %} list-group-item-secondary{% endif %}">
         <div>
           <strong>{% trans "Institution:" %}</strong>
           {% if team.institution %}
@@ -103,7 +103,7 @@
     {% endif %}
 
     {% if admin_page %}
-      <div class="list-group-item list-group-item-dark">
+      <div class="list-group-item list-group-item-secondary">
 
         <div>
           <strong>{% trans "Institutional Conflicts:" %}</strong>
@@ -125,7 +125,7 @@
 
       </div>
 
-      <div class="list-group-item list-group-item-dark">
+      <div class="list-group-item list-group-item-secondary">
         <strong>{% trans "Room Constraints:" %}</strong>
         {% for vc in team.venue_constraints.all %}
           {{ vc.category }}{% if not forloop.last %}{% trans ", " %}{% endif %}

--- a/tabbycat/participants/templates/team_registration_card.html
+++ b/tabbycat/participants/templates/team_registration_card.html
@@ -40,7 +40,11 @@
         {% if pref.show_emoji %}
           <div>
             <strong>{% trans "Emoji:" %}</strong>
-            {{ team.emoji }}
+            {% if team.emoji %}
+              {{ team.emoji }}
+            {% else %}
+              <span class="text-muted">{% trans "No emoji assigned" %}</span>
+            {% endif %}
           </div>
         {% endif %}
       </div>


### PR DESCRIPTION
For team names:
- Moved emoji to a separate line so that its display is conditional only on one thing
- Show both short name and long name whenever they differ
- Show code name whenver code names in use, but show "No code name assigned" in muted text if the team doesn't have one
- Change line breaks (`<br />`) to divs (`<div>...</div>`), mostly to avoid problems with stray line breaks in edge cases
    - Not sure if a class should be added to these divs
    - I sort of think we might have enough info there now that a two-column table would be better, so might investigate that

More generally:
- Add `list-group-item-dark` to items where it is not public information. I'm not wedded to this particular style, but I feel like it'd be nice to visually differentiate it with more than just a message.

Extends #1511 and #1518, as discussed. Work in progress for now.

I think this should be targeted at Nebelung, since it's not just a bug fix.