### PR TITLE
Add CORS headers to API endpoints

### DIFF
--- a/config/requirements_core.txt
+++ b/config/requirements_core.txt
@@ -16,6 +16,7 @@ django-statici18n==2.0.1                # Compile translations files as static f
 django-summernote==0.8.11.6             # WYSIWYG editor
 dj-cmd==1.0                             # Provides the dj command alias
 django-redis==4.12.1                    # Use redis for cache (on heroku; local optional)
+django-cors-headers==3.7.0              # CORS headers for API endpoints
 
 # Database
 psycopg2==2.8.6                         # For Django to talk to postgres

--- a/tabbycat/settings/core.py
+++ b/tabbycat/settings/core.py
@@ -95,12 +95,11 @@ MIDDLEWARE = [
     # User language preferences; must be after Session
     'django.middleware.locale.LocaleMiddleware',
     # Set Etags; i.e. cached requests not on network; must precede Common
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.http.ConditionalGetMiddleware',
     'django.middleware.common.CommonMiddleware',
     # Must be after SessionMiddleware
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.middleware.common.CommonMiddleware',
-    # Must be after SessionMiddleware
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'utils.middleware.DebateMiddleware',
@@ -149,6 +148,7 @@ INSTALLED_APPS = (
     'formtools',
     'statici18n', # Compile js translations as static file; saving requests
     'polymorphic',
+    'corsheaders',
     'rest_framework',
     'rest_framework.authtoken',
     'django_better_admin_arrayfield',
@@ -336,3 +336,10 @@ REST_FRAMEWORK = {
     ],
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
 }
+
+# ----------------------------------------
+# CORS-related settings for REST framework
+# ----------------------------------------
+
+CORS_ALLOW_ALL_ORIGINS = True
+CORS_URLS_REGEX = r'^/api(/.*)?$'


### PR DESCRIPTION
If trying to access the API on the frontend of a website, the request is blocked by CORS. This commit adds the required CORS headers to allow access to API paths (none other) by other sites.