### PR TITLE
Wrap around colours for region statistics

### DIFF
--- a/tabbycat/participants/utils.py
+++ b/tabbycat/participants/utils.py
@@ -12,7 +12,7 @@ def regions_ordered(t):
 
     regions = Region.objects.all().order_by('name')
     data = [{
-        'seq': count + 1,
+        'seq': count % 9,  # There are 9 available colours
         'name': r.name,
         'id': r.id,
     } for count, r in enumerate(regions)]

--- a/tabbycat/templates/admin/style_guide.html
+++ b/tabbycat/templates/admin/style_guide.html
@@ -212,6 +212,7 @@
 
 <hr>
 
+<button class="btn btn-primary region-display region-0 h6">region-0</button>
 <button class="btn btn-primary region-display region-1 h6">region-1</button>
 <button class="btn btn-primary region-display region-2 h6">region-2</button>
 <button class="btn btn-primary region-display region-3 h6">region-3</button>
@@ -219,6 +220,7 @@
 <button class="btn btn-primary region-display region-5 h6">region-5</button>
 <button class="btn btn-primary region-display region-6 h6">region-6</button>
 <button class="btn btn-primary region-display region-7 h6">region-7</button>
+<button class="btn btn-primary region-display region-8 h6">region-8</button>
 
 <h6 class="mt-5">Allocation Conflicts Colors</h6>
 


### PR DESCRIPTION
The CSS for the region colours go from 0 to 8, but the tags are set from 1 on. This makes the 0th colour ignored, and makes the 9th region on the default purple colour (or black). To fix, the region sequence now uses modular arithmetic. The style page is also updated to show the other colours.