### PR TITLE
Revise email docs and update email configuration

### DIFF
--- a/app.json
+++ b/app.json
@@ -7,7 +7,6 @@
   "logo": "https://raw.githubusercontent.com/TabbycatDebate/tabbycat/develop/tabbycat/static/logo-48x48.png",
   "addons": [
     "papertrail",
-    "sendgrid:starter",
     "rediscloud:30",
     "heroku-postgresql:hobby-dev",
     {

--- a/deploy_heroku.py
+++ b/deploy_heroku.py
@@ -157,7 +157,7 @@ if sys.version_info >= (3, 3) and shutil.which("heroku") is None:
     exit(1)
 
 # Create the app with addons
-addons = ["papertrail", "sendgrid:starter", "heroku-postgresql:%s" % args.pg_plan, "rediscloud:30"]
+addons = ["papertrail", "heroku-postgresql:%s" % args.pg_plan, "rediscloud:30"]
 command = ["heroku", "apps:create", "--stack", "heroku-18"]
 
 if addons:

--- a/docs/features/notifications.rst
+++ b/docs/features/notifications.rst
@@ -47,8 +47,8 @@ If you configure these config vars, Tabbycat will use them to send emails.
 - ``EMAIL_HOST``: Host server
 - ``EMAIL_HOST_USER``: Username for authentification to host
 - ``EMAIL_HOST_PASSWORD``: Password with username
-- ``EMAIL_PORT`` (default 587): Port for server
-- ``EMAIL_USE_TLS`` (default True): Whether to use `Transport Layer Security <https://en.wikipedia.org/wiki/Transport_Layer_Security>`_ (True/False)
+- ``EMAIL_PORT`` (default ``587``): Port for server
+- ``EMAIL_USE_TLS`` (default ``true``): Whether to use `Transport Layer Security <https://en.wikipedia.org/wiki/Transport_Layer_Security>`_ (``true`` or ``false``)
 
 Events
 ======

--- a/docs/features/notifications.rst
+++ b/docs/features/notifications.rst
@@ -13,6 +13,8 @@ Configuring an email provider
 
 Tabbycat does not come with an email provider. You will need to configure your app to use a third-party email provider. Your Tabbycat site will not be able to send emails until you have done this. There are a number of options for this. The right one for you will depend on your tournament size and budget.
 
+.. _configuring-sendgrid:
+
 SendGrid
 --------
 
@@ -37,6 +39,17 @@ Once you have a SendGrid account:
 4. Send a test email using the tool on your Tabbycat site's home page.
 
   *Changed in version 2.6:* The ``SENDGRID_USERNAME`` and ``SENDGRID_PASSWORD`` config vars are deprecated in favour of ``SENDGRID_API_KEY``.
+
+.. admonition:: Upgrading from legacy settings
+  :class: tip
+
+  If you've recently upgraded to version 2.6, and need to update your config vars, follow these instructions. First, check if the value of the config var ``SENDGRID_USERNAME`` is ``apikey``. If it is, you can do the following:
+
+  1. Create a new config var ``SENDGRID_API_KEY``, and copy the value from ``SENDGRID_PASSWORD`` to it. This value should start with ``SG.******``. Be sure you have the value saved (try sending a test email now) before you continue.
+  2. Delete the config vars ``SENDGRID_USERNAME`` and ``SENDGRID_PASSWORD`` (whose value you just copied over).
+  3. If it's not already set, set ``DEFAULT_FROM_EMAIL`` to the email address you want your emails to appears as coming from.
+
+  If the value of ``SENDGRID_USERNAME`` is anything other than ``apikey``, you'll need to convert your SendGrid configuration to use an API key instead. To do so, follow the instructions under :ref:`configuring-sendgrid` above. Then, delete the old ``SENDGRID_USERNAME`` and ``SENDGRID_PASSWORD`` config vars.
 
 Other email providers
 ---------------------

--- a/docs/features/notifications.rst
+++ b/docs/features/notifications.rst
@@ -2,7 +2,53 @@
 Sending Notifications
 =====================
 
-Tabbycat offers integrations with email delivery services to send notifications to participants on certain enumerated events. For sending these emails, `SendGrid <https://sendgrid.com/>`_ is readily available as an add-on in Heroku. It may be necessary to install the `SendGrid add-on <https://elements.heroku.com/addons/sendgrid>`_ manually. Other integrations may also be used in its place by changing the relevant environment variables.
+Tabbycat offers integrations with email delivery services to send notifications to participants on certain enumerated events. Before you can use them, you will need to configure your app to use an external email provider, such as SendGrid, Mailgun or MailChimp.
+
+.. _configuring-email-provider:
+
+Configuring an email provider
+=============================
+
+  *Changed in version 2.6:* Tabbycat no longer automatically provisions SendGrid via Heroku.
+
+Tabbycat does not come with an email provider. You will need to configure your app to use a third-party email provider. Your Tabbycat site will not be able to send emails until you have done this. There are a number of options for this. The right one for you will depend on your tournament size and budget.
+
+SendGrid
+--------
+
+To use `SendGrid <https://sendgrid.com/>`_, you'll need to create your own (personal or business) SendGrid account. The free tier is unlikely to suffice. If you're a student, you may be eligible for `SendGrid's (free) offer <https://sendgrid.com/partners/github-education/>`_ under the `GitHub Education Pack <https://education.github.com/pack>`_.
+
+Once you have a SendGrid account:
+
+1. `Create an API key <https://app.sendgrid.com/settings/api_keys>`_ in your SendGrid account.
+
+  There are `instructions for how to do this in the SendGrid documentation <https://sendgrid.com/docs/User_Guide/Settings/api_keys.html>`_. The only permission that is needed is the "Mail Send" permission, so you can turn off all others if you want to be safe.
+
+2. Set the following config vars in Heroku Dashboard (or using the Heroku CLI, if you have it):
+
+  - Set ``SENDGRID_API_KEY`` to your API key, which will start with ``SG.*******``.
+  - Set ``DEFAULT_FROM_EMAIL`` to the email address you want your emails to appears as coming from. This will probably need to be an email address that you can verify ownership of to SendGrid (see next step).
+
+3. You'll probably need to complete sender authentication on SendGrid by following `these instructions in the SendGrid documentation <https://sendgrid.com/docs/for-developers/sending-email/sender-identity/>`_. Specifically, if sending a test email raises an error about "not matching a verified Sender Identity" (this is likely), you need to complete one of the two methods listed there:
+
+  - *Single Sender Verification*, if you're comfortable with all of Tabbycat's emails coming from an email address that belongs to you and exists (*e.g.* your personal email address). This is more likely to be convenient for most users.
+  - *Domain Authentication*, if you have access to a domain whose DNS record you control, *e.g.* a tournament or society website hosted on its own domain.
+
+4. Send a test email using the tool on your Tabbycat site's home page.
+
+  *Changed in version 2.6:* The ``SENDGRID_USERNAME`` and ``SENDGRID_PASSWORD`` config vars are deprecated in favour of ``SENDGRID_API_KEY``.
+
+Other email providers
+---------------------
+
+If you configure these config vars, Tabbycat will use them to send emails.
+
+- ``DEFAULT_FROM_EMAIL``: Email to send from
+- ``EMAIL_HOST``: Host server
+- ``EMAIL_HOST_USER``: Username for authentification to host
+- ``EMAIL_HOST_PASSWORD``: Password with username
+- ``EMAIL_PORT`` (default 587): Port for server
+- ``EMAIL_USE_TLS`` (default True): Whether to use `Transport Layer Security <https://en.wikipedia.org/wiki/Transport_Layer_Security>`_ (True/False)
 
 Events
 ======

--- a/docs/install/heroku.rst
+++ b/docs/install/heroku.rst
@@ -221,6 +221,8 @@ Your Heroku app will be available at ``yourappname.herokuapp.com``. You may want
 
 The custom domain name basically requires two things: a DNS ``CNAME`` entry on your website targeting ``yourappname.herokuapp.com``, and the custom domain configured on Heroku using ``heroku domains:add tab.yourwebsite.com``.  You'll also need to provide an SSL certificate for your custom domain and add it using the ``heroku certs:add`` command.
 
+If you're using Tabbycat's email notifications, you might also configure your email provider to use domain authentication---see :ref:`configuring-email-provider`.
+
 HTTPS
 -----
 
@@ -235,36 +237,12 @@ Time zone
 
 If you want to change the time zone you nominated during deployment, you can do so by going to the `Heroku Dashboard <https://dashboard.heroku.com/>`_, clicking on your app, going to the **Settings** tab, clicking **Reveal Config Vars** and changing the value of the ``TIME_ZONE`` variable. This value must be one of the names in the IANA tz database, *e.g.* ``Pacific/Auckland``, ``America/Mexico_City``, ``Asia/Kuala_Lumpur``.  You can find a `list of these on Wikipedia <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List>`_ in the 'TZ\*' column.
 
-SendGrid account details
-------------------------
-
-By default, Heroku will automatically create a SendGrid account for you. For small tournaments, this should work fine. For larger ones, though, SendGrid typically doesn't allow new accounts to send so many emails without additional vetting. This vetting is separate to the verification you did for your Heroku account, and as far as we're aware, it can't be done until you send your first email, by which time it's probably too late.
-
-If you're running a large tournament, you may wish to use your own SendGrid account instead. The free tier probably won't suffice after the trial period, but the Essentials tier should be more than adequate. If you're a student and have the `GitHub Education Pack <https://education.github.com/pack>`_, you might find the SendGrid plan here useful.
-
-If you set up and use your own SendGrid account, you can remove the SendGrid add-on from your Heroku app. The SendGrid add-on is only necessary if you wish to use Heroku's auto-created SendGrid account.
-
-To set up your app to use your own SendGrid account:
-
-.. rst-class:: spaced-list
-
-1. `Sign up for a SendGrid account <https://sendgrid.com/pricing/>`_, if you don't already have one.
-
-2. `Create an API key <https://app.sendgrid.com/settings/api_keys>`_ in your SendGrid account.
-
-  There are `instructions for how to do this in the SendGrid documentation <https://sendgrid.com/docs/User_Guide/Settings/api_keys.html>`_. The only permission that is needed is the "Mail Send" permission, so you can turn off all others if you want to be safe.
-
-3. Set the following config vars in Heroku Dashboard (or using the Heroku CLI, if you have it):
-
-  - ``SENDGRID_USERNAME`` should be set to ``apikey`` (not your username).
-  - ``SENDGRID_PASSWORD`` should be set to your API key, which will start with ``SG*******``.
-
-  .. warning:: The `Heroku SendGrid instructions <https://devcenter.heroku.com/articles/sendgrid#setup-api-key-environment-variable>`_ to do something with ``SENDGRID_API_KEY`` are **incorrect**. We figured this out by contacting SendGrid support staff. Use the above config vars instead.
-
-Email settings
+Email provider
 --------------
 
-By default, Tabbycat uses a SendGrid add-on for sending emails, as explored in the previous section. To use another email service, such as `Mailchimp <https://mailchimp.com/>`_, you may add/change the following config vars:
+  *Changed in version 2.6:* Tabbycat no longer automatically provisions SendGrid via Heroku.
+
+Tabbycat does not come with an email provider. Before Tabbycat will send emails, you will need to install a third-party email provider yourself. To do so, you may add/change the following config vars:
 
 - ``DEFAULT_FROM_EMAIL``: Email to send from
 - ``EMAIL_HOST``: Host server
@@ -273,6 +251,7 @@ By default, Tabbycat uses a SendGrid add-on for sending emails, as explored in t
 - ``EMAIL_PORT`` (default 587): Port for server
 - ``EMAIL_USE_TLS`` (default True): Whether to use `Transport Layer Security <https://en.wikipedia.org/wiki/Transport_Layer_Security>`_ (True/False)
 
+See :ref:`configuring-email-provider` for more information, including a few options for email service providers.
 
 .. _upgrade-heroku:
 

--- a/tabbycat/notifications/templates/test_email.html
+++ b/tabbycat/notifications/templates/test_email.html
@@ -5,6 +5,10 @@
 {% block page-title %}{% trans "Send Test Email" context "page title" %}{% endblock %}
 {% block nav %}{% endblock %}
 
+{% block page-alerts %}
+  {% include 'errors/legacy_sendgrid_warning.html' %}
+{% endblock %}
+
 {% block content %}
 
 <div class="row">

--- a/tabbycat/notifications/templates/test_email.html
+++ b/tabbycat/notifications/templates/test_email.html
@@ -5,10 +5,6 @@
 {% block page-title %}{% trans "Send Test Email" context "page title" %}{% endblock %}
 {% block nav %}{% endblock %}
 
-{% block page-alerts %}
-  {% include 'errors/legacy_sendgrid_warning.html' %}
-{% endblock %}
-
 {% block content %}
 
 <div class="row">
@@ -21,7 +17,12 @@
 
       {% trans "Send Test Email" context "page title" as title %}
       {% trans "You can use this form to send a test email, to check that your email backend settings are working, before you try to send email notifications to participants." as text %}
+      {% blocktrans trimmed asvar p1 %}
+        The email will be sent from: <strong>{{ default_from_email }}</strong>. If this doesn't look right, change the <code>DEFAULT_FROM_EMAIL</code> config var in Heroku (or environment variable).
+      {% endblocktrans %}
       {% include "components/form-title.html" with emoji="📧" %}
+
+      {% include 'errors/legacy_sendgrid_warning.html' %}
 
       {% include "components/form-main.html" %}
 

--- a/tabbycat/notifications/views.py
+++ b/tabbycat/notifications/views.py
@@ -15,7 +15,7 @@ from django.views.generic.edit import FormView
 
 from participants.models import Person
 from tournaments.mixins import RoundMixin, TournamentMixin
-from utils.mixins import AdministratorMixin
+from utils.mixins import AdministratorMixin, WarnAboutLegacySendgridConfigVarsMixin
 from utils.tables import TabbycatTableBuilder
 from utils.views import VueTableTemplateView
 
@@ -23,7 +23,7 @@ from .forms import BasicEmailForm, TestEmailForm
 from .models import EmailStatus, SentMessage
 
 
-class TestEmailView(AdministratorMixin, FormView):
+class TestEmailView(WarnAboutLegacySendgridConfigVarsMixin, AdministratorMixin, FormView):
     form_class = TestEmailForm
     template_name = 'test_email.html'
     success_url = reverse_lazy('notifications-test-email')

--- a/tabbycat/settings/heroku.py
+++ b/tabbycat/settings/heroku.py
@@ -121,7 +121,10 @@ elif environ.get('SENDGRID_API_KEY', ''):
     EMAIL_USE_TLS = True
 
 elif environ.get('SENDGRID_USERNAME', ''):
-    # these settings are deprecated as of Tabbycat 2.6.0 (Ocicat)
+    # These settings are deprecated as of Tabbycat 2.6.0 (Ocicat).
+    # When removing, also remove utils.mixins.WarnAboutLegacySendgridConfigVarsMixin and
+    # templates/errors/legacy_sendgrid_warning.html (and references thereto).
+    USING_LEGACY_SENDGRID_CONFIG_VARS = True
     SERVER_EMAIL = environ['SENDGRID_USERNAME']
     DEFAULT_FROM_EMAIL = environ.get('DEFAULT_FROM_EMAIL', environ['SENDGRID_USERNAME'])
     EMAIL_HOST = 'smtp.sendgrid.net'

--- a/tabbycat/settings/heroku.py
+++ b/tabbycat/settings/heroku.py
@@ -109,7 +109,7 @@ if environ.get('EMAIL_HOST', ''):
     EMAIL_HOST_USER = environ['EMAIL_HOST_USER']
     EMAIL_HOST_PASSWORD = environ['EMAIL_HOST_PASSWORD']
     EMAIL_PORT = int(environ.get('EMAIL_PORT', 587))
-    EMAIL_USE_TLS = environ.get('EMAIL_USE_TLS', '').lower() == 'true'
+    EMAIL_USE_TLS = environ.get('EMAIL_USE_TLS', 'true').lower() == 'true'
 
 elif environ.get('SENDGRID_API_KEY', ''):
     SERVER_EMAIL = environ.get('DEFAULT_FROM_EMAIL', 'root@localhost')

--- a/tabbycat/settings/heroku.py
+++ b/tabbycat/settings/heroku.py
@@ -109,8 +109,19 @@ if environ.get('EMAIL_HOST', ''):
     EMAIL_HOST_USER = environ['EMAIL_HOST_USER']
     EMAIL_HOST_PASSWORD = environ['EMAIL_HOST_PASSWORD']
     EMAIL_PORT = int(environ.get('EMAIL_PORT', 587))
-    EMAIL_USE_TLS = bool(environ.get('EMAIL_USE_TLS', True))
+    EMAIL_USE_TLS = environ.get('EMAIL_USE_TLS', '').lower() == 'true'
+
+elif environ.get('SENDGRID_API_KEY', ''):
+    SERVER_EMAIL = environ.get('DEFAULT_FROM_EMAIL', 'root@localhost')
+    DEFAULT_FROM_EMAIL = environ.get('DEFAULT_FROM_EMAIL', 'notconfigured@tabbycatsite')
+    EMAIL_HOST = 'smtp.sendgrid.net'
+    EMAIL_HOST_USER = 'apikey'
+    EMAIL_HOST_PASSWORD = environ['SENDGRID_API_KEY']
+    EMAIL_PORT = 587
+    EMAIL_USE_TLS = True
+
 elif environ.get('SENDGRID_USERNAME', ''):
+    # these settings are deprecated as of Tabbycat 2.6.0 (Ocicat)
     SERVER_EMAIL = environ['SENDGRID_USERNAME']
     DEFAULT_FROM_EMAIL = environ.get('DEFAULT_FROM_EMAIL', environ['SENDGRID_USERNAME'])
     EMAIL_HOST = 'smtp.sendgrid.net'

--- a/tabbycat/templates/errors/legacy_sendgrid_warning.html
+++ b/tabbycat/templates/errors/legacy_sendgrid_warning.html
@@ -1,0 +1,21 @@
+{% load i18n humanize %}
+{% comment %}
+This template is paired with utils.mixins.WarnAboutLegacySendgridConfigVarsMixin
+and is intended for including in page-alerts blocks.
+
+When removing, also remove the relevant block in settings/heroku.py,
+utils.mixins.WarnAboutLegacySendgridConfigVarsMixin, and references to this
+template.
+{% endcomment %}
+{% if using_legacy_sendgrid_config_vars %}
+  {% blocktrans trimmed asvar legacy_sendgrid_warning_message %}
+    It looks like you're using the old SendGrid config vars on Heroku,
+    <code>SENDGRID_USERNAME</code> and <code>SENDGRID_PASSWORD</code>.
+    These are now deprecated, and will stop working in a future version of
+    Tabbycat. Please change your config vars to use
+    <code>SENDGRID_API_KEY</code> instead. For more information, please see
+    <a href="https://tabbycat.readthedocs.io/en/stable/features/notifications.html#configuring-an-email-provider">
+        our documentation on this topic</a>.
+  {% endblocktrans %}
+  {% include "components/alert.html" with type="warning" icon="alert-circle" message=legacy_sendgrid_warning_message %}
+{% endif %}

--- a/tabbycat/templates/errors/legacy_sendgrid_warning.html
+++ b/tabbycat/templates/errors/legacy_sendgrid_warning.html
@@ -11,8 +11,8 @@ template.
   {% blocktrans trimmed asvar legacy_sendgrid_warning_message %}
     It looks like you're using the old SendGrid config vars on Heroku,
     <code>SENDGRID_USERNAME</code> and <code>SENDGRID_PASSWORD</code>.
-    These are now deprecated, and will stop working in a future version of
-    Tabbycat. Please change your config vars to use
+    These are now deprecated (as of version 2.6), and will stop working in a
+    future version of Tabbycat. Please change your config vars to use
     <code>SENDGRID_API_KEY</code> instead. For more information, please see
     <a href="https://tabbycat.readthedocs.io/en/stable/features/notifications.html#configuring-an-email-provider">
         our documentation on this topic</a>.

--- a/tabbycat/tournaments/templates/assistant_tournament_index.html
+++ b/tabbycat/tournaments/templates/assistant_tournament_index.html
@@ -12,6 +12,7 @@
 
 {% block page-alerts %}
   {% include 'errors/database_limit_warning.html' %}
+  {% include 'errors/legacy_sendgrid_warning.html' %}
 {% endblock %}
 
 {% block content %}

--- a/tabbycat/tournaments/templates/site_index.html
+++ b/tabbycat/tournaments/templates/site_index.html
@@ -6,6 +6,7 @@
 
 {% block page-alerts %}
   {% include 'errors/database_limit_warning.html' %}
+  {% include 'errors/legacy_sendgrid_warning.html' %}
 {% endblock %}
 
 {% block content %}

--- a/tabbycat/tournaments/views.py
+++ b/tabbycat/tournaments/views.py
@@ -24,7 +24,8 @@ from results.prefetch import populate_confirmed_ballots
 from tournaments.models import Round
 from utils.forms import SuperuserCreationForm
 from utils.misc import redirect_round, redirect_tournament, reverse_round, reverse_tournament
-from utils.mixins import AdministratorMixin, AssistantMixin, CacheMixin, TabbycatPageTitlesMixin, WarnAboutDatabaseUseMixin
+from utils.mixins import (AdministratorMixin, AssistantMixin, CacheMixin, TabbycatPageTitlesMixin,
+                          WarnAboutDatabaseUseMixin, WarnAboutLegacySendgridConfigVarsMixin)
 from utils.views import PostOnlyRedirectView
 
 from .forms import (SetCurrentRoundMultipleBreakCategoriesForm,
@@ -38,7 +39,7 @@ User = get_user_model()
 logger = logging.getLogger(__name__)
 
 
-class PublicSiteIndexView(WarnAboutDatabaseUseMixin, TemplateView):
+class PublicSiteIndexView(WarnAboutDatabaseUseMixin, WarnAboutLegacySendgridConfigVarsMixin, TemplateView):
     template_name = 'site_index.html'
 
     def get(self, request, *args, **kwargs):
@@ -70,7 +71,7 @@ class TournamentPublicHomeView(CacheMixin, TournamentMixin, TemplateView):
     template_name = 'public_tournament_index.html'
 
 
-class BaseTournamentDashboardHomeView(TournamentMixin, WarnAboutDatabaseUseMixin, TemplateView):
+class BaseTournamentDashboardHomeView(TournamentMixin, WarnAboutDatabaseUseMixin, WarnAboutLegacySendgridConfigVarsMixin, TemplateView):
 
     def get_context_data(self, **kwargs):
         t = self.tournament

--- a/tabbycat/utils/mixins.py
+++ b/tabbycat/utils/mixins.py
@@ -119,6 +119,20 @@ class WarnAboutDatabaseUseMixin(ContextMixin):
         return super().get_context_data(**kwargs)
 
 
+class WarnAboutLegacySendgridConfigVarsMixin(ContextMixin):
+    """Mixin for views that should warn about legacy SendGrid settings that were
+    removed in version 2.6.0 (Ocicat).
+
+    When removing, also remove the relevant block in settings/heroku.py, and
+    templates/errors/legacy_sendgrid_warning.html (and references thereto).
+    """
+
+    def get_context_data(self, **kwargs):
+        if self.request.user.is_authenticated and getattr(settings, 'USING_LEGACY_SENDGRID_CONFIG_VARS', False):
+            kwargs['using_legacy_sendgrid_config_vars'] = True
+        return super().get_context_data(**kwargs)
+
+
 class CacheMixin:
     """Mixin for views that cache the page and need to update quickly."""
 


### PR DESCRIPTION
Will close #1751, once it's ready.

Notable changes:
- Replaced config vars `SENDGRID_USERNAME` and `SENDGRID_PASSWORD` with just `SENDGRID_API_KEY`—this is more aligned with how personal SendGrid accounts should be used, and since we're dropping automatic provisioning of the SendGrid add-on, there's no need for us to follow their convention. Plan is to check for the old setting and for it still to function, but to show a warning on the tournament overview page.

More to come—may add more notes on other options to docs. Thoughts welcome while still being drafted.