### PR TITLE
Clean some uses of the cache

### DIFF
--- a/tabbycat/participants/signals.py
+++ b/tabbycat/participants/signals.py
@@ -1,10 +1,9 @@
 import logging
 
-from django.core.cache import cache
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
-from participants.models import Institution, Team
+from participants.models import Institution
 
 logger = logging.getLogger(__name__)
 
@@ -16,11 +15,3 @@ def update_team_names_from_institution(sender, instance, created, **kwargs):
         logger.info("Updating names of all %d teams from institution %s" % (len(teams), instance.name))
         for team in teams:
             team.save()
-
-
-@receiver(post_save, sender=Team)
-def update_team_cache(sender, instance, created, **kwargs):
-    cached_key = "%s_%s_%s" % ('teamid', instance.id, '_institution__object')
-    cache.delete(cached_key)
-    cached_key = "%s_%s_%s" % ('teamid', instance.id, '_speaker__objects')
-    cache.delete(cached_key)

--- a/tabbycat/tournaments/models.py
+++ b/tabbycat/tournaments/models.py
@@ -1,6 +1,5 @@
 import logging
 
-from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models import Count, Prefetch, Q
@@ -255,15 +254,6 @@ class Tournament(models.Model):
             for category in self.breakcategory_set.order_by('seq')  # Order by break, then seq
             if category.pk in current_elim_rounds
         ]
-
-    @cached_property
-    def get_current_round_cached(self):
-        cached_key = "%s_current_round_object" % self.slug
-        if self.current_round:
-            cache.get_or_set(cached_key, self.current_round, None)
-            return cache.get(cached_key)
-        else:
-            return None
 
     @cached_property
     def billable_teams(self):

--- a/tabbycat/tournaments/signals.py
+++ b/tabbycat/tournaments/signals.py
@@ -11,10 +11,7 @@ logger = logging.getLogger(__name__)
 
 @receiver(post_save, sender=Tournament)
 def update_tournament_cache(sender, instance, **kwargs):
-    cached_key = "%s_%s" % (instance.slug, 'object')
-    cache.delete(cached_key)
-    cached_key = "%s_%s" % (instance.slug, 'current_round_object')
-    cache.delete(cached_key)
+    cache.delete("%s_%s" % (instance.slug, 'object'))
 
 
 @receiver(post_delete, sender=Round)


### PR DESCRIPTION
The cache was being unused for teams (both institution and speakers caches), never being set, as well as tournament's current round, in an unused property.

Also, set round caches to be deleted when the objects are bulk-updated when setting the current round.