### PR TITLE
Remove icon for unexpected feedback in tables

### DIFF
--- a/tabbycat/participants/templates/feedback_progress_panel.html
+++ b/tabbycat/participants/templates/feedback_progress_panel.html
@@ -35,7 +35,6 @@
       {% elif tracker.expected %}
         <div class="list-group-item {% if not pref.feedback_progress %}list-group-item-secondary{% endif %} text-warning">
           <span class="badge badge-secondary">{{ tracker.round.name }}</span>
-          <i data-feather="info"></i>
           {% trans "More feedback submissions than expected for this debate:" %}
           {% for submission in tracker.acceptable_submissions %}
             <strong>{{ submission.adjudicator.name }}</strong>{% if not forloop.last %},{% endif %}


### PR DESCRIPTION
It's the only status with a symbol, which makes a misalignment with other rows, even missing feedback, which would be more serious. The colour is distinction enough.