### PR TITLE
Add links to Calico to documentation

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -34,13 +34,11 @@ Our user guide is at [tabbycat.readthedocs.io](http://tabbycat.readthedocs.io/).
 
 ## ⬆️ Installation
 
-The fastest way to launch a Tabbycat site is to click this button:
+The fastest way to launch a Tabbycat site is with [Calico](https://calicotab.com/), at a flat cost of 50CAD per site.
 
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/TabbycatDebate/tabbycat/tree/master)
+We also support creating sites through [Heroku](https://heroku.com/deploy?template=https://github.com/TabbycatDebate/tabbycat/tree/master). During the installation process Heroku will ask you to verify your account by adding a credit or debit card. A standard Tabbycat site *will not charge* your card without explicit permission — charges only accrue if you deliberately add a paid service in the Heroku dashboard.
 
-During the installation process Heroku will ask you to verify your account by adding a credit or debit card. A standard Tabbycat site *will not charge* your card without explicit permission — charges only accrue if you deliberately add a paid service in the Heroku dashboard.
-
-That said if you do not have access to a credit or debit card we offer a version of the software — 'Tabbykitten' — that does not require Heroku to verify your account. However, as a result, this version is limited: it cannot send emails and cannot be upgraded with extra database capacity or to better handle large amounts of traffic (although you can perform these upgrades later if you verify your Heroku account). We recommend using it only for small tournaments. [Use this link to set up a Tabbykitten version](https://heroku.com/deploy?template=https://github.com/TabbycatDebate/tabbycat/tree/kitten).
+That said if you do not have access to a credit or debit card we offer a version of the software — 'Tabbykitten' — that does not require Heroku to verify your account. However, as a result, this version is out-of-date and limited: it cannot send emails and cannot be upgraded with extra database capacity or to better handle large amounts of traffic (although you can perform these upgrades later if you verify your Heroku account). We recommend using it only for small tournaments. [Use this link to set up a Tabbykitten version](https://heroku.com/deploy?template=https://github.com/TabbycatDebate/tabbycat/tree/kitten).
 
 Our documentation also provides guides for how to run Tabbycat on your local machine.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,6 +19,7 @@ formats too. If you're looking for a general overview of the software, check out
    :maxdepth: 1
    :caption: Installation
 
+   install/calico
    install/heroku
    install/local
    install/docker

--- a/docs/install/calico.rst
+++ b/docs/install/calico.rst
@@ -1,0 +1,17 @@
+.. _install-calico:
+
+====================
+Installing on Calico
+====================
+
+When running Tabbycat on the internet, you can choose to use `Calico <https://calicotab.com/>`_ for hosting. Calico was designed to host Tabbycat sites without needing extra configuration. Naturally, this requires you to have a Calico account.
+
+Click `this link <https://calicotab.com/tournaments/new/>`_!
+
+This is the easiest way to deploy an instance of Tabbycat online. It requires no technical background.
+
+If you don't already have a Calico account, it'll prompt you to create one. Once you're logged in, choose a name for your installation, then scroll down and click **Create Site**. After you've paid the 50CAD fee, it will redirect you to your new site, and you can log in with your Calico account. Once finished, open the site and from there you can easily set up a demo data set (if you just want to learn Tabbycat) or use the data importer to set up a real tournament.
+
+.. note:: Your Calico account and the accounts on your site are independent, i.e. changing passwords on a site does not change your Calico password.
+
+Calico does not allow for the use of the ``importtournament`` command, but custom CNAME records pointing to a site do work for custom domains.

--- a/docs/install/heroku.rst
+++ b/docs/install/heroku.rst
@@ -4,7 +4,7 @@
 Installing on Heroku
 ====================
 
-When running Tabbycat on the internet, we set it up on `Heroku <http://www.heroku.com/>`_. The project is set up to be good to go on Heroku, and it works well for us, so if you'd like to run it online, we recommend that you do the same. Naturally, this requires you to have a Heroku account.
+When running Tabbycat on the internet, we set it up on `Heroku <http://www.heroku.com/>`_. The project is set up to be good to go on Heroku, and it works well for us. Naturally, this requires you to have a Heroku account.
 
 There are two ways to do this: a **short way** and a **long way**. Most people should use the short way. The long way requires some familiarity with command-line interfaces and Git, and requires a :ref:`local installation <install-local>` as a prerequisite, but makes it easier to :ref:`upgrade versions <upgrade-heroku>` later on and (unlike the short way) allows you to import data from CSV files.
 
@@ -21,7 +21,7 @@ If you don't already have a Heroku account, it'll prompt you to create one. Once
 
 .. note:: During the setup process, Heroku will ask you to verify your account by adding a credit card. A standard Tabbycat site *will not charge* your card — charges only accrue if you deliberately add a paid service in the Heroku dashboard.
 
-  If you can't access a credit card, you can instead install a limited version, which we call "Tabbykitten". However, Tabbykitten cannot send any e-mails or handle as much public traffic. We therefore strongly recommend it only as a last resort, and even then only for small tournaments.  `Use this link to set up a Tabbykitten site <https://heroku.com/deploy?template=https://github.com/TabbycatDebate/tabbycat/tree/kitten>`_.
+  If you can't access a credit card, you can instead install an out-of-date limited version, which we call "Tabbykitten". However, Tabbykitten cannot send any e-mails or handle as much public traffic. We therefore strongly recommend it only as a last resort, and even then only for small tournaments.  `Use this link to set up a Tabbykitten site <https://heroku.com/deploy?template=https://github.com/TabbycatDebate/tabbycat/tree/kitten>`_.
 
 The long way
 ============


### PR DESCRIPTION
This commit prefers Calico to Heroku for setting up a site, so it adds a link to create a site through Calico to the README and a page about installing to Calico in the docs.

We still keep info about Heroku, but at a lesser importance.