### PR TITLE
Fix room constrainee ID dropdown

### DIFF
--- a/tabbycat/utils/fields.py
+++ b/tabbycat/utils/fields.py
@@ -1,5 +1,6 @@
 from django import forms
 from django.contrib.postgres.fields import ArrayField
+from django.db.models import ForeignKey
 
 
 class ChoiceArrayField(ArrayField):
@@ -18,3 +19,19 @@ class ChoiceArrayField(ArrayField):
         # Skip our parent's formfield implementation completely as we don't
         # care for it.
         return super(ArrayField, self).formfield(**defaults)
+
+
+class LabelByNameModelChoiceField(forms.ModelChoiceField):
+    """ModelChoiceField that uses `obj.name` rather than `str(obj)` for labels."""
+
+    def label_from_instance(self, obj):
+        return obj.name
+
+
+class LabelByNameForeignKey(ForeignKey):
+    """ForeignKey that uses `obj.name` rather than `str(obj)` for labels."""
+
+    def formfield(self, **kwargs):
+        defaults = {'form_class': LabelByNameModelChoiceField}
+        defaults.update(kwargs)
+        return super().formfield(**defaults)

--- a/tabbycat/utils/widgets.py
+++ b/tabbycat/utils/widgets.py
@@ -1,9 +1,0 @@
-from django.forms import TextInput
-
-
-class SelectPrepopulated(TextInput):
-    template_name = 'select_prepopulated_widget.html'
-
-    def __init__(self, data_list, *args, **kwargs):
-        super(SelectPrepopulated, self).__init__(*args, **kwargs)
-        self.data_list = data_list

--- a/tabbycat/venues/models.py
+++ b/tabbycat/venues/models.py
@@ -3,6 +3,8 @@ from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 
+from utils.fields import LabelByNameForeignKey
+
 
 class Venue(models.Model):
     name = models.CharField(max_length=40,
@@ -119,7 +121,7 @@ class VenueConstraint(models.Model):
         verbose_name=_("category"))
     priority = models.IntegerField(verbose_name=_("priority"))
 
-    subject_content_type = models.ForeignKey(ContentType, models.CASCADE,
+    subject_content_type = LabelByNameForeignKey(ContentType, models.CASCADE,
         verbose_name=_("subject content type"),
         limit_choices_to=SUBJECT_CONTENT_TYPE_CHOICES)
     subject_id = models.PositiveIntegerField(


### PR DESCRIPTION
Fixes #1722.

@tienne-B can you think of any cleaner ways to do this?

Also, I wanted to add a simple regression test just to check the label of the field, so that if a package change bites us like this again, we'll know straight away rather than only when it's reported by a user. But I couldn't find any off-the-shelf tests suitable for [checking the label of a field](https://docs.djangoproject.com/en/3.1/topics/testing/tools/#django.test.SimpleTestCase.assertFieldOutput), and it's complicated by how the formset and form in question aren't classes in their own right; they're constructed by factories in the view. We could check the HTML output directly, but that's messy, and the `value` attribute of the `<option>` element is database-dependent (since it's the ID of the content type). I guess this is mostly a frontend function (the labels aren't, but the dropdown filtering is), so it's not really cut out for testing by the Django testing tools. The other idea would be to include a unit test for the JavaScript in venues/templates/venue_constraints_edit.html, @philipbelesky is there any (easy) scope for this?

(If adding a test is too hard then we should just merge without it, I just wanted to get takes on the idea first, since this seems like the kind of thing regression testing is for.)