### PR TITLE
Mention the Tabbycat Debate Association in the footer

### DIFF
--- a/tabbycat/templates/footer.html
+++ b/tabbycat/templates/footer.html
@@ -51,7 +51,7 @@
         <h6 class="d-inline-block">{% blocktrans trimmed %}Need ballots?{% endblocktrans %}</h6>
         <p class="text-muted">
           {% blocktrans trimmed %}
-            You can <a href="https://tabbycatdebate.github.io/debate-ballots/" rel="noreferrer" target="_blank"> customise and print</a> great ballots from your browser.
+            Tabbycat is supported by the <a href="http://tabbycat-debate.org/">Tabbycat Debate Association</a>, a non-profit for advancing open debate technology.
           {% endblocktrans %}
         </p>
       </div>


### PR DESCRIPTION
In the place of the printed ballots, as I'd think the usage would be quite low (especially with the printable Tabbycat ballots).

The new message will link to the association's website.