### PR TITLE
Add formats for Malay

### DIFF
--- a/tabbycat/utils/formats/ms/formats.py
+++ b/tabbycat/utils/formats/ms/formats.py
@@ -1,0 +1,8 @@
+BADGE_DATETIME_FORMAT = 'h:i A d/m'  # '4:33 PM 08/02'
+
+# Provide Django format definitions as Malay is not included yet
+DATE_FORMAT = 'd/m/Y'  # '08/02/2020'
+TIME_FORMAT = 'h:i A'  # '4:33 PM'
+DATETIME_FORMAT = 'h:i A d/m/Y'  # '4:33 PM 08/02/2020'
+SHORT_DATE_FORMAT = 'd/m/Y'  # '08/02/2020'
+SHORT_DATETIME_FORMAT = 'h:i A d/m/Y'  # '4:33 PM 08/02/2020'


### PR DESCRIPTION
DateTime formats for Malay, including some Django-provided ones as they are not included in Django itself for Malay.

Fixes #1510.