### PR TITLE
Include checkins websocket for availabilities

### DIFF
--- a/tabbycat/availability/templates/AvailabilityTableContainer.vue
+++ b/tabbycat/availability/templates/AvailabilityTableContainer.vue
@@ -1,0 +1,80 @@
+<template>
+  <checkbox-tables-container  :tables-data="localTableData"
+                              :categories="categories"
+                              :round-info="roundInfo"
+                              :translations="translations"
+                              :urls="urls"
+                              :navigation="navigation"
+                              :hide-auto-save="hideAutoSave" >
+  </checkbox-tables-container>
+</template>
+
+<script>
+import CheckboxTablesContainer from '../../templates/tables/TablesContainer.vue'
+import WebsocketMixin from '../../templates/ajax/WebSocketMixin.vue'
+
+export default {
+  mixins: [WebsocketMixin],
+  components: { CheckboxTablesContainer },
+  props: {
+    tablesData: Array,
+    categories: Array,
+    urls: Object,
+    navigation: Array,
+    roundInfo: Object,
+    translations: Object,
+    hideAutoSave: Boolean,
+    tournamentSlug: String,
+    speakers: String,
+  },
+  data: function () {
+    return {
+      localTableData: this.tablesData,
+      substantiveSpeakers: Number(this.speakers),
+      sockets: ['checkins'],
+    }
+  },
+  methods: {
+    handleSocketReceive: function (socketLabel, payload) {
+      const table = this.localTableData[0]
+      const col = table.headers[1].key === 'active-prev' ? 2 : 1
+      if (socketLabel === 'checkins') {
+        // Note: must alter the original object not the computed property
+        for (const checkin of payload.checkins) {
+          if (!checkin.identifier) {
+            continue
+          }
+          const row = table.data.find(cell => cell[col].identifiers.find(id => id.identifier === identifier))
+          if (!row) {
+            continue // Could not find matching participant; probably different type
+          }
+          const identifier = row[col].identifiers.find(id => id.identifier === identifier)
+          identifier.checked = payload.status
+
+          if (this.roundInfo.model === 'participants.Team') {
+            const numChecked = row[col].identifiers.reduce((sum, id) => sum + (id.checked ? 1 : 0), 0)
+            if (numChecked >= this.substantiveSpeakers - 1) {
+              row[col].sort = numChecked >= this.substantiveSpeakers - 1
+              row[col].icon = numChecked >= this.substantiveSpeakers ? 'check' : 'shuffle'
+            } else {
+              row[col].sort = false
+              row[col].icon = ''
+            }
+          } else {
+            row[col].sort = identifier.checked
+            row[col].icon = identifier.checked ? 'check' : ''
+          }
+
+          row[0].checked_in = row[col].sort
+        }
+      }
+    },
+  },
+  computed: {
+    tournamentSlugForWSPath: function () {
+      return this.tournamentSlug
+    },
+  },
+}
+
+</script>

--- a/tabbycat/availability/templates/base_availability.html
+++ b/tabbycat/availability/templates/base_availability.html
@@ -4,15 +4,17 @@
 {% block content %}
 
   <div id="vueMount">
-    <checkbox-tables-container  :tables-data=tablesData
-                                :categories=categories
-                                :round-info=roundInfo
-                                :translations=translations
-                                :urls=urls
-                                :navigation=navigation
-                                :hide-auto-save=hideAutoSave
-                                orientation={{ tables_orientation|safe }} >
-    </checkbox-tables-container>
+    <availability-table-container :tables-data=tablesData
+                                  :categories=categories
+                                  :round-info=roundInfo
+                                  :translations=translations
+                                  :urls=urls
+                                  :navigation=navigation
+                                  :hide-auto-save=hideAutoSave
+                                  orientation={{ tables_orientation|safe }}
+                                  tournament-slug="{{ tournament_slug }}"
+                                  speakers="{{ pref.substantive_speakers }}" >
+    </availability-table-container>
   </div>
 
 {% endblock content %}

--- a/tabbycat/availability/views.py
+++ b/tabbycat/availability/views.py
@@ -172,6 +172,9 @@ class AvailabilityTypeBase(RoundMixin, AdministratorMixin, VueTableTemplateView)
     def get_queryset(self):
         return self.model.objects.filter(tournament=self.tournament)
 
+    def get_identifiers(self, inst):
+        return [{"identifier": inst.barcode, "checked": inst.checked_in}]
+
     def get_table(self):
         table = TabbycatTableBuilder(view=self, sort_key=self.sort_key)
         queryset = utils.annotate_availability(self.get_queryset(), self.round)
@@ -196,7 +199,7 @@ class AvailabilityTypeBase(RoundMixin, AdministratorMixin, VueTableTemplateView)
 
         checked_in_header = {'key': "tournament", 'title': _('Checked-In')}
         checked_in_data = [{
-            'sort': inst.checked_in, 'icon': inst.checked_icon, 'tooltip': inst.checked_tooltip,
+            'sort': inst.checked_in, 'icon': inst.checked_icon, 'identifiers': self.get_identifiers(inst),
         } for inst in queryset]
         table.add_column(checked_in_header, checked_in_data)
 
@@ -212,7 +215,7 @@ class AvailabilityTypeTeamView(AvailabilityTypeBase):
     update_view = 'availability-update-teams'
 
     def get_queryset(self):
-        return super().get_queryset().prefetch_related('speaker_set').prefetch_related('speaker_set__checkin_identifier')
+        return super().get_queryset().prefetch_related('speaker_set', 'speaker_set__checkin_identifier')
 
     @staticmethod
     def add_description_columns(table, teams):
@@ -221,6 +224,9 @@ class AvailabilityTypeTeamView(AvailabilityTypeBase):
     @staticmethod
     def annotate_checkins(queryset, t):
         return get_checkins(queryset, t, 'checkin_window_people')
+
+    def get_identifiers(self, inst):
+        return [{"identifier": s.barcode, "checked": s.checked_in} for s in inst.speaker_set.all()]
 
 
 class AvailabilityTypeAdjudicatorView(AvailabilityTypeBase):

--- a/tabbycat/templates/js-bundles/main.js
+++ b/tabbycat/templates/js-bundles/main.js
@@ -10,6 +10,7 @@ import 'bootstrap' // Import bootstrap javascript plugins
 import CheckboxTablesContainer from '../tables/CheckboxTablesContainer.vue'
 import TablesContainer from '../tables/TablesContainer.vue'
 // App Templates
+import AvailabilityTableContainer from '../../availability/templates/AvailabilityTableContainer.vue'
 import CheckInStatusContainer from '../../checkins/templates/CheckInStatusContainer.vue'
 import DiversityContainer from '../../participants/templates/DiversityContainer.vue'
 import PrintableBallot from '../../printing/templates/PrintableBallot.vue'
@@ -177,6 +178,7 @@ $(document).ready(() => {
 vueComponents.TablesContainer = TablesContainer
 vueComponents.CheckboxTablesContainer = CheckboxTablesContainer
 vueComponents.ResultsTablesContainer = ResultsTablesContainer
+vueComponents.AvailabilityTableContainer = AvailabilityTableContainer
 // Checkin Statuses
 vueComponents.CheckInStatusContainer = CheckInStatusContainer
 // Divisions Containers


### PR DESCRIPTION
This commit implements a use of the checkins websocket in the availabilities table. When a message is received, it finds the participant(s) for who the message is found, then updates their status and checked-in icon accordingly.

Closes #1869