### PR TITLE
Avoid re-fetching objects for notifications

### DIFF
--- a/tabbycat/notifications/consumers.py
+++ b/tabbycat/notifications/consumers.py
@@ -54,14 +54,18 @@ class NotificationQueueConsumer(SyncConsumer):
     def email(self, event):
         # Get database objects
         if 'debate_id' in event['extra']:
-            round = Debate.objects.get(pk=event['extra']['debate_id']).round
+            event['extra']['debate'] = Debate.objects.all().select_related(
+                'round', 'round__tournament').get(pk=event['extra'].pop('debate_id'))
+            round = event['extra']['debate'].round
             t = round.tournament
         elif 'round_id' in event['extra']:
-            round = Round.objects.get(pk=event['extra']['round_id'])
+            round = Round.objects.all().select_related('tournament').get(pk=event['extra'].pop('round_id'))
+            event['extra']['round'] = round
             t = round.tournament
         else:
             round = None
             t = Tournament.objects.get(pk=event['extra']['tournament_id'])
+            event['extra']['tournament'] = t
 
         from_email, reply_to = self._get_from_fields(t)
         notification_type = event['message']

--- a/tabbycat/notifications/utils.py
+++ b/tabbycat/notifications/utils.py
@@ -16,13 +16,11 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
 
 from adjallocation.allocation import AdjudicatorAllocation
-from draw.models import Debate
 from options.utils import use_team_code_names
 from participants.models import Person
 from participants.prefetch import populate_win_counts
 from results.result import BaseConsensusDebateResultWithSpeakers, DebateResult, VotingDebateResult
 from results.utils import side_and_position_names
-from tournaments.models import Round, Tournament
 
 
 adj_position_names = {
@@ -41,12 +39,10 @@ def _assemble_panel(adjs):
     return ", ".join(adj_string)
 
 
-def adjudicator_assignment_email_generator(to, url, round_id):
+def adjudicator_assignment_email_generator(to, url, round):
     emails = []
-    round = Round.objects.get(id=round_id)
-    tournament = round.tournament
     draw = round.debate_set_with_prefetches(speakers=False).all()
-    use_codes = use_team_code_names(tournament, False)
+    use_codes = use_team_code_names(round.tournament, False)
 
     for debate in draw:
         matchup = debate.matchup_codes if use_codes else debate.matchup
@@ -75,9 +71,8 @@ def adjudicator_assignment_email_generator(to, url, round_id):
     return emails
 
 
-def randomized_url_email_generator(to, url, tournament_id):
+def randomized_url_email_generator(to, url, tournament):
     emails = []
-    tournament = Tournament.objects.get(id=tournament_id)
 
     for instance in tournament.participants:
         try:
@@ -93,15 +88,14 @@ def randomized_url_email_generator(to, url, tournament_id):
     return emails
 
 
-def ballots_email_generator(to, debate_id):
+def ballots_email_generator(to, debate):
     emails = []
-    debate = Debate.objects.get(id=debate_id)
     tournament = debate.round.tournament
     results = DebateResult(debate.confirmed_ballot)
     round_name = _("%(tournament)s %(round)s @ %(room)s") % {'tournament': str(tournament),
                                                              'round': debate.round.name, 'room': debate.venue.name}
 
-    use_codes = use_team_code_names(debate.round.tournament, False)
+    use_codes = use_team_code_names(tournament, False)
 
     def _create_ballot(result, scoresheet):
         ballot = "<ul>"
@@ -159,18 +153,15 @@ def ballots_email_generator(to, debate_id):
     return emails
 
 
-def standings_email_generator(to, url, round_id):
+def standings_email_generator(to, url, round):
     emails = []
-    round = Round.objects.get(id=round_id)
-    tournament = round.tournament
-
     teams = round.active_teams.prefetch_related('speaker_set')
     populate_win_counts(teams)
 
     context = {
-        'TOURN': str(tournament),
+        'TOURN': str(round.tournament),
         'ROUND': round.name,
-        'URL': url if tournament.pref('public_team_standings') else "",
+        'URL': url if round.tournament.pref('public_team_standings') else "",
     }
 
     for team in teams:
@@ -192,9 +183,8 @@ def standings_email_generator(to, url, round_id):
     return emails
 
 
-def motion_release_email_generator(to, round_id):
+def motion_release_email_generator(to, round):
     emails = []
-    round = Round.objects.get(id=round_id)
 
     def _create_motion_list():
         motion_list = "<ul>"
@@ -224,9 +214,8 @@ def motion_release_email_generator(to, round_id):
     return emails
 
 
-def team_speaker_email_generator(to, tournament_id):
+def team_speaker_email_generator(to, tournament):
     emails = []
-    tournament = Tournament.objects.get(id=tournament_id)
 
     for team in tournament.team_set.all().prefetch_related('speaker_set', 'break_categories').select_related('institution'):
         context = {
@@ -254,12 +243,10 @@ def team_speaker_email_generator(to, tournament_id):
     return emails
 
 
-def team_draw_email_generator(to, round_id):
+def team_draw_email_generator(to, round):
     emails = []
-    round = Round.objects.get(id=round_id)
-    tournament = round.tournament
     draw = round.debate_set_with_prefetches(speakers=True).all()
-    use_codes = use_team_code_names(tournament, False)
+    use_codes = use_team_code_names(round.tournament, False)
 
     for debate in draw:
         matchup = debate.matchup_codes if use_codes else debate.matchup
@@ -273,7 +260,7 @@ def team_draw_email_generator(to, round_id):
         for dt in debate.debateteam_set.all():
             context_team = context.copy()
             context_team['TEAM'] = dt.team.code_name if use_codes else dt.team.short_name
-            context_team['SIDE'] = dt.get_side_name(tournament=tournament)
+            context_team['SIDE'] = dt.get_side_name(tournament=round.tournament)
 
             for speaker in dt.team.speakers:
                 try:


### PR DESCRIPTION
While the consumers need to be passed PKs and not the objects, the generators which are then called can be passed objects directly. This commit makes the generators take Tournament, Round, or Debate objects depending on which are required. It also removes other arguments that can be inferred from another. Select-related is used to make it more efficient.