### PR TITLE
Duplicate private URL warning message

### DIFF
--- a/tabbycat/results/locale/en/LC_MESSAGES/django.po
+++ b/tabbycat/results/locale/en/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tabbycat\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-05 13:59-0300\n"
+"POT-Creation-Date: 2020-07-24 17:38-0300\n"
 "PO-Revision-Date: 2019-07-11 23:48\n"
 "Last-Translator: philip_tc\n"
 "Language-Team: English\n"
@@ -639,7 +639,7 @@ msgstr ""
 
 #: results/templates/includes/public_enter_results_info.html:4
 #, python-format
-msgid "The URL of this page is personalised to you, %(adjudicator)s. <strong>Do not share it with anyone:</strong> anyone who knows this URL can submit results for your debates. If you bookmark this page and return here after each debate, it will always show the debate that you just adjudicated."
+msgid "The URL of this page is personalised to you, %(name)s. <strong>Do not share it with anyone;</strong> anyone who knows this URL can submit results and/or feedback for your debates. You may bookmark this page and return here after each debate for the available actions."
 msgstr ""
 
 #: results/templates/privateurl_ballot_set.html:7

--- a/tabbycat/results/templates/includes/public_enter_results_info.html
+++ b/tabbycat/results/templates/includes/public_enter_results_info.html
@@ -1,11 +1,11 @@
 {% load i18n %}
 
 {% if private_url %}
-  {% blocktrans trimmed with adjudicator=adjudicator.name asvar p1 %}
-    The URL of this page is personalised to you, {{ adjudicator }}. <strong>Do not
-    share it with anyone:</strong> anyone who knows this URL can submit results
-    for your debates. If you bookmark this page and return here after each
-    debate, it will always show the debate that you just adjudicated.
+  {% blocktrans trimmed with name=adjudicator.name asvar p1 %}
+    The URL of this page is personalised to you, {{ name }}. <strong>Do not
+    share it with anyone;</strong> anyone who knows this URL can submit results and/or
+    feedback for your debates. You may bookmark this page and return here after each
+    debate for the available actions.
   {% endblocktrans %}
   {% include "components/explainer-card.html" with type="info" %}
 {% endif %}


### PR DESCRIPTION
To reduce the number of similar messages, the private URL ballot form could use the same message from the landing page, which is more general.

It also hints more that the URL can be used to deduce the landing page and so gives more than just ballot access.