### PR TITLE
i18n: Combine BP result messages

### DIFF
--- a/tabbycat/draw/models.py
+++ b/tabbycat/draw/models.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.contrib.humanize.templatetags.humanize import ordinal
 from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
 from django.db import models
 from django.utils.translation import gettext, gettext_lazy as _
@@ -307,14 +308,8 @@ class DebateTeam(models.Model):
 
     def get_result_display(self):
         if self.team.tournament.pref('teams_in_debate') == 'bp':
-            if self.points == 3:
-                return gettext("placed 1st")
-            elif self.points == 2:
-                return gettext("placed 2nd")
-            elif self.points == 1:
-                return gettext("placed 3rd")
-            elif self.points == 0:
-                return gettext("placed 4th")
+            if self.points is not None:
+                return gettext("placed %(place)s") % {'place': ordinal(4 - self.points)}
             else:
                 return gettext("result unknown")
         else:

--- a/tabbycat/utils/tables.py
+++ b/tabbycat/utils/tables.py
@@ -295,32 +295,22 @@ class TabbycatTableBuilder(BaseTableBuilder):
             cell['sort'] = 0
         return cell
 
+    BP_POINT_ICONS = ("chevrons-down", "chevron-down", "chevron-up", "chevrons-up")
+    BP_POINT_ICONCLASSES = ("text-danger result-icon", "text-warning result-icon", "text-info result-icon", "text-success result-icon")
+
     def _result_cell_class_four(self, points, cell):
         team_name = cell['popover']['title']
-        if points == 3:
-            cell['popover']['title'] = _("%(team)s took 1st") % {'team': team_name}
-            cell['icon'] = "chevrons-up"
-            cell['iconClass'] = "text-success result-icon"
-            cell['sort'] = 4
-        elif points == 2:
-            cell['popover']['title'] = _("%(team)s took 2nd") % {'team': team_name}
-            cell['icon'] = "chevron-up"
-            cell['iconClass'] = "text-info result-icon"
-            cell['sort'] = 3
-        elif points == 1:
-            cell['popover']['title'] = _("%(team)s took 3rd") % {'team': team_name}
-            cell['icon'] = "chevron-down"
-            cell['iconClass'] = "text-warning result-icon"
-            cell['sort'] = 2
-        elif points == 0:
-            cell['popover']['title'] = _("%(team)s took 4th") % {'team': team_name}
-            cell['icon'] = "chevrons-down"
-            cell['iconClass'] = "text-danger result-icon"
-            cell['sort'] = 1
-        else: # None
+
+        if points is None:
             cell['popover']['title'] = _("%(team)s—no result") % {'team': team_name}
             cell['icon'] = ""
             cell['sort'] = 0
+            return cell
+
+        cell['popover']['title'] = _("%(team)s placed %(place)s") % {'team': team_name, 'place': ordinal(4 - points)}
+        cell['icon'] = self.BP_POINT_ICONS[points]
+        cell['iconClass'] = self.BP_POINT_ICONCLASSES[points]
+        cell['sort'] = points + 1
         return cell
 
     def _result_cell_class_four_elim(self, advancing, cell):


### PR DESCRIPTION
This commit simplifies the messages for debate results in BP (like "%(team)s took %(place)s") so that all places use the same terminology of "placed" rather than "took", and combining the messages to abstract the position, using the ordinal function of Django for the ordinal.

Also, instead of testing the value of the value with a chain of ifs, it'll just be tested for being null. As a big integer (>3) would be problematic, an exception is raised, rather than hidden as unknown.