### PR TITLE
Rename deprecated Django methods

### DIFF
--- a/tabbycat/breakqual/base.py
+++ b/tabbycat/breakqual/base.py
@@ -4,7 +4,7 @@ generator (which just takes the top teams)."""
 import logging
 from itertools import groupby
 
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.translation import gettext as _
 
 from breakqual.models import BreakingTeam
@@ -88,7 +88,7 @@ class BaseBreakGenerator:
                     name = annotator_class.choice_name
                 else:
                     name = annotator_class.name
-                return force_text(name)
+                return force_str(name)
 
             raise BreakGeneratorError(
                 _("The break qualification rule %(rule)s requires the following "

--- a/tabbycat/checkins/apps.py
+++ b/tabbycat/checkins/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class CheckinsConfig(AppConfig):

--- a/tabbycat/draw/tables.py
+++ b/tabbycat/draw/tables.py
@@ -1,6 +1,6 @@
 from itertools import islice, zip_longest
 
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.html import format_html
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy
@@ -260,8 +260,8 @@ class PositionBalanceReportSummaryTableBuilder(BasePositionBalanceReportTableBui
             metric_info = next(self.standings.metrics_info())
             header = {
                 'key': "pts",  # always use 'pts' to make it more predictable
-                'title': force_text(metric_info['abbr']),
-                'tooltip': force_text(metric_info['name']),
+                'title': force_str(metric_info['abbr']),
+                'tooltip': force_str(metric_info['name']),
             }
             cells = []
             infos = self.standings.get_standings(teams)

--- a/tabbycat/options/preferences.py
+++ b/tabbycat/options/preferences.py
@@ -1,6 +1,6 @@
 from django.core.validators import MinValueValidator, validate_slug
 from django.forms import ValidationError
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
 from django_summernote.widgets import SummernoteWidget
 from dynamic_preferences.preferences import Section
@@ -543,7 +543,7 @@ class TeamStandingsPrecedence(MultiValueChoicePreference):
         classes = [TeamStandingsGenerator.metric_annotator_classes[metric] for metric in value]
         duplicates = [c for c in classes if c.repeatable is False and classes.count(c) > 1]
         if duplicates:
-            duplicates_str = ", ".join(list(set(force_text(c.name) for c in duplicates)))
+            duplicates_str = ", ".join(list(set(force_str(c.name) for c in duplicates)))
             raise ValidationError(_("The following metrics can't be listed twice: "
                     "%(duplicates)s") % {'duplicates': duplicates_str})
 
@@ -578,7 +578,7 @@ class SpeakerStandingsPrecedence(MultiValueChoicePreference):
         classes = [SpeakerStandingsGenerator.metric_annotator_classes[metric] for metric in value]
         duplicates = [c for c in classes if c.repeatable is False and classes.count(c) > 1]
         if duplicates:
-            duplicates_str = ", ".join(list(set(force_text(c.name) for c in duplicates)))
+            duplicates_str = ", ".join(list(set(force_str(c.name) for c in duplicates)))
             raise ValidationError(_("The following metrics can't be listed twice: "
                     "%(duplicates)s") % {'duplicates': duplicates_str})
 

--- a/tabbycat/tournaments/mixins.py
+++ b/tabbycat/tournaments/mixins.py
@@ -10,7 +10,7 @@ from django.db.models import Prefetch, Q
 from django.shortcuts import get_object_or_404, redirect
 from django.template.response import TemplateResponse
 from django.urls import NoReverseMatch, reverse
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.translation import gettext as _
 from django.views.generic.base import ContextMixin
 from django.views.generic.detail import SingleObjectMixin
@@ -160,8 +160,8 @@ class TournamentWebsocketMixin(TournamentFromUrlMixin):
     def send_error(self, error, message, original_content):
         # Need to forcibly decode the string (for translations)
         self.send_json({
-            'error': force_text(error),
-            'message': force_text(message),
+            'error': force_str(error),
+            'message': force_str(message),
             'original_content': original_content,
             'component_id': original_content['component_id'],
         })

--- a/tabbycat/tournaments/utils.py
+++ b/tabbycat/tournaments/utils.py
@@ -1,6 +1,6 @@
 import logging
 
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.translation import gettext, gettext_lazy as _, pgettext_lazy
 
 from .models import Round
@@ -89,7 +89,7 @@ def get_side_name_choices():
     """Returns a list of choices for position names suitable for presentation in
     a form."""
     return [
-        (code, force_text(names["aff_full"]).capitalize() + ", " + force_text(names["neg_full"]).capitalize())
+        (code, force_str(names["aff_full"]).capitalize() + ", " + force_str(names["neg_full"]).capitalize())
         for code, names in SIDE_NAMES.items()
     ]
 
@@ -103,9 +103,9 @@ def get_side_name(tournament, side, name_type):
     """
     if side in ('aff', 'neg'):
         names = SIDE_NAMES.get(tournament.pref('side_names'), SIDE_NAMES['aff-neg'])
-        return force_text(names["%s_%s" % (side, name_type)])
+        return force_str(names["%s_%s" % (side, name_type)])
     elif side in ('og', 'oo', 'cg', 'co'):
-        return force_text(BP_SIDE_NAMES["%s_%s" % (side, name_type)])
+        return force_str(BP_SIDE_NAMES["%s_%s" % (side, name_type)])
     else:
         raise ValueError("get_side_name() side must be one of: 'aff', 'neg', 'og', 'oo', 'cg', 'co', not: %r" % (side,))
 
@@ -113,7 +113,7 @@ def get_side_name(tournament, side, name_type):
 def _get_side_name(name_type):
     def _wrapped(tournament):
         names = SIDE_NAMES.get(tournament.pref('side_names'), SIDE_NAMES['aff-neg'])
-        return force_text(names[name_type])
+        return force_str(names[name_type])
     return _wrapped
 
 

--- a/tabbycat/tournaments/views.py
+++ b/tabbycat/tournaments/views.py
@@ -10,7 +10,7 @@ from django.db.models import Count, Q
 from django.shortcuts import redirect, resolve_url
 from django.urls import reverse_lazy
 from django.utils.html import format_html_join
-from django.utils.http import is_safe_url
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext_lazy as _
 from django.views.generic.base import TemplateView
 from django.views.generic.edit import CreateView, FormView, UpdateView
@@ -294,7 +294,7 @@ class SetCurrentRoundView(AdministratorMixin, TournamentMixin, FormView):
     def get_success_url(self):
         # Copied from django.contrib.auth.views.LoginView.get_success_url
         redirect_to = self.get_redirect_to(use_default=True)
-        url_is_safe = is_safe_url(
+        url_is_safe = url_has_allowed_host_and_scheme(
             url=redirect_to,
             allowed_hosts={self.request.get_host()},
             require_https=self.request.is_secure(),

--- a/tabbycat/utils/tables.py
+++ b/tabbycat/utils/tables.py
@@ -2,7 +2,7 @@ import logging
 import warnings
 
 from django.contrib.humanize.templatetags.humanize import ordinal
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.translation import gettext as _
 from django.utils.translation import ngettext
 
@@ -45,24 +45,24 @@ class BaseTableBuilder:
     @staticmethod
     def _convert_header(header):
         if isinstance(header, dict):
-            header['key'] = force_text(header['key'])
+            header['key'] = force_str(header['key'])
             return header
         else:
             # not sure why warnings module isn't working, so also use logger.warning to be annoying
             warnings.warn("Plain-text headers are deprecated, use a dict with key and title instead", stacklevel=3)
-            return {'key': force_text(header), 'title': force_text(header)}
+            return {'key': force_str(header), 'title': force_str(header)}
 
     @staticmethod
     def _convert_cell(cell):
         if isinstance(cell, dict):
             if 'text' in cell:
-                cell['text'] = force_text(cell['text'])
+                cell['text'] = force_str(cell['text'])
             return cell
         else:
             cell_dict = {}
             if isinstance(cell, int) or isinstance(cell, float):
                 cell_dict['sort'] = cell
-            cell_dict['text'] = force_text(cell)
+            cell_dict['text'] = force_str(cell)
             return cell_dict
 
     def add_column(self, header, data):
@@ -134,9 +134,9 @@ class BaseTableBuilder:
         return {
             'head': self.headers,
             'data': self.data,
-            'title': force_text(self.title),
-            'subtitle': force_text(self.subtitle),
-            'empty_title': force_text(self.empty_title),
+            'title': force_str(self.title),
+            'subtitle': force_str(self.subtitle),
+            'empty_title': force_str(self.empty_title),
             'class': self.table_class,
             'sort_key': self.sort_key,
             'sort_order': self.sort_order,
@@ -780,11 +780,11 @@ class TabbycatTableBuilder(BaseTableBuilder):
         headers = []
         for info in info_list:
             header = {'key': info['abbr'],
-                      'tooltip': force_text(info['name']).capitalize()}
+                      'tooltip': force_str(info['name']).capitalize()}
             if info['icon']:
                 header['icon'] = info['icon']
             else:
-                header['title'] = force_text(info['abbr'])
+                header['title'] = force_str(info['abbr'])
 
             headers.append(header)
         return headers

--- a/tabbycat/utils/views.py
+++ b/tabbycat/utils/views.py
@@ -6,7 +6,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.forms.models import modelformset_factory
 from django.http import HttpResponseRedirect
 from django.urls import reverse_lazy
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import TemplateView, View
 from django.views.generic.base import ContextMixin, TemplateResponseMixin
@@ -96,7 +96,7 @@ class FormSetMixin(ContextMixin):
     def get_success_url(self):
         if self.success_url:
             # Forcing possible reverse_lazy evaluation
-            url = force_text(self.success_url)
+            url = force_str(self.success_url)
         else:
             raise ImproperlyConfigured("No URL to redirect to. Provide a success_url.")
         return url


### PR DESCRIPTION
Django 3 deprecates a few names, using them as aliases to the new names
- `force_text` to `force_str`
- `ugettext_lazy` to `gettext_lazy`
- `is_safe_url` to `url_has_allowed_host_and_scheme`