### PR TITLE
Associate more motions to ballots

### DIFF
--- a/tabbycat/participants/tables.py
+++ b/tabbycat/participants/tables.py
@@ -55,7 +55,6 @@ class AdjudicatorDebateTable:
             Prefetch('debate__debateadjudicator_set',
                 queryset=DebateAdjudicator.objects.select_related('adjudicator__institution')),
             'debate__debateteam_set__team__speaker_set',
-            'debate__round__motion_set',
         )
         if not table.admin and not view.tournament.pref('all_results_released') and not table.private_url:
             debateadjs = debateadjs.filter(
@@ -99,7 +98,6 @@ class TeamDebateTable:
             Prefetch('debate_team__debate__debateadjudicator_set',
                 queryset=DebateAdjudicator.objects.select_related('adjudicator__institution')),
             'debate_team__debate__debateteam_set__team',
-            'debate_team__debate__round__motion_set',
             Prefetch('debate_team__speakerscore_set',
                 queryset=SpeakerScore.objects.filter(ballot_submission__confirmed=True).select_related('speaker').order_by('position'),
                 to_attr='speaker_scores'),

--- a/tabbycat/results/forms.py
+++ b/tabbycat/results/forms.py
@@ -421,6 +421,8 @@ class BaseBallotSetForm(BaseResultForm):
         # 5. Save motions
         if self.using_motions:
             self.ballotsub.motion = self.cleaned_data['motion']
+        elif self.motions.count() == 1:
+            self.ballotsub.motion = self.motions.get().motion
 
         if self.using_vetoes:
             for side in self.sides:

--- a/tabbycat/results/migrations/0009_ballotsubmission_motions.py
+++ b/tabbycat/results/migrations/0009_ballotsubmission_motions.py
@@ -1,0 +1,43 @@
+from django.db import migrations
+from django.db.models import Count, Prefetch
+
+
+def modify_ballotsubmission_motions(apps, schema_editor, reverse):
+    Tournament = apps.get_model('tournaments', 'Tournament')
+    BallotSubmission = apps.get_model('results', 'BallotSubmission')
+    Round = apps.get_model('tournaments', 'Round')
+    tournaments = Tournament.objects.prefetch_related(Prefetch(
+        'round_set', queryset=Round.objects.annotate(
+            num_motions=Count('roundmotion')).filter(num_motions=1
+        ).prefetch_related('debate_set', 'roundmotion_set')))
+    for t in tournaments.all():
+        pref, created = t.preferences.get_or_create(section='motions', name='enable_motions', defaults={'raw_value': 'False'})
+        if pref.raw_value == 'True':
+            continue
+        for r in t.round_set.all():
+            if r.roundmotion_set.count() != 1:
+                continue
+            motion_id = None if reverse else r.roundmotion_set.get().motion_id
+            BallotSubmission.objects.filter(
+                debate__in=list(r.debate_set.all()), motion__isnull=not reverse).update(motion_id=motion_id)
+
+
+def populate_ballotsubmission_motions(apps, schema_editor):
+    modify_ballotsubmission_motions(apps, schema_editor, False)
+
+
+def depopulate_ballotsubmission_motions(apps, schema_editor):
+    modify_ballotsubmission_motions(apps, schema_editor, True)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('results', '0008_auto_20201126_0037'),
+        ('motions', '0005_motions_mtm'),
+        ('options', '0009_create_motions_section'),
+    ]
+
+    operations = [
+        migrations.RunPython(populate_ballotsubmission_motions, depopulate_ballotsubmission_motions),
+    ]

--- a/tabbycat/tournaments/models.py
+++ b/tabbycat/tournaments/models.py
@@ -566,7 +566,7 @@ class Round(models.Model):
     @cached_property
     def is_last(self):
         """Returns a boolean if no next round in the sequence exists."""
-        return not self._rounds_in_same_sequence().filter(seq__gt=self.seq).order_by('seq').exists()
+        return not self._rounds_in_same_sequence().filter(seq__gt=self.seq).exists()
 
     @cached_property
     def is_break_round(self):

--- a/tabbycat/utils/tables.py
+++ b/tabbycat/utils/tables.py
@@ -584,23 +584,8 @@ class TabbycatTableBuilder(BaseTableBuilder):
         self.add_column({'key': 'adjudicators', 'title': _(title)}, da_data)
 
     def add_debate_motion_column(self, debates):
-        """Shows the motions associated with the debates.
-        The mechanism depends on whether the 'enable_motions' preferences is enabled:
-        if it is, then the motion is attached to the debate's confirmed ballot; if
-        not, then it's just attached to the round."""
-        if self.tournament.pref('enable_motions'):
-            motions = [debate.confirmed_ballot.motion if debate.confirmed_ballot else None
-                       for debate in debates]
-        else:
-            motions = []
-            for debate in debates:
-                round = debate.round
-                motion = round.motion_set.first()
-                if debate.round.motions_released or round.tournament.pref('all_results_released'):
-                    motions.append(motion)
-                else:
-                    motions.append(None)
-        self.add_motion_column(motions)
+        """Shows the motions associated with the debates."""
+        self.add_motion_column([debate.confirmed_ballot.motion if debate.confirmed_ballot else None for debate in debates])
 
     def add_motion_column(self, motions):
         motion_data = [{


### PR DESCRIPTION
Currently, motions are only associated with ballot submissions directly
if the 'enable_motions' preference is enabled. This creates two paths to
get motions from debates, and ignores edge-cases for special motions but
without selection. This commit adds the motion foreign key to all
ballots regardless of the preference, added automatically if there is
only one option.

A migration is there to populate the field, but is conservative to not
prefer a motion over another and to only update where motions are null.