### PR TITLE
Add preference to exclude ghosts from team scores

### DIFF
--- a/tabbycat/options/preferences.py
+++ b/tabbycat/options/preferences.py
@@ -93,6 +93,15 @@ class MarginIncludesDissent(BooleanPreference):
     default = False
 
 
+@tournament_preferences_registry.register
+class TeamScoreIncludesGhost(BooleanPreference):
+    help_text = _("If checked, all speaker scores, including for duplicate speeches, will be counted for team scores")
+    verbose_name = _("Team score includes ghosts")
+    section = scoring
+    name = 'teamscore_includes_ghosts'
+    default = True
+
+
 # ==============================================================================
 draw_rules = Section('draw_rules', verbose_name=_("Draw Rules"))
 # ==============================================================================

--- a/tabbycat/options/presets.py
+++ b/tabbycat/options/presets.py
@@ -119,6 +119,7 @@ class BritishParliamentaryPreferences(PreferencesPreset):
     scoring__score_max                         = 99.0
     scoring__score_step                        = 1.0
     scoring__maximum_margin                    = 0.0
+    scoring__teamscore_includes_ghosts         = False  # WUDC 34.9.3.2
     # Debate Rules
     debate_rules__substantive_speakers         = 2
     debate_rules__teams_in_debate              = 'bp'

--- a/tabbycat/results/result.py
+++ b/tabbycat/results/result.py
@@ -888,6 +888,8 @@ class ConsensusDebateResultWithScores(DebateResultWithScoresMixin, ConsensusDeba
     get_score = speakerscore_field_score
 
     def teamscore_field_score(self, side):
+        if not self.tournament.pref('teamscore_includes_ghosts'):
+            return sum(self.get_score(side, pos) for pos in self.positions if not self.get_ghost(side, pos))
         return self.scoresheet.get_total(side)
 
 

--- a/tabbycat/results/result.py
+++ b/tabbycat/results/result.py
@@ -888,9 +888,9 @@ class ConsensusDebateResultWithScores(DebateResultWithScoresMixin, ConsensusDeba
     get_score = speakerscore_field_score
 
     def teamscore_field_score(self, side):
-        if not self.tournament.pref('teamscore_includes_ghosts'):
-            return sum(self.get_score(side, pos) for pos in self.positions if not self.get_ghost(side, pos))
-        return self.scoresheet.get_total(side)
+        if self.tournament.pref('teamscore_includes_ghosts'):
+            return self.scoresheet.get_total(side)
+        return sum(self.get_score(side, pos) for pos in self.positions if not self.get_ghost(side, pos))
 
 
 class DebateResultByAdjudicatorWithScores(DebateResultWithScoresMixin, DebateResultByAdjudicator):
@@ -948,8 +948,8 @@ class DebateResultByAdjudicatorWithScores(DebateResultWithScoresMixin, DebateRes
 
     def _teamscore_score_component(self, adj, side):
         if self.tournament.pref('teamscore_includes_ghosts'):
-            return sum(self.get_score(adj, side, pos) for pos in self.positions if not self.get_ghost(side, pos))
-        return self.scoresheets[adj].get_total(side)
+            return self.scoresheets[adj].get_total(side)
+        return sum(self.get_score(adj, side, pos) for pos in self.positions if not self.get_ghost(side, pos))
 
     def teamscore_field_score(self, side):
         # Should be decision-decorated

--- a/tabbycat/results/result.py
+++ b/tabbycat/results/result.py
@@ -946,13 +946,18 @@ class DebateResultByAdjudicatorWithScores(DebateResultWithScoresMixin, DebateRes
     def teamscorebyadj_field_score(self, adj, side):
         return self.scoresheets[adj].get_total(side)
 
+    def _teamscore_score_component(self, adj, side):
+        if self.tournament.pref('teamscore_includes_ghosts'):
+            return sum(self.get_score(adj, side, pos) for pos in self.positions if not self.get_ghost(side, pos))
+        return self.scoresheets[adj].get_total(side)
+
     def teamscore_field_score(self, side):
         # Should be decision-decorated
         if not self.is_complete():
             return None
         if not self._decision_calculated:
             self._calculate_decision()
-        return mean(self.scoresheets[adj].get_total(side) for adj in self.relevant_adjudicators())
+        return mean(self._teamscore_score_component(adj, side) for adj in self.relevant_adjudicators())
 
     def speakerscorebyadj_field_score(self, adjudicator, side, position):
         return self.scoresheets[adjudicator].get_score(side, position)


### PR DESCRIPTION
As pointed out recently, the WUDC and EUDC rules show that team scores must not include scores from iron-men (except for their highest). This is 34.9.3.2 in WUDC. The current behaviour was to keep ghost scores, and is expected now. As such, a new preference is added to toggle between these calculations, but is set correctly in the preset.