### PR TITLE
Decouple adj feedback progress with statistics

### DIFF
--- a/tabbycat/adjfeedback/progress.py
+++ b/tabbycat/adjfeedback/progress.py
@@ -12,9 +12,10 @@ adjudicator).
 import logging
 from operator import attrgetter
 
+from django.db.models import Count, F, Q
+
 from adjallocation.models import DebateAdjudicator
 from adjfeedback.models import AdjudicatorFeedback
-from draw.models import DebateTeam
 from results.prefetch import populate_confirmed_ballots
 from tournaments.models import Round
 
@@ -369,58 +370,48 @@ class FeedbackProgressForAdjudicator(BaseFeedbackProgress):
         return trackers
 
 
-def get_feedback_progress(tournament):
-    """Returns a list of FeedbackProgressForTeam objects and a list of
-    FeedbackProgressForAdjudicator objects.
+def get_feedback_progress_statistics(tournament):
+    """Returns a tuple ([Team], [Adjudicator]), with statistics of the number
+    of feedback submitted, missing, and expected. Using Progress objects would
+    be too costly for use when only aggregate statistics are needed."""
 
-    This function pre-populates the FeedbackProgress objects to avoid needing
-    duplicate SQL queries for every team and adjudicator, so it should be used
-    for performance when the feedback progress of all teams and adjudicators is
-    needed."""
+    if tournament.pref('feedback_from_teams') == 'orallist':
+        teams_expected_annotation = Count('debateteam', filter=Q(debateteam__debate__round__stage=Round.STAGE_PRELIMINARY))
+    else:  # 'all-adjs'
+        teams_expected_annotation = Count('debateteam__debate__debateadjudicator', filter=Q(
+            debateteam__debate__round__stage=Round.STAGE_PRELIMINARY))
+    teams = tournament.team_set.annotate(
+        num_submitted=Count('debateteam__adjudicatorfeedback', filter=Q(debateteam__adjudicatorfeedback__confirmed=True)),
+    ).prefetch_related('speaker_set').all()
+    by_team_id = {t.id: t for t in teams}
+    ts = tournament.team_set.filter(id__in=by_team_id.keys()).annotate(num_expected=teams_expected_annotation)
+    for t in ts.all():
+        o_t = by_team_id[t.id]
+        o_t.num_expected = t.num_expected
+        o_t.num_missing = t.num_expected - o_t.num_submitted
 
-    teams_progress = []
-    adjs_progress = []
+    adjudicators = tournament.adjudicator_set.annotate(
+        num_submitted=Count('debateadjudicator__adjudicatorfeedback', filter=Q(debateadjudicator__adjudicatorfeedback__confirmed=True)),
+    ).all()
+    by_adj_id = {adj.id: adj for adj in adjudicators}
 
-    teams = tournament.team_set.prefetch_related('speaker_set').all()
+    exclude_self_filter = ~Q(debateadjudicator__debate__debateadjudicator__adjudicator_id=F('id'))
+    when_chair_filter = Q(debateadjudicator__type=DebateAdjudicator.TYPE_CHAIR) & exclude_self_filter
+    adj_expected_filter = {
+        'minimal': when_chair_filter,
+        'with-p-on-c': Q(
+            debateadjudicator__type=DebateAdjudicator.TYPE_PANEL,
+            debateadjudicator__debate__debateadjudicator__type=DebateAdjudicator.TYPE_CHAIR,
+        ) | when_chair_filter,
+        'all-adjs': exclude_self_filter,
+    }[tournament.pref('feedback_paths')]
+    adjs = tournament.adjudicator_set.filter(id__in=by_adj_id.keys()).annotate(
+        num_expected=Count('debateadjudicator__debate__debateadjudicator',
+            filter=Q(debateadjudicator__debate__round__stage=Round.STAGE_PRELIMINARY) & adj_expected_filter),
+    ).all()
+    for adj in adjs:
+        o_adj = by_adj_id[adj.id]
+        o_adj.num_expected = adj.num_expected
+        o_adj.num_missing = adj.num_expected - o_adj.num_submitted
 
