### PR TITLE
Generalize the controlled access mixin

### DIFF
--- a/tabbycat/adjfeedback/views.py
+++ b/tabbycat/adjfeedback/views.py
@@ -431,8 +431,8 @@ class PublicAddFeedbackIndexView(PublicTournamentPageMixin, BaseAddFeedbackIndex
     template_name = 'public_add_feedback.html'
     tabroom = False
 
-    def is_page_enabled(self, tournament):
-        return tournament.pref('participant_feedback') == 'public'
+    def is_page_enabled(self):
+        return self.tournament.pref('participant_feedback') == 'public'
 
     def get_from_adj_link(self, team):
         return reverse_tournament('adjfeedback-public-add-from-adjudicator-pk',
@@ -555,8 +555,8 @@ class PublicAddFeedbackByRandomisedUrlView(SingleObjectByRandomisedUrlMixin, Pub
         # It's a private URL, so always show the team's real name.
         return team.short_name
 
-    def is_page_enabled(self, tournament):
-        return tournament.pref('participant_feedback') == 'private-urls'
+    def is_page_enabled(self):
+        return self.tournament.pref('participant_feedback') == 'private-urls'
 
     def get_submitter_fields(self):
         fields = super().get_submitter_fields()
@@ -593,8 +593,8 @@ class PublicAddFeedbackByIdUrlView(PublicAddFeedbackView):
         use_code_names = use_team_code_names(self.tournament, admin=False)
         return team.code_name if use_code_names else team.short_name
 
-    def is_page_enabled(self, tournament):
-        return tournament.pref('participant_feedback') == 'public'
+    def is_page_enabled(self):
+        return self.tournament.pref('participant_feedback') == 'public'
 
     def get_success_url(self):
         # Redirect to non-cached page: the public feedback form

--- a/tabbycat/draw/views.py
+++ b/tabbycat/draw/views.py
@@ -203,14 +203,14 @@ class PublicDrawMixin(PublicTournamentPageMixin):
 
 class PublicDrawForRoundView(PublicDrawMixin, BaseDisplayDrawForSpecificRoundTableView):
 
-    def is_page_enabled(self, tournament):
-        return tournament.pref('public_draw') == 'all-released'
+    def is_page_enabled(self):
+        return self.tournament.pref('public_draw') == 'all-released'
 
 
 class PublicDrawForCurrentRoundsView(PublicDrawMixin, BaseDisplayDrawForCurrentRoundsTableView):
 
-    def is_page_enabled(self, tournament):
-        return tournament.pref('public_draw') == 'current'
+    def is_page_enabled(self):
+        return self.tournament.pref('public_draw') == 'current'
 
 
 class PublicAllDrawsAllTournamentsView(PublicTournamentPageMixin, BaseDisplayDrawTableView):
@@ -300,16 +300,16 @@ class AssistantDrawDisplayForSpecificRoundByVenueView(OptionalAssistantTournamen
         BriefingRoomDrawByVenueTableMixin, BaseDisplayDrawForSpecificRoundTableView):
     assistant_page_permissions = ['all_areas', 'results_draw']
 
-    def is_page_enabled(self, tournament):
-        return self.round.is_current and super().is_page_enabled(tournament)
+    def is_page_enabled(self):
+        return self.round.is_current and super().is_page_enabled()
 
 
 class AssistantDrawDisplayForSpecificRoundByTeamView(OptionalAssistantTournamentPageMixin,
         BriefingRoomDrawByTeamTableMixin, BaseDisplayDrawForSpecificRoundTableView):
     assistant_page_permissions = ['all_areas', 'results_draw']
 
-    def is_page_enabled(self, tournament):
-        return self.round.is_current and super().is_page_enabled(tournament)
+    def is_page_enabled(self):
+        return self.round.is_current and super().is_page_enabled()
 
 
 class AssistantDrawDisplayForCurrentRoundsByVenueView(OptionalAssistantTournamentPageMixin,

--- a/tabbycat/privateurls/views.py
+++ b/tabbycat/privateurls/views.py
@@ -180,7 +180,7 @@ class PersonIndexView(SingleObjectByRandomisedUrlMixin, PersonalizablePublicTour
 
     table_title = _("Debates")
 
-    def is_page_enabled(self, tournament):
+    def is_page_enabled(self):
         return True
 
     def get_object(self, url_key):

--- a/tabbycat/results/views.py
+++ b/tabbycat/results/views.py
@@ -557,8 +557,8 @@ class OldPublicNewBallotSetByIdUrlView(SingleObjectFromTournamentMixin, BasePubl
     def get_success_url(self):
         return reverse_tournament('post-results-public-ballotset-new', self.tournament)
 
-    def is_page_enabled(self, tournament):
-        return tournament.pref('participant_ballots') == 'public'
+    def is_page_enabled(self):
+        return self.tournament.pref('participant_ballots') == 'public'
 
 
 class OldPublicNewBallotSetByRandomisedUrlView(SingleObjectByRandomisedUrlMixin, BasePublicNewBallotSetView):
@@ -569,8 +569,8 @@ class OldPublicNewBallotSetByRandomisedUrlView(SingleObjectByRandomisedUrlMixin,
     def get_success_url(self):
         return reverse_tournament('privateurls-person-index', self.tournament, kwargs={'url_key': self.kwargs['url_key']})
 
-    def is_page_enabled(self, tournament):
-        return tournament.pref('participant_ballots') == 'private-urls'
+    def is_page_enabled(self):
+        return self.tournament.pref('participant_ballots') == 'private-urls'
 
 
 class PostPublicBallotSetSubmissionURLView(TournamentMixin, TemplateView):
@@ -663,7 +663,7 @@ class AdjudicatorPrivateUrlBallotScoresheetView(RoundMixin, SingleObjectByRandom
     slug_url_kwarg = 'url_key'
     slug_field = 'debateadjudicator__adjudicator__url_key'
 
-    def is_page_enabled(self, tournament):
+    def is_page_enabled(self):
         return True
 
     def check_permissions(self):
@@ -697,7 +697,7 @@ class SpeakerPrivateUrlBallotScoresheetView(RoundMixin, SingleObjectByRandomised
     slug_field = 'debateteam__team__speaker__url_key'
     public_page_preference = 'private_ballots_released'
 
-    def is_page_enabled(self, tournament):
+    def is_page_enabled(self):
         return True
 
     def get_queryset(self):
@@ -708,8 +708,8 @@ class PublicBallotSubmissionIndexView(PublicTournamentPageMixin, RoundMixin, Vue
     """Public view listing all debate-adjudicators for the current round, as
     links for them to enter their ballots."""
 
-    def is_page_enabled(self, tournament):
-        return tournament.pref('participant_ballots') == 'public'
+    def is_page_enabled(self):
+        return self.tournament.pref('participant_ballots') == 'public'
 
     def is_draw_released(self):
         return self.round.draw_status == Round.STATUS_RELEASED and self.round.motions_good_for_public

--- a/tabbycat/utils/mixins.py
+++ b/tabbycat/utils/mixins.py
@@ -50,6 +50,9 @@ class TabbycatPageTitlesMixin(ContextMixin):
 class BaseAccessControlledPageMixin:
     """Base mixin for views that can be enabled and disabled."""
 
+    _user_role = 'public'
+    template_403_name = "errors/public_403.html"
+
     def is_page_enabled(self):
         raise NotImplementedError
 

--- a/tabbycat/utils/tests.py
+++ b/tabbycat/utils/tests.py
@@ -187,7 +187,7 @@ class ConditionalTournamentTestsMixin(SingleViewTestMixin):
         for value in values:
             with self.subTest(value=value):
                 self.tournament.preferences[self.view_toggle_preference] = value
-                with self.assertLogs('tournaments.mixins', logging.WARNING):
+                with self.assertLogs('utils.mixins', logging.WARNING):
                     with suppress_logs('django.request', logging.WARNING):
                         response = self.get_response()
                 self.assertResponsePermissionDenied(response)


### PR DESCRIPTION
As it is also used with global preferences, thus without a tournament.

The tournament argument for `is_page_enabled` is also un-needed as the
object's tournament property is available there.