### PR TITLE
Fix assistant form behaviour when checks bypassed

### DIFF
--- a/tabbycat/results/templates/assistant_enter_results.html
+++ b/tabbycat/results/templates/assistant_enter_results.html
@@ -43,7 +43,7 @@
           <input id="id_confirmed" type="hidden" name="confirmed" value="True" />
           <div class="row">
             <div class="col">
-              <input id="correct" {% if request.user == ballotsub.submitter or form.confirmed.field.disabled %}disabled="disabled"{% endif %} class="btn {% if request.user != ballotsub.submitter %}btn-success{% endif %} btn-block" type="submit" value="{% trans "Confirm results" %}" tabindex="{{ form.nexttabindex }}" />
+              <input id="correct" {% if not new and request.user == ballotsub.submitter or form.confirmed.field.disabled %}disabled="disabled"{% endif %} class="btn btn-success btn-block" type="submit" value="{% trans "Confirm results" %}" tabindex="{{ form.nexttabindex }}" />
             </div>
             <div class="col">
               <input id="incorrect" class="btn btn-danger btn-block" type="button" value="{% trans "Results are incorrect" %}" tabindex="{{ form.nexttabindex|add:1 }}" />


### PR DESCRIPTION
Discovered when reviewing #1905. The assistant form does weird things when `disable_ballot_confirms` (bypass double-checking) is enabled:
<img width="918" alt="image" src="https://user-images.githubusercontent.com/1725499/143851553-50e8a6d4-a998-46a4-b23f-a9af5dce2056.png">

I think it's just disabling the button on a weaker condition than it should be applying, as indicated by the `not new` condition a few lines above it (for displaying the "can't confirm your own entry" error message).

Also, I don't know why there's a condition on the `btn-success` class… I assume it was to stylize the button differently when it's disabled, but our CSS already does that.