-    submitted_feedback_by_team_id = {team.id: [] for team in teams}
-    submitted_feedback_teams = AdjudicatorFeedback.objects.filter(
-            source_team__team__in=teams).select_related('source_team')
-    submitted_feedback_teams = FeedbackProgressForTeam._submitted_feedback_queryset_operations(submitted_feedback_teams)
-    for feedback in submitted_feedback_teams:
-        submitted_feedback_by_team_id[feedback.source_team.team_id].append(feedback)
-
-    debateteams_by_team_id = {team.id: [] for team in teams}
-    debateteams = DebateTeam.objects.filter(team__in=teams)
-    debateteams = FeedbackProgressForTeam._debateteam_queryset_operations(debateteams)
-    for debateteam in debateteams:
-        debateteams_by_team_id[debateteam.team_id].append(debateteam)
-
-    for team in teams:
-        progress = FeedbackProgressForTeam(team)
-        progress._submitted_feedback = submitted_feedback_by_team_id[team.id]
-        progress._debateteams = debateteams_by_team_id[team.id]
-        teams_progress.append(progress)
-
-    adjudicators = tournament.adjudicator_set.all()
-
-    submitted_feedback_by_adj_id = {adj.id: [] for adj in adjudicators}
-    submitted_feedback_adjs = AdjudicatorFeedback.objects.filter(
-            source_adjudicator__adjudicator__in=adjudicators).select_related('source_adjudicator')
-    submitted_feedback_adjs = FeedbackProgressForAdjudicator._submitted_feedback_queryset_operations(submitted_feedback_adjs)
-    for feedback in submitted_feedback_adjs:
-        submitted_feedback_by_adj_id[feedback.source_adjudicator.adjudicator_id].append(feedback)
-
-    debateadjs_by_adj_id = {adj.id: [] for adj in adjudicators}
-    debateadjs = DebateAdjudicator.objects.filter(adjudicator__in=adjudicators)
-    debateadjs = FeedbackProgressForAdjudicator._debateadjudicator_queryset_operations(debateadjs)
-    for debateadj in debateadjs:
-        debateadjs_by_adj_id[debateadj.adjudicator_id].append(debateadj)
-
-    for adj in adjudicators:
-        progress = FeedbackProgressForAdjudicator(adj)
-        progress._submitted_feedback = submitted_feedback_by_adj_id[adj.id]
-        progress._debateadjudicators = debateadjs_by_adj_id[adj.id]
-        adjs_progress.append(progress)
-
-    return teams_progress, adjs_progress
+    return by_team_id.values(), by_adj_id.values()

--- a/tabbycat/adjfeedback/tables.py
+++ b/tabbycat/adjfeedback/tables.py
@@ -2,10 +2,9 @@ import logging
 
 from django.utils.translation import gettext as _, ngettext
 
+from participants.models import Adjudicator, Team
 from utils.misc import reverse_tournament
 from utils.tables import TabbycatTableBuilder
-
-from .progress import FeedbackProgressForAdjudicator, FeedbackProgressForTeam
 
 logger = logging.getLogger(__name__)
 
@@ -134,7 +133,7 @@ class FeedbackTableBuilder(TabbycatTableBuilder):
 
     def add_feedback_progress_columns(self, progress_list, key="P"):
         def _owed_cell(progress):
-            owed = progress.num_unsubmitted()
+            owed = progress.num_missing
             cell = {
                 'text': owed,
                 'sort': owed,
@@ -153,16 +152,14 @@ class FeedbackTableBuilder(TabbycatTableBuilder):
         if self._show_record_links:
 
             def _record_link(progress):
-                if isinstance(progress, FeedbackProgressForTeam):
+                if isinstance(progress, Team):
                     url_name = 'participants-team-record' if self.admin else 'participants-public-team-record'
-                    pk = progress.team.pk
-                elif isinstance(progress, FeedbackProgressForAdjudicator):
+                elif isinstance(progress, Adjudicator):
                     url_name = 'participants-adjudicator-record' if self.admin else 'participants-public-adjudicator-record'
-                    pk = progress.adjudicator.pk
                 else:
                     logger.error("Unrecognised progress type: %s", progress.__class__.__name__)
                     return ''
-                return reverse_tournament(url_name, self.tournament, kwargs={'pk': pk})
+                return reverse_tournament(url_name, self.tournament, kwargs={'pk': progress.pk})
 
             owed_link_header = {
                 'key': 'submitted',


### PR DESCRIPTION
The pages listing participants with the number of feedback to submit does not require loading all the progress objects; just aggregated values. With this, less memory is used as well as fewer database queries.