### PR TITLE
API: Add validation for unique together

### DIFF
--- a/tabbycat/api/serializers.py
+++ b/tabbycat/api/serializers.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
 from collections.abc import Mapping
+from functools import partialmethod
 from urllib import parse
 
 from django.core.exceptions import ValidationError as DjangoValidationError
@@ -28,6 +29,12 @@ from tournaments.models import Round, Tournament
 from venues.models import Venue, VenueCategory
 
 from . import fields
+
+
+def _validate_field(self, field, value):
+    if value is not None and self.Meta.model.objects.filter(tournament=self.context['tournament'], **{field: value}).exists():
+        raise serializers.ValidationError("Object with same value exists in the tournament")
+    return value
 
 
 class TournamentSerializer(serializers.ModelSerializer):
@@ -102,6 +109,11 @@ class RoundSerializer(serializers.ModelSerializer):
             model = RoundMotion
             exclude = ('round', 'motion')
 
+        def validate_seq(self, value):
+            if self.Meta.model.objects.filter(round=self.context['round'], seq=value).exists():
+                raise serializers.ValidationError("Object with same value exists in the round")
+            return value
+
         def create(self, validated_data):
             motion_data = validated_data.pop('motion')
             if '' in motion_data:
@@ -144,6 +156,8 @@ class RoundSerializer(serializers.ModelSerializer):
     class Meta:
         model = Round
         exclude = ('tournament',)
+
+    validate_seq = partialmethod(_validate_field, 'seq')
 
     def validate(self, data):
         if (data.get('break_category') is None) == (data.get('stage', Round.STAGE_ELIMINATION) == Round.STAGE_ELIMINATION):
@@ -286,6 +300,9 @@ class BreakCategorySerializer(serializers.ModelSerializer):
         model = BreakCategory
         exclude = ('tournament', 'breaking_teams')
 
+    validate_slug = partialmethod(_validate_field, 'slug')
+    validate_seq = partialmethod(_validate_field, 'seq')
+
 
 class SpeakerCategorySerializer(serializers.ModelSerializer):
 
@@ -300,6 +317,9 @@ class SpeakerCategorySerializer(serializers.ModelSerializer):
     class Meta:
         model = SpeakerCategory
         exclude = ('tournament',)
+
+    validate_slug = partialmethod(_validate_field, 'slug')
+    validate_seq = partialmethod(_validate_field, 'seq')
 
 
 class BaseEligibilitySerializer(serializers.ModelSerializer):
@@ -353,6 +373,11 @@ class BreakingTeamSerializer(serializers.ModelSerializer):
     class Meta:
         model = BreakingTeam
         exclude = ('id', 'break_category')
+
+    def validate_team(self, value):
+        if self.Meta.model.objects.filter(**{'break_category': self.context['break_category'], 'team': value}).exists():
+            raise serializers.ValidationError("Object with same value already exists")
+        return value
 
 
 class PartialBreakingTeamSerializer(BreakingTeamSerializer):
@@ -534,9 +559,15 @@ class TeamSerializer(serializers.ModelSerializer):
             if not t.pref('public_break_categories'):
                 self.fields.pop('break_categories')
 
+    validate_emoji = partialmethod(_validate_field, 'emoji')
+
     def validate(self, data):
-        if data.get('use_institution_prefix', False) and data.get('institution') is None:
-            raise serializers.ValidationError("Cannot include institution prefix without institution.")
+        t = self.context['tournament']
+        if data.get('institution') is None:
+            if data.get('use_institution_prefix', False):
+                raise serializers.ValidationError("Cannot include institution prefix without institution.")
+        elif Team.objects.filter(tournament=t, reference=data['reference'], institution=data['institution']).exists():
+            raise serializers.ValidationError("Object with same reference and institution exists in the tournament")
         return super().validate(data)
 
     def create(self, validated_data):
@@ -760,6 +791,9 @@ class FeedbackQuestionSerializer(serializers.ModelSerializer):
     class Meta:
         model = AdjudicatorFeedbackQuestion
         exclude = ('tournament',)
+
+    validate_reference = partialmethod(_validate_field, 'reference')
+    validate_seq = partialmethod(_validate_field, 'seq')
 
 
 class FeedbackSerializer(TabroomSubmissionFieldsMixin, serializers.ModelSerializer):
@@ -1031,22 +1065,22 @@ class BallotSerializer(TabroomSubmissionFieldsMixin, serializers.ModelSerializer
                 required=False, allow_null=True,
             )
 
-            def validate(self, data):
+            def validate_adjudicator(self, value):
                 # Make sure adj is in debate
-                adj = data.get('adjudicator', None)
                 debate = self.context.get('debate')
-                if adj is not None and not debate.debateadjudicator_set.filter(adjudicator=adj).exists():
+                if value is not None and not debate.debateadjudicator_set.filter(adjudicator=value).exists():
                     raise serializers.ValidationError('Adjudicator must be in debate')
+                return value
 
+            def validate_teams(self, value):
                 # Teams in their proper positions - this also checks having proper and consistent sides
-                teams = data.get('teams', {})
-                if len(teams) != debate.debateteam_set.count():
+                debate = self.context.get('debate')
+                if len(value) != debate.debateteam_set.count():
                     raise serializers.ValidationError('Incorrect number of teams')
-                for team in teams:
+                for team in value:
                     if debate.get_team(team['side']) != team['team']:
                         raise serializers.ValidationError('Inconsistent team')
-
-                return data
+                return value
 
             def save(self, **kwargs):
                 team_serializer = self.TeamResultSerializer(context=self.context)


### PR DESCRIPTION
As DRF cannot detect exceptions caused by unique together constraints where some fields are not in the serializer (tournament), this commit adds a free method that checks for the existence of such object and raises a validation error on that field, with `partialmethod`. More complex contraints are in the general validation method.

Should check:

- [ ] The free method with `partialmethod` can actually detect and handle the situations
- [x] Updating existing objects to the same value doesn't hit