### PR TITLE
Enable Redis in Docker compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,7 @@ services:
       - DEBUG=1
       - IN_DOCKER=1
       - DISABLE_SENTRY=1
+      - DOCKER_REDIS=1
     ports:
       - "127.0.0.1:8000:8000"
     volumes:
@@ -55,6 +56,7 @@ services:
       - DEBUG=1
       - IN_DOCKER=1
       - DISABLE_SENTRY=1
+      - DOCKER_REDIS=1
     volumes:
       - ./tabbycat/settings:/tcd/tabbycat/settings
     working_dir: /tcd


### PR DESCRIPTION
Fixes #1932.

This sets the `DOCKER_REDIS` environment variable in docker-compose.yml, so that Redis will be set up as in settings/docker.py:
https://github.com/TabbycatDebate/tabbycat/blob/5c68911acd5fed04103493e2e60a81c2049a5a73/tabbycat/settings/docker.py#L20-L41

Redis seems to be necessary for the `"django.contrib.sessions.backends.cache"` session engine to work. Or at least, I think it is… I'm not sure if we fall back to another cache if Redis isn't running?