### PR TITLE
Remove deprecated URL paths

### DIFF
--- a/tabbycat/adjfeedback/urls_public.py
+++ b/tabbycat/adjfeedback/urls_public.py
@@ -1,5 +1,4 @@
 from django.urls import path
-from django.views.generic.base import RedirectView
 
 from participants.models import Adjudicator, Team
 
@@ -10,10 +9,6 @@ urlpatterns = [
     path('progress/',
         views.PublicFeedbackProgress.as_view(),
         name='public_feedback_progress'),
-
-    # Transitional provision added 7/10/2017, remove after 7/11/2017
-    path('feedback_progress/',
-        RedirectView.as_view(url='/%(tournament_slug)s/feedback/progress/', permanent=True)),
 
     # Submission via Public Form
     path('add/',

--- a/tabbycat/standings/urls_public.py
+++ b/tabbycat/standings/urls_public.py
@@ -1,5 +1,4 @@
 from django.urls import path
-from django.views.generic.base import RedirectView
 
 from . import views
 
@@ -7,10 +6,6 @@ urlpatterns = [
     path('current-standings/',
         views.PublicCurrentTeamStandingsView.as_view(),
         name='standings-public-teams-current'),
-
-    # Transitional provision added 7/10/2017, remove after 7/11/2017
-    path('current_standings/',
-        RedirectView.as_view(url='/%(tournament_slug)s/tab/current-standings/', permanent=True)),
 
     path('team/',
         views.PublicTeamTabView.as_view(),


### PR DESCRIPTION
Were going to be removed in 2017; un-named so unlinked elsewhere.