### PR TITLE
Fix #1521, partially revert 326a548

### DIFF
--- a/tabbycat/breakqual/views.py
+++ b/tabbycat/breakqual/views.py
@@ -296,7 +296,7 @@ class EditTeamEligibilityView(AdministratorMixin, TournamentMixin, VueTableTempl
                 'checked': True if bc in team.break_categories.all() else False,
                 'sort': True if bc in team.break_categories.all() else False,
                 'id': team.id,
-                'type': bc.slug,
+                'type': bc.id,
             } for team in teams])
 
         # Provide list of members within speaker categories for convenient entry


### PR DESCRIPTION
Changes the "type" of columns in the break eligbility table to the break category's ID, rather than its name. This changes the value understood by CheckboxTablesContainer.vue:108.

This partially reverts 326a5485da93305e3b1e98e5a22bf4b000e369eb. Since this is @philipbelesky's commit, tagging him for review to ensure this is the intended structure, as opposed to the other way round, changing the ID to slug somewhere else to change the value understood by CheckboxTablesContainer.vue:101:

https://github.com/TabbycatDebate/tabbycat/blob/5606afff0afb9ce3d2c98cc9f3358104e3446ca2/tabbycat/templates/tables/CheckboxTablesContainer.vue#L98-L113

This fixes #1521. If @philipbelesky approves, I'd go ahead and release this hotfix straight away.