### PR TITLE
Change instances of "iron man" to "iron person" in draw table and elsewhere

### DIFF
--- a/docs/features/data-entry.rst
+++ b/docs/features/data-entry.rst
@@ -45,7 +45,7 @@ Duplicate/Swing Speeches
 
 .. image:: images/iron-speakers.png
 
-When entering the ballots there is a toggle label *'Iron' speeches*. When set to "yes" this allows you to have the same speaker deliver multiple speeches provided their extra speeches are labelled on the form as 'duplicates'. Typically, most tournaments require that lesser 'iron man' speech is discarded from the tab, which would mean that you would mark the lower speaker of the two scores as the duplicate (note that this may require you to check each score's average across a panel).
+When entering the ballots there is a toggle label *'Iron' speeches*. When set to "yes" this allows you to have the same speaker deliver multiple speeches provided their extra speeches are labelled on the form as 'duplicates'. Typically, most tournaments require that the lesser 'iron-person' speech is discarded from the tab, which would mean that you would mark the lower speaker of the two scores as the duplicate (note that this may require you to check each score's average across a panel).
 
 Speeches marked as duplicates are not included in the speaker tab. This means that they can also be used to exclude swing speakers from the tab as needed; even if they do not actually speak twice. To do so, change the name of the swing speaker to be that of an existing team member and ensure that that speech is marked as a duplicate.
 

--- a/docs/guide/tournament-logistics.rst
+++ b/docs/guide/tournament-logistics.rst
@@ -330,7 +330,7 @@ If at all feasible you want to train that volunteers acting as runners and/or da
   - Run through this in the actual tab room; illustrating examples with actual ballots and going through the roles in the actual spots which they will occur.
   - Run through how the seating/table/box arrangement works and the types of roles at different positions.
   - Emphasise that in general, any ambiguities should be raised with the tab directors/assistants; i.e. that you should never guess about ballots but instead always delegate resolving issues to someone else.
-  - Run through the different edge cases and things to check during entry. For example Iron Person speeches, mismatched totals, entering the wrong ballot for the wrong panellist, etc (see section below). Be sure to also go through what happens when the validation step fails; i.e. when a ballot needs to be re-entered.
+  - Run through the different edge cases and things to check during entry. For example, iron-person speeches, mismatched totals, entering the wrong ballot for the wrong panellist, etc. (see section below). Be sure to also go through what happens when the validation step fails; i.e. when a ballot needs to be re-entered.
 
 Training the adjudication core
 ------------------------------

--- a/tabbycat/results/templates/BallotEntryHeader.vue
+++ b/tabbycat/results/templates/BallotEntryHeader.vue
@@ -70,7 +70,7 @@
         </div>
         <div class="alert alert-info mb-0" v-if="showDuplicates">
           Speeches marked as 'duplicates' are hidden from the speaker tab and often need to be
-          tracked in order to determine break eligibility. If a speaker is 'iron-manning' you would
+          tracked in order to determine break eligibility. If a speaker is 'iron-personing' you would
           typically set their lowest-scoring speech as the 'duplicate'.
         </div>
       </div>

--- a/tabbycat/results/templates/ballot/ballot_speaks.html
+++ b/tabbycat/results/templates/ballot/ballot_speaks.html
@@ -16,7 +16,7 @@
 
         <div class="iron-person small pt-0 m-0 form-check form-check-inline" style="display: none;"
                data-toggle="tooltip" data-placement="bottom"
-               title="{% trans "Duplicate speeches are hidden from the speaker tab. If a speaker is 'iron-manning' you would typically mark only the lesser of their scores as a duplicate." %}">
+               title="{% trans "Duplicate speeches are hidden from the speaker tab. If a speaker is 'iron-personing' you would typically mark only the lesser of their scores as a duplicate." %}">
           {{ position.ghost|addcss:"form-check-input" }}
           <span class="mt-2"></span>
           {{ position.ghost.label_tag }}

--- a/tabbycat/utils/tables.py
+++ b/tabbycat/utils/tables.py
@@ -924,13 +924,13 @@ class TabbycatTableBuilder(BaseTableBuilder):
 
                     popover_text = []
                     if debateteam.iron > 0 and debateteam.iron_prev > 0:
-                        popover_text = _("Team iron-manned this round and the last.")
+                        popover_text = _("Team iron-personed this round and the last.")
                         warning_level = "text-info"
                     elif debateteam.iron > 0:
-                        popover_text = _("Team iron-manned this round.")
+                        popover_text = _("Team iron-personed this round.")
                         warning_level = "text-info"
                     else:
-                        popover_text = _("Team iron-manned last round.")
+                        popover_text = _("Team iron-personed last round.")
                         warning_level = "text-warning"
 
                     cell['class'] = "%s strong" % warning_level


### PR DESCRIPTION
Elsewhere in the Tabbycat interface, the phrase "iron man" has been replaced with "iron person". 
I noticed it's still present in these popovers. I'm proposing this change for the sake of 
consistency.