### PR TITLE
Add links to Calico to documentation

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -34,15 +34,13 @@ Our user guide is at [tabbycat.readthedocs.io](http://tabbycat.readthedocs.io/).
 
 ## ⬆️ Installation
 
-The fastest way to launch a Tabbycat site is to click this button:
+Tabbycat sites can be deployed with various platforms. The two main platforms are [Calico](https://calicotab.com/), specially designed for Tabbycat, and Heroku.
+
+To deploy on Calico, [click here](https://calicotab.com/). For Heroku, click this button:
 
 [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/TabbycatDebate/tabbycat/tree/master)
 
-During the installation process Heroku will ask you to verify your account by adding a credit or debit card. A standard Tabbycat site *will not charge* your card without explicit permission — charges only accrue if you deliberately add a paid service in the Heroku dashboard.
-
-That said if you do not have access to a credit or debit card we offer a version of the software — 'Tabbykitten' — that does not require Heroku to verify your account. However, as a result, this version is limited: it cannot send emails and cannot be upgraded with extra database capacity or to better handle large amounts of traffic (although you can perform these upgrades later if you verify your Heroku account). We recommend using it only for small tournaments. [Use this link to set up a Tabbykitten version](https://heroku.com/deploy?template=https://github.com/TabbycatDebate/tabbycat/tree/kitten).
-
-Our documentation also provides guides for how to run Tabbycat on your local machine.
+[Our documentation](https://tabbycat.readthedocs.io/en/stable/#installation-docs) also provides advanced instructions for deployment and troubleshooting, including locally.
 
 ## 💪 Support and Contributing
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -34,13 +34,13 @@ Our user guide is at [tabbycat.readthedocs.io](http://tabbycat.readthedocs.io/).
 
 ## ⬆️ Installation
 
-Tabbycat sites can be deployed with various platforms. The two main platforms are [Calico](https://calicotab.com/), specially designed for Tabbycat, and Heroku.
+Tabbycat can be deployed in a number of ways. While you can set it up to [run on your own computer](https://tabbycat.readthedocs.io/en/stable/install/local.html) most users will want to run it as a website.
 
-To deploy on Calico, [click here](https://calicotab.com/). For Heroku, click this button:
+Tabbycat is configured for a '1 click' install to the [Heroku](https://www.heroku.com) web platform. Click this button to begin:
 
 [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/TabbycatDebate/tabbycat/tree/master)
 
-[Our documentation](https://tabbycat.readthedocs.io/en/stable/#installation-docs) also provides advanced instructions for deployment and troubleshooting, including locally.
+While the baseline Heroku hosting is free, some features require additional setup and larger tournaments will likely need to pay for greater hosting capacities. As an alternative, the [Calico](https://calicotab.com/) service will host Tabbycat sites for a flat fee while also managing all scaling/configuration concerns and providing ongoing access to the released tab.
 
 ## 💪 Support and Contributing
 

--- a/docs/install/heroku.rst
+++ b/docs/install/heroku.rst
@@ -21,7 +21,7 @@ If you don't already have a Heroku account, it'll prompt you to create one. Once
 
 .. note:: During the setup process, Heroku will ask you to verify your account by adding a credit card. A standard Tabbycat site *will not charge* your card — charges only accrue if you deliberately add a paid service in the Heroku dashboard.
 
-  If you can't access a credit card, you can instead install a limited version, which we call "Tabbykitten". However, Tabbykitten is out-of-date nor cannot send any e-mails or handle as much public traffic. We therefore strongly recommend it only as a last resort, and even then only for small tournaments.  `Use this link to set up a Tabbykitten site <https://heroku.com/deploy?template=https://github.com/TabbycatDebate/tabbycat/tree/kitten>`_.
+  If you can't access a credit card, you can instead install a limited version, which we call "Tabbykitten". However, Tabbykitten is out-of-date, cannot send e-mails, and is less able to serve lots of simultaneous users. We therefore strongly recommend it only as a last resort, and even then only for small tournaments.  `Use this link to set up a Tabbykitten site <https://heroku.com/deploy?template=https://github.com/TabbycatDebate/tabbycat/tree/kitten>`_.
 
 The long way
 ============

--- a/docs/install/heroku.rst
+++ b/docs/install/heroku.rst
@@ -4,7 +4,7 @@
 Installing on Heroku
 ====================
 
-When running Tabbycat on the internet, we set it up on `Heroku <http://www.heroku.com/>`_. The project is set up to be good to go on Heroku, and it works well for us, so if you'd like to run it online, we recommend that you do the same. Naturally, this requires you to have a Heroku account.
+`Heroku <http://www.heroku.com/>`_ is a platform as a service on which Tabbycat can be installed to be available on the internet. Naturally, this requires you to have a Heroku account.
 
 There are two ways to do this: a **short way** and a **long way**. Most people should use the short way. The long way requires some familiarity with command-line interfaces and Git, and requires a :ref:`local installation <install-local>` as a prerequisite, but makes it easier to :ref:`upgrade versions <upgrade-heroku>` later on and (unlike the short way) allows you to import data from CSV files.
 
@@ -15,13 +15,13 @@ Click this button:
 .. image:: https://www.herokucdn.com/deploy/button.svg
   :target: https://heroku.com/deploy?template=https://github.com/TabbycatDebate/tabbycat/tree/master
 
-This is the easiest way to deploy an instance of Tabbycat online. It requires no technical background.
+It requires no technical background.
 
 If you don't already have a Heroku account, it'll prompt you to create one. Once you're logged in to Heroku, choose a name for your installation, then scroll down and click **Deploy**. Once it's finished, click **View** and follow the prompts. Once finished, open the site and from there you can easily set up a demo data set (if you just want to learn Tabbycat) or use the data importer to set up a real tournament.
 
 .. note:: During the setup process, Heroku will ask you to verify your account by adding a credit card. A standard Tabbycat site *will not charge* your card — charges only accrue if you deliberately add a paid service in the Heroku dashboard.
 
-  If you can't access a credit card, you can instead install a limited version, which we call "Tabbykitten". However, Tabbykitten cannot send any e-mails or handle as much public traffic. We therefore strongly recommend it only as a last resort, and even then only for small tournaments.  `Use this link to set up a Tabbykitten site <https://heroku.com/deploy?template=https://github.com/TabbycatDebate/tabbycat/tree/kitten>`_.
+  If you can't access a credit card, you can instead install a limited version, which we call "Tabbykitten". However, Tabbykitten is out-of-date nor cannot send any e-mails or handle as much public traffic. We therefore strongly recommend it only as a last resort, and even then only for small tournaments.  `Use this link to set up a Tabbykitten site <https://heroku.com/deploy?template=https://github.com/TabbycatDebate/tabbycat/tree/kitten>`_.
 
 The long way
 ============
@@ -39,7 +39,7 @@ When we say "command shell", on Windows we mean **Command Prompt**, and on Linux
 .. admonition:: Advanced users
   :class: tip
 
-  Tabbycat is a `Django <https://www.djangoproject.com/>`_ project. As such, it can be installed on any web platform that supports Django, using any SQL system that Django supports. Just be aware that we haven't tried any other platform.
+  Tabbycat is a `Django <https://www.djangoproject.com/>`_ project. As such, it can be installed on any web platform that supports Django, using PostgreSQL. Just be aware that requirements and installation may be slightly different.
 
 Short version of the long way
 -----------------------------


### PR DESCRIPTION
This commit adds a link to Calico to the README for deployment, but also redirects people towards the documentation to reduce the section.

We still keep info about Heroku, but at a lesser importance.