### PR TITLE
Remove rank annotators from draw generation

### DIFF
--- a/tabbycat/draw/manager.py
+++ b/tabbycat/draw/manager.py
@@ -197,7 +197,7 @@ class PowerPairedDrawManager(BaseDrawManager):
         metrics = self.round.tournament.pref('team_standings_precedence')
         pullup_metric = PowerPairedDrawGenerator.PULLUP_RESTRICTION_METRICS[self.round.tournament.pref('draw_pullup_restriction')]
 
-        generator = TeamStandingsGenerator(metrics, ('rank', 'subrank'), tiebreak="random",
+        generator = TeamStandingsGenerator(metrics, (), tiebreak="random",
             extra_metrics=(pullup_metric,) if pullup_metric and pullup_metric not in metrics else ())
         standings = generator.generate(teams, round=self.round.prev)
 


### PR DESCRIPTION
Fixes #1997

The subrank annotator crashes when there is only one team standings metric (because there's nothing to subrank on). But I don't think the ranking annotators are necessary for draw generation anyway, as it just works on the ordering returned, not the rank annotations. So this just removes them.

See discussion in #1997 about whether this should be a hotfix.