### PR TITLE
Add warning about multiple confirmed ballots

### DIFF
--- a/tabbycat/results/templates/admin_results.html
+++ b/tabbycat/results/templates/admin_results.html
@@ -101,6 +101,25 @@
     {% include "components/alert.html" with type="danger" icon="alert-octagon" %}
   {% endif %}
 
+  {% comment %}
+    Another warning about potential database inconsistency, but this one's only
+    ever happened as a consequence of direct database edits via SQL, so we've
+    probably already got all the consistency checks we can reasonably have. This
+    is just an extra courtesy for users who try to hack too much.
+  {% endcomment %}
+  {% if debates_with_multiple_confirmed_ballots_found %}
+    {% blocktrans trimmed asvar message %}
+      One or more debates in this round appear to have more than one confirmed
+      ballot submission. This can cause unexpected results (or crashes), because
+      Tabbycat assumes that each debate has at most one confirmed ballot
+      submission. This inconsistency can generally only arise if you manipulate
+      the database with SQL queries directly. You'll need to find the offending
+      debate(s) and ballot submissions yourself in the Edit Database area, or if
+      that doesn't work, you might need to find them using SQL queries directly.
+    {% endblocktrans %}
+    {% include "components/alert.html" with type="danger" icon="alert-octagon" %}
+  {% endif %}
+
   {% if pref.teams_in_debate == "bp" and round.ballots_per_debate == "per-adj" %}
     {% tournamenturl 'options-tournament-section' section='debate_rules' as debate_rules_url %}
     {% blocktrans trimmed asvar message %}

--- a/tabbycat/results/views.py
+++ b/tabbycat/results/views.py
@@ -138,9 +138,12 @@ class AdminResultsEntryForRoundView(AdministratorMixin, BaseResultsEntryForRound
         # reasonably have. This is just an extra courtesy for users who try to
         # hack too much. Just check `exists()`, no further information---it's
         # not worth the performance hit to do this work for them.
-        kwargs["debates_with_multiple_confirmed_ballots_found"] = self.round.debate_set.annotate(
+        multiple_confirmed_ballots_found = self.round.debate_set.annotate(
             num_ballots=Count('ballotsubmission', filter=Q(ballotsubmission__confirmed=True)),
         ).filter(num_ballots__gt=1).exists()
+        if multiple_confirmed_ballots_found:
+            logger.error("Multiple confirmed ballots for a single debate found")
+        kwargs["debates_with_multiple_confirmed_ballots_found"] = multiple_confirmed_ballots_found
 
         return super().get_context_data(**kwargs)
 


### PR DESCRIPTION
This adds a warning for the situation where a debate has two or more confirmed ballots, as happened at USUDC 2020.

This should never happen in normal use, and we had never heard of a case before USUDC. The `save()` method of `Submission` (the parent class of `BallotSubmission` and `AdjudicatorFeedback`) has a fairly elaborate duplicate prevention mechanism:
https://github.com/TabbycatDebate/tabbycat/blob/04541b006eda88e7a21abd9cf386829ca213b5e7/tabbycat/results/models.py#L72-L92

It was probably caused by a third-party bot directly modifying the Tabbycat database via SQL. The warning is therefore just watching out for adventurous users, to provide some hope of detecting it before the tab is released. As such, it doesn't provide any further information on narrowing down where the issue is—unlike the trainee scoresheets check in #922, it doesn't check how many debates are affected, nor list what they are. The warning message tells the user that it's probably due to direct SQL queries, and the user is pretty much on their own to figure out what to do with it.

One could probably reasonably argue about whether this check is worth putting in in the first place, but I tend to take the view that if it can hit us without us realising it, it's worth checking programmatically for the rare occasion where it saves a major headache.