### PR TITLE
Bump channels to 3.0.4

### DIFF
--- a/config/requirements_core.txt
+++ b/config/requirements_core.txt
@@ -28,7 +28,7 @@ psycopg2==2.9.2                         # For Django to talk to postgres
 
 # Channels
 asgiref==3.3.4                          # Must set version to avoid Channels bug #1713
-channels==2.4.0                         # Channels; also includes the Daphne server
+channels==3.0.4                         # Channels; also includes the Daphne server
 channels_redis==3.2.0                   # Channels Layer
 
 # Misc

--- a/tabbycat/routing.py
+++ b/tabbycat/routing.py
@@ -1,6 +1,7 @@
 from channels.auth import AuthMiddlewareStack
 from channels.routing import ChannelNameRouter, ProtocolTypeRouter, URLRouter
 from django.conf.urls import url
+from django.core.asgi import get_asgi_application
 
 from actionlog.consumers import ActionLogEntryConsumer
 from adjallocation.consumers import AdjudicatorAllocationWorkerConsumer, PanelEditConsumer
@@ -17,28 +18,29 @@ from venues.consumers import VenuesWorkerConsumer
 
 application = ProtocolTypeRouter({
 
-    # HTTP handled automatically
+    # HTTP handler
+    "http": get_asgi_application(),
 
     # WebSocket handlers
     "websocket": AuthMiddlewareStack(
         URLRouter([
             # TournamentOverviewContainer
-            url(r'^ws/(?P<tournament_slug>[-\w_]+)/action_logs/$', ActionLogEntryConsumer),
-            url(r'^ws/(?P<tournament_slug>[-\w_]+)/ballot_results/$', BallotResultConsumer),
-            url(r'^ws/(?P<tournament_slug>[-\w_]+)/ballot_statuses/$', BallotStatusConsumer),
+            url(r'^ws/(?P<tournament_slug>[-\w_]+)/action_logs/$', ActionLogEntryConsumer.as_asgi()),
+            url(r'^ws/(?P<tournament_slug>[-\w_]+)/ballot_results/$', BallotResultConsumer.as_asgi()),
+            url(r'^ws/(?P<tournament_slug>[-\w_]+)/ballot_statuses/$', BallotStatusConsumer.as_asgi()),
             # CheckInStatusContainer
-            url(r'^ws/(?P<tournament_slug>[-\w_]+)/checkins/$', CheckInEventConsumer),
+            url(r'^ws/(?P<tournament_slug>[-\w_]+)/checkins/$', CheckInEventConsumer.as_asgi()),
             # Draw and Preformed Panel Edits
-            url(r'^ws/(?P<tournament_slug>[-\w_]+)/round/(?P<round_seq>[-\w_]+)/debates/$', DebateEditConsumer),
-            url(r'^ws/(?P<tournament_slug>[-\w_]+)/round/(?P<round_seq>[-\w_]+)/panels/$', PanelEditConsumer),
+            url(r'^ws/(?P<tournament_slug>[-\w_]+)/round/(?P<round_seq>[-\w_]+)/debates/$', DebateEditConsumer.as_asgi()),
+            url(r'^ws/(?P<tournament_slug>[-\w_]+)/round/(?P<round_seq>[-\w_]+)/panels/$', PanelEditConsumer.as_asgi()),
         ]),
     ),
 
     # Worker handlers (which don't need a URL/protocol)
     "channel": ChannelNameRouter({
         # Name used in runworker cmd : SyncConsumer responsible
-        "notifications":  NotificationQueueConsumer, # Email sending
-        "adjallocation": AdjudicatorAllocationWorkerConsumer,
-        "venues": VenuesWorkerConsumer,
+        "notifications":  NotificationQueueConsumer.as_asgi(), # Email sending
+        "adjallocation": AdjudicatorAllocationWorkerConsumer.as_asgi(),
+        "venues": VenuesWorkerConsumer.as_asgi(),
     }),
 })


### PR DESCRIPTION
This upgrade is slightly nontrivial; it involves consequential compatibility changes:
https://channels.readthedocs.io/en/stable/releases/3.0.0.html

So just looking to get a second pair of eyes to make sure I haven't done anything stupid.