### PR TITLE
Disable contextual alternates for plain URLs

### DIFF
--- a/tabbycat/privateurls/views.py
+++ b/tabbycat/privateurls/views.py
@@ -62,7 +62,7 @@ class RandomisedUrlsView(RandomisedUrlsMixin, VueTableTemplateView):
                 return {'text': _("no URL"), 'class': 'text-warning'}
             path = reverse_tournament('privateurls-person-index', self.tournament,
                 kwargs={'url_key': person.url_key})
-            return {'text': request.build_absolute_uri(path), 'class': 'small'}
+            return {'text': request.build_absolute_uri(path), 'class': 'small mixed-text'}
 
         def build_link(person):
             if person.url_key is None:

--- a/tabbycat/templates/scss/modules/typography.scss
+++ b/tabbycat/templates/scss/modules/typography.scss
@@ -27,6 +27,10 @@ h6,
   font-family: $font-family-monospace; // Want evenly aligned labels
 }
 
+.mixed-text {
+  font-feature-settings: "calt" off;
+}
+
 //------------------------------------------------------------------------------
 // Text Utilities
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Inter (font) provides alternates for glyphs when used in various circumstances. However, one of these alternates 'x' (U+0078) with '×' (U+00D7) when between two digits (supposing a multiplication). This is not the case though with URL keys when shown in the URLs in the list.

This commit disables the alternates in this case, and provides a CSS class to use elsewhere if needed (.mixed-text).