### PR TITLE
Tidy up password change and reset forms

### DIFF
--- a/tabbycat/templates/registration/password_change_done.html
+++ b/tabbycat/templates/registration/password_change_done.html
@@ -9,7 +9,7 @@
 {% block content %}
 
   {% trans "Your password has been changed." as message %}
-  {% include "components/alert.html" with type="info" %}
+  {% include "components/alert.html" with type="success" %}
 
   {% trans "Go to the home page" as text %}
   {% url 'tabbycat-index' as index %}

--- a/tabbycat/templates/registration/password_reset_complete.html
+++ b/tabbycat/templates/registration/password_reset_complete.html
@@ -8,20 +8,11 @@
 
 {% block content %}
 
-  <div class="row">
-    <div class="col-md-12">
-      <div class="alert alert-info">
-        <i data-feather="alert-circle"></i>
-        <p>
-          {% trans "Your password has been reset." %}
-        </p>
-      </div>
-    </div>
-    <div class="col-md-3">
-      <a href="{% url 'login' %}" class="btn btn-primary btn-block">
-        {# Translators: This text appears on a button that takes the user to the login page after a password reset. #}
-        {% trans "Go to the login page" %} <i data-feather="chevron-right"></i>
-      </a>
-    </div>
-  </div>
+  {% trans "Your password has been reset." as message %}
+  {% include "components/alert.html" with type="success" icon="info" %}
+
+  {% trans "Go to the login page" as text %}
+  {% url 'login' as login_url %}
+  {% include "components/item-action.html" with icon="log-in" url=login_url %}
+
 {% endblock %}

--- a/tabbycat/templates/registration/password_reset_confirm.html
+++ b/tabbycat/templates/registration/password_reset_confirm.html
@@ -8,46 +8,32 @@
 
 {% block content %}
 
-<div class="col-md-6 col-md-offset-3 col-sm-12">
-  <div class="card">
-    <div class="panel-heading panel-title">
-      <h4><span class="emoji">🔐</span>{% trans "Password Reset Confirmation" context "page title" %}</h4>
-    </div>
-    <div class="card-body">
+<div class="row">
+  <div class="col-lg-8 ml-lg-auto mr-md-auto">
 
     {% if validlink %}
-      {% if form.errors %}
-        <div class="alert alert-danger">
-          {% include "components/form-errors.html" with errors=form.errors %}
-        </div>
-      {% endif %}
+      <div class="card">
+        {% trans "Password Reset" context "page title" as title %}
+        {% include "components/form-title.html" with emoji="🔐" p1="" p2="" %}
+        {% trans "Please enter a new password (twice):" as text %}
 
-      <p class="mb-3">
-        <em>{% trans "Please enter a new password (twice):" %}</em>
-      </p>
+        <form id="reset-confirm" action="." method="POST">
+          {% csrf_token %}
 
-      <form id="reset-confirm" action="." method="POST">
-        {% csrf_token %}
+          {% include "components/form-main.html" %}
 
-        {% for field in form %}
-          {% include "components/form-field.html" %}
-        {% endfor %}
+          {% trans "Change my password" context "button" as title %}
+          {% trans "Cancel and go back to the site home page" as subtitle %}
+          {% url 'tabbycat-index' as suburl %}
+          {% include "components/form-submit.html" %}
+        </form>
+      </div>
 
-        <div class="mb-3">
-          <button type="submit" class="btn btn-success btn-block">
-            {% trans "Change my password" context "button" %}
-          </button>
-        </div>
+    {% else %}
+      {% trans "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset." as text %}
+      {% include "components/explainer-card.html" with type="danger" %}
+    {% endif %}
 
-      {% else %}
-
-        <p>{% trans "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset." %}</p>
-
-      {% endif %}
-
-      </form>
-
-    </div>
   </div>
 </div>
 {% endblock %}

--- a/tabbycat/templates/registration/password_reset_done.html
+++ b/tabbycat/templates/registration/password_reset_done.html
@@ -8,23 +8,12 @@
 
 {% block content %}
 
-  <div class="row">
-    <div class="col-md-12">
-      <div class="alert alert-info">
-        <i data-feather="alert-circle"></i>
-        <p>
-          {% trans "We've emailed you instructions for setting your password, if an account exists with the email address you entered. You should receive them shortly." %}
-        </p>
-        <p>
-          {% trans "If you don't receive an email, please make sure you've entered the address you registered with, and check your spam folder." %}
-        </p>
-      </div>
-    </div>
-    <div class="col-md-3">
-      <a href="{% url 'login' %}" class="btn btn-primary btn-block">
-        {# Translators: This text appears on a button that takes the user back to the login page from the password reset page. #}
-        <i data-feather="chevron-left"></i> {% trans "Return to the login page" %}
-      </a>
-    </div>
-  </div>
+  {% trans "We've emailed you instructions for setting your password, if an account exists with the email address you entered. You should receive them shortly." as reset_message %}
+  {% trans "If you don't receive an email, please make sure you've entered the address you registered with, and check your spam folder." as reset_extra %}
+  {% include "components/alert.html" with type="success" icon="info" message=reset_message extra=reset_extra %}
+
+  {% trans "Go to the login page" as text %}
+  {% url 'login' as login_url %}
+  {% include "components/item-action.html" with icon="log-in" url=login_url %}
+
 {% endblock %}


### PR DESCRIPTION
Some of the forms seem to have been thrown off by later CSS changes. This brings them into line with the new (well it's not really new anymore) style guide.

## Before
![image](https://user-images.githubusercontent.com/1725499/86503090-7fafec80-bd5f-11ea-8992-307e72c17f37.png)
![image](https://user-images.githubusercontent.com/1725499/86503098-95bdad00-bd5f-11ea-9c85-7cba13c857f4.png)
![image](https://user-images.githubusercontent.com/1725499/86503111-aff78b00-bd5f-11ea-8016-2b6f390559f7.png)

## After
![image](https://user-images.githubusercontent.com/1725499/86503121-c867a580-bd5f-11ea-8bc6-d4a97f8f9b68.png)
![image](https://user-images.githubusercontent.com/1725499/86503133-dae1df00-bd5f-11ea-8848-dd037fa187c2.png)
![image](https://user-images.githubusercontent.com/1725499/86503156-01077f00-bd60-11ea-803e-47b89b5b8df4.png)

