### PR TITLE
Rename ranking-display to rank-display

### DIFF
--- a/tabbycat/adjfeedback/templates/overview_breakdowns.html
+++ b/tabbycat/adjfeedback/templates/overview_breakdowns.html
@@ -8,7 +8,7 @@
 
           {% if threshold.count != 0 %}
             {% widthratio threshold.count c_total 100 as c_percentage %}
-            <div class="progress-bar ranking-display ranking-{{ threshold.class }}" role="progressbar"
+            <div class="progress-bar rank-display ranking-{{ threshold.class }}" role="progressbar"
                  style="width: {{ c_percentage }}%;" data-toggle="tooltip"
                  title="{% blocktrans trimmed with min=threshold.min max=threshold.max percent=c_percentage|floatformat:"0" count count=threshold.count %}
                    {{ count }} adjudicator currently has a score equal to or above

--- a/tabbycat/templates/admin/style_guide.html
+++ b/tabbycat/templates/admin/style_guide.html
@@ -260,15 +260,15 @@
 
 <h6 class="mt-5">Allocation Adj Ranking Colors</h6>
 
-<button class="btn ranking-display ranking-90 h6">ranking-90%</button>
-<button class="btn ranking-display ranking-80 h6">ranking-80%</button>
-<button class="btn ranking-display ranking-70 h6">ranking-70%</button>
-<button class="btn ranking-display ranking-60 h6">ranking-60%</button>
-<button class="btn ranking-display ranking-50 h6">ranking-50%</button>
-<button class="btn ranking-display ranking-40 h6">ranking-40%</button>
-<button class="btn ranking-display ranking-30 h6">ranking-30%</button>
-<button class="btn ranking-display ranking-20 h6">ranking-20%</button>
-<button class="btn ranking-display ranking-10 h6">ranking-10%</button>
+<button class="btn rank-display ranking-90 h6">ranking-90%</button>
+<button class="btn rank-display ranking-80 h6">ranking-80%</button>
+<button class="btn rank-display ranking-70 h6">ranking-70%</button>
+<button class="btn rank-display ranking-60 h6">ranking-60%</button>
+<button class="btn rank-display ranking-50 h6">ranking-50%</button>
+<button class="btn rank-display ranking-40 h6">ranking-40%</button>
+<button class="btn rank-display ranking-30 h6">ranking-30%</button>
+<button class="btn rank-display ranking-20 h6">ranking-20%</button>
+<button class="btn rank-display ranking-10 h6">ranking-10%</button>
 
 <h6 class="mt-5">Positions Colors</h6>
 


### PR DESCRIPTION
The former is incorrect, but was used in adjfeedback and style. The class must be used as `rank-display ranking-##`.

Candidate for hotfix.