### PR TITLE
Include IP addresses in django_action_log

### DIFF
--- a/tabbycat/actionlog/admin.py
+++ b/tabbycat/actionlog/admin.py
@@ -1,5 +1,7 @@
 from django.contrib import admin
 
+from utils.admin import ModelAdmin
+
 from .models import ActionLogEntry
 
 # ==============================================================================
@@ -8,14 +10,14 @@ from .models import ActionLogEntry
 
 
 @admin.register(ActionLogEntry)
-class ActionLogEntryAdmin(admin.ModelAdmin):
+class ActionLogEntryAdmin(ModelAdmin):
     list_display = ('type', 'user', 'ip_address', 'timestamp', 'content_object',
                     'tournament', 'round')
     list_filter = ('tournament', 'user', 'type', 'content_type', 'round')
     search_fields = ('type', 'user__username')
 
     def get_queryset(self, request):
-        return super(ActionLogEntryAdmin, self).get_queryset(request).select_related(
+        return super().get_queryset(request).select_related(
             'tournament', 'round', 'round__tournament', 'user').prefetch_related('content_object')
 
     def has_add_permission(self, request, obj=None):

--- a/tabbycat/adjallocation/admin.py
+++ b/tabbycat/adjallocation/admin.py
@@ -2,6 +2,7 @@ from django.contrib import admin
 from django.db.models import Prefetch
 
 from draw.models import DebateTeam
+from utils.admin import ModelAdmin
 
 from .models import (AdjudicatorAdjudicatorConflict, AdjudicatorInstitutionConflict,
                      AdjudicatorTeamConflict, DebateAdjudicator, PreformedPanel,
@@ -9,7 +10,7 @@ from .models import (AdjudicatorAdjudicatorConflict, AdjudicatorInstitutionConfl
 
 
 @admin.register(DebateAdjudicator)
-class DebateAdjudicatorAdmin(admin.ModelAdmin):
+class DebateAdjudicatorAdmin(ModelAdmin):
     list_display = ('debate', 'adjudicator', 'type')
     search_fields = ('adjudicator__name', 'type')
     raw_id_fields = ('debate',)
@@ -26,7 +27,7 @@ class DebateAdjudicatorAdmin(admin.ModelAdmin):
 
 
 @admin.register(AdjudicatorTeamConflict)
-class AdjudicatorTeamConflictAdmin(admin.ModelAdmin):
+class AdjudicatorTeamConflictAdmin(ModelAdmin):
     list_display = ('adjudicator', 'team')
     list_select_related = ('adjudicator__institution', 'team__tournament')
     search_fields = ('adjudicator__name', 'team__short_name', 'team__long_name')
@@ -38,7 +39,7 @@ class AdjudicatorTeamConflictAdmin(admin.ModelAdmin):
 
 
 @admin.register(AdjudicatorAdjudicatorConflict)
-class AdjudicatorAdjudicatorConflictAdmin(admin.ModelAdmin):
+class AdjudicatorAdjudicatorConflictAdmin(ModelAdmin):
     list_display = ('adjudicator1', 'adjudicator2')
     list_select_related = ('adjudicator1__institution', 'adjudicator2__institution')
     search_fields = ('adjudicator1__name', 'adjudicator2__name',
@@ -46,14 +47,14 @@ class AdjudicatorAdjudicatorConflictAdmin(admin.ModelAdmin):
 
 
 @admin.register(AdjudicatorInstitutionConflict)
-class AdjudicatorInstitutionConflictAdmin(admin.ModelAdmin):
+class AdjudicatorInstitutionConflictAdmin(ModelAdmin):
     list_display = ('adjudicator', 'institution')
     list_select_related = ('adjudicator__institution', 'institution')
     search_fields = ('adjudicator__name', 'institution__name')
 
 
 @admin.register(TeamInstitutionConflict)
-class TeamInstitutionConflictAdmin(admin.ModelAdmin):
+class TeamInstitutionConflictAdmin(ModelAdmin):
     list_display = ('team', 'institution')
     list_select_related = ('team__institution', 'team__tournament', 'institution')
     search_fields = ('team__short_name', 'team__long_name', 'institution__name')
@@ -66,7 +67,7 @@ class PreformedPanelAdjudicatorInline(admin.TabularInline):
 
 
 @admin.register(PreformedPanel)
-class PreformedPanelAdmin(admin.ModelAdmin):
+class PreformedPanelAdmin(ModelAdmin):
     list_filter = ('round', 'round__tournament')
     list_display = ('id', 'round', 'importance', 'bracket_min', 'bracket_max', 'room_rank', 'liveness')
     list_select_related = ('round__tournament',)

--- a/tabbycat/adjfeedback/admin.py
+++ b/tabbycat/adjfeedback/admin.py
@@ -6,7 +6,7 @@ from django.utils.translation import gettext_lazy as _
 from django_better_admin_arrayfield.admin.mixins import DynamicArrayMixin
 
 from draw.models import DebateTeam
-from utils.admin import custom_titled_filter
+from utils.admin import custom_titled_filter, ModelAdmin
 
 from .models import (AdjudicatorBaseScoreHistory, AdjudicatorFeedback, AdjudicatorFeedbackBooleanAnswer,
     AdjudicatorFeedbackFloatAnswer, AdjudicatorFeedbackIntegerAnswer, AdjudicatorFeedbackManyAnswer,
@@ -18,7 +18,7 @@ from .models import (AdjudicatorBaseScoreHistory, AdjudicatorFeedback, Adjudicat
 # ==============================================================================
 
 @admin.register(AdjudicatorBaseScoreHistory)
-class AdjudicatorBaseScoreHistoryAdmin(admin.ModelAdmin):
+class AdjudicatorBaseScoreHistoryAdmin(ModelAdmin):
     list_display = ('adjudicator', 'round', 'score', 'timestamp')
     list_filter  = ('adjudicator', 'round')
     ordering     = ('timestamp',)
@@ -46,7 +46,7 @@ class QuestionForm(forms.ModelForm):
 
 
 @admin.register(AdjudicatorFeedbackQuestion)
-class AdjudicatorFeedbackQuestionAdmin(DynamicArrayMixin, admin.ModelAdmin):
+class AdjudicatorFeedbackQuestionAdmin(DynamicArrayMixin, ModelAdmin):
     form = QuestionForm
     list_display = ('reference', 'text', 'seq', 'tournament', 'answer_type',
                     'required', 'from_adj', 'from_team')
@@ -63,7 +63,7 @@ class AdjudicatorFeedbackQuestionAdmin(DynamicArrayMixin, admin.ModelAdmin):
 @admin.register(AdjudicatorFeedbackIntegerAnswer)
 @admin.register(AdjudicatorFeedbackManyAnswer)
 @admin.register(AdjudicatorFeedbackStringAnswer)
-class AdjudicatorFeedbackAnswerAdmin(admin.ModelAdmin):
+class AdjudicatorFeedbackAnswerAdmin(ModelAdmin):
     list_display = ('question', 'get_target', 'get_source', 'answer', 'get_feedback_description')
     list_select_related = ('question', 'feedback__adjudicator',
                            'feedback__source_adjudicator__adjudicator',
@@ -128,7 +128,7 @@ class RoundListFilter(admin.SimpleListFilter):
 # ==============================================================================
 
 @admin.register(AdjudicatorFeedback)
-class AdjudicatorFeedbackAdmin(admin.ModelAdmin):
+class AdjudicatorFeedbackAdmin(ModelAdmin):
     list_display  = ('adjudicator', 'confirmed', 'ignored', 'score', 'version', 'get_source')
     search_fields = ('adjudicator__name', 'adjudicator__institution__name',
             'score', 'source_adjudicator__adjudicator__name',

--- a/tabbycat/availability/admin.py
+++ b/tabbycat/availability/admin.py
@@ -1,11 +1,13 @@
 from django.contrib import admin
 from django.contrib.contenttypes.admin import GenericTabularInline
 
+from utils.admin import ModelAdmin
+
 from .models import RoundAvailability
 
 
 @admin.register(RoundAvailability)
-class RoundAvailabilityAdmin(admin.ModelAdmin):
+class RoundAvailabilityAdmin(ModelAdmin):
     list_display = ('content_object', 'content_type', 'round')
     list_filter = ('content_type__model', 'round')
 

--- a/tabbycat/breakqual/admin.py
+++ b/tabbycat/breakqual/admin.py
@@ -1,5 +1,7 @@
 from django.contrib import admin
 
+from utils.admin import ModelAdmin
+
 from .models import BreakCategory, BreakingTeam
 
 
@@ -8,7 +10,7 @@ from .models import BreakCategory, BreakingTeam
 # ==============================================================================
 
 @admin.register(BreakCategory)
-class BreakCategoryAdmin(admin.ModelAdmin):
+class BreakCategoryAdmin(ModelAdmin):
     list_display = ('name', 'slug', 'seq', 'tournament', 'break_size',
                     'priority', 'is_general', 'rule')
     list_filter = ('tournament', )
@@ -20,7 +22,7 @@ class BreakCategoryAdmin(admin.ModelAdmin):
 # ==============================================================================
 
 @admin.register(BreakingTeam)
-class BreakingTeamAdmin(admin.ModelAdmin):
+class BreakingTeamAdmin(ModelAdmin):
     list_display = ('break_category', 'team', 'rank', 'break_rank', 'remark')
     list_filter = ('break_category__tournament', 'break_category')
     search_fields = ('team__short_name', 'team__long_name',

--- a/tabbycat/checkins/admin.py
+++ b/tabbycat/checkins/admin.py
@@ -1,10 +1,12 @@
 from django.contrib import admin
 
+from utils.admin import ModelAdmin
+
 from .models import DebateIdentifier, Event, PersonIdentifier, VenueIdentifier
 
 
 @admin.register(PersonIdentifier)
-class PersonIdentifierAdmin(admin.ModelAdmin):
+class PersonIdentifierAdmin(ModelAdmin):
     base_model = PersonIdentifier
     list_display = ('person', 'barcode')
     list_filter = ('person__adjudicator__institution', 'person__speaker__team__institution')
@@ -13,7 +15,7 @@ class PersonIdentifierAdmin(admin.ModelAdmin):
 
 
 @admin.register(DebateIdentifier)
-class DebateIdentifierAdmin(admin.ModelAdmin):
+class DebateIdentifierAdmin(ModelAdmin):
     base_model = DebateIdentifier
     list_display = ('debate', 'barcode')
     list_filter = ('debate__round',)
@@ -21,7 +23,7 @@ class DebateIdentifierAdmin(admin.ModelAdmin):
 
 
 @admin.register(VenueIdentifier)
-class VenueIdentifierAdmin(admin.ModelAdmin):
+class VenueIdentifierAdmin(ModelAdmin):
     base_model = VenueIdentifier
     list_display = ('venue', 'barcode')
     list_filter = ('venue__venuecategory',)
@@ -29,7 +31,7 @@ class VenueIdentifierAdmin(admin.ModelAdmin):
 
 
 @admin.register(Event)
-class CheckinEventAdmin(admin.ModelAdmin):
+class CheckinEventAdmin(ModelAdmin):
     list_display = ('identifier', 'polymorphic_ctype', 'checkin_time')
     list_filter = ('identifier', 'identifier__polymorphic_ctype')
 

--- a/tabbycat/draw/admin.py
+++ b/tabbycat/draw/admin.py
@@ -3,7 +3,7 @@ from django.db.models import Prefetch
 from django.utils.translation import gettext_lazy, ngettext
 
 from adjallocation.models import DebateAdjudicator
-from utils.admin import TabbycatModelAdminFieldsMixin
+from utils.admin import ModelAdmin, TabbycatModelAdminFieldsMixin
 
 from .models import Debate, DebateTeam
 
@@ -13,7 +13,7 @@ from .models import Debate, DebateTeam
 # ==============================================================================
 
 @admin.register(DebateTeam)
-class DebateTeamAdmin(TabbycatModelAdminFieldsMixin, admin.ModelAdmin):
+class DebateTeamAdmin(TabbycatModelAdminFieldsMixin, ModelAdmin):
     list_display = ('team', 'side', 'debate', 'get_tournament', 'get_round')
     search_fields = ('team__long_name', 'team__short_name', 'team__institution__name', 'team__institution__code', 'flags')
     raw_id_fields = ('debate', 'team')
@@ -43,7 +43,7 @@ class DebateAdjudicatorInline(admin.TabularInline):
 
 
 @admin.register(Debate)
-class DebateAdmin(admin.ModelAdmin):
+class DebateAdmin(ModelAdmin):
     list_display = ('id', 'round', 'bracket', 'matchup', 'result_status', 'sides_confirmed')
     list_filter = ('round__tournament', 'round')
     list_editable = ('result_status', 'sides_confirmed')

--- a/tabbycat/motions/admin.py
+++ b/tabbycat/motions/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from utils.admin import TabbycatModelAdminFieldsMixin
+from utils.admin import ModelAdmin, TabbycatModelAdminFieldsMixin
 
 from .models import DebateTeamMotionPreference, Motion, RoundMotion
 
@@ -10,20 +10,20 @@ from .models import DebateTeamMotionPreference, Motion, RoundMotion
 # ==============================================================================
 
 @admin.register(Motion)
-class MotionAdmin(TabbycatModelAdminFieldsMixin, admin.ModelAdmin):
+class MotionAdmin(TabbycatModelAdminFieldsMixin, ModelAdmin):
     list_display = ('reference', 'text')
     list_filter = ('rounds',)
 
 
 @admin.register(DebateTeamMotionPreference)
-class DebateTeamMotionPreferenceAdmin(TabbycatModelAdminFieldsMixin, admin.ModelAdmin):
+class DebateTeamMotionPreferenceAdmin(TabbycatModelAdminFieldsMixin, ModelAdmin):
     list_display = ('ballot_submission', 'get_confirmed', 'get_team',
                     'get_team_side', 'preference', 'get_motion_ref')
     search_fields = ('motion__reference',)
 
 
 @admin.register(RoundMotion)
-class RoundMotionAdmin(TabbycatModelAdminFieldsMixin, admin.ModelAdmin):
+class RoundMotionAdmin(TabbycatModelAdminFieldsMixin, ModelAdmin):
     list_display = ('seq', 'round', 'motion')
     list_filter = ('round', 'motion')
     ordering = ('round__seq', 'seq')

--- a/tabbycat/notifications/admin.py
+++ b/tabbycat/notifications/admin.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 from django.utils import timezone
 
-from utils.admin import TabbycatModelAdminFieldsMixin
+from utils.admin import ModelAdmin, TabbycatModelAdminFieldsMixin
 
 from .models import BulkNotification, EmailStatus, SentMessage
 
@@ -14,7 +14,7 @@ def precise_timestamp_isoformat(model, field_name):
 
 
 @admin.register(SentMessage)
-class SentMessageAdmin(TabbycatModelAdminFieldsMixin, admin.ModelAdmin):
+class SentMessageAdmin(TabbycatModelAdminFieldsMixin, ModelAdmin):
     list_display = ('recipient', 'email', 'precise_timestamp', 'notification')
     list_filter = ('notification__round', 'method', 'notification__event')
     search_fields = ('message_id', 'recipient__name', 'email', 'recipient__email')
@@ -27,7 +27,7 @@ class SentMessageAdmin(TabbycatModelAdminFieldsMixin, admin.ModelAdmin):
 
 
 @admin.register(BulkNotification)
-class BulkNotificationAdmin(TabbycatModelAdminFieldsMixin, admin.ModelAdmin):
+class BulkNotificationAdmin(TabbycatModelAdminFieldsMixin, ModelAdmin):
     list_display = ('precise_timestamp', 'event', 'round', 'tournament')
     list_filter = ('tournament', 'round', 'event')
     ordering = ('-timestamp',)
@@ -39,7 +39,7 @@ class BulkNotificationAdmin(TabbycatModelAdminFieldsMixin, admin.ModelAdmin):
 
 
 @admin.register(EmailStatus)
-class EmailStatusAdmin(TabbycatModelAdminFieldsMixin, admin.ModelAdmin):
+class EmailStatusAdmin(TabbycatModelAdminFieldsMixin, ModelAdmin):
     list_display = ('email', 'event', 'precise_timestamp')
     list_filter = ('event',)
     ordering = ('-timestamp',)

--- a/tabbycat/participants/admin.py
+++ b/tabbycat/participants/admin.py
@@ -12,6 +12,7 @@ from availability.admin import RoundAvailabilityInline
 from breakqual.models import BreakCategory
 from draw.models import TeamSideAllocation
 from tournaments.models import Tournament
+from utils.admin import ModelAdmin
 from venues.admin import VenueConstraintInline
 
 from .emoji import pick_unused_emoji, populate_code_names_from_emoji, set_emoji
@@ -23,7 +24,7 @@ from .models import Adjudicator, Institution, Region, Speaker, SpeakerCategory, 
 # ==============================================================================
 
 @admin.register(Region)
-class RegionAdmin(admin.ModelAdmin):
+class RegionAdmin(ModelAdmin):
     pass
 
 
@@ -32,7 +33,7 @@ class RegionAdmin(admin.ModelAdmin):
 # ==============================================================================
 
 @admin.register(Institution)
-class InstitutionAdmin(admin.ModelAdmin):
+class InstitutionAdmin(ModelAdmin):
     list_display = ('name', 'code', 'region')
     list_select_related = ('region',)
     ordering = ('name', )
@@ -44,7 +45,7 @@ class InstitutionAdmin(admin.ModelAdmin):
 # ==============================================================================
 
 @admin.register(Speaker)
-class SpeakerAdmin(admin.ModelAdmin):
+class SpeakerAdmin(ModelAdmin):
     list_filter = ('team__tournament', 'team__institution')
     list_display = ('name', 'team', 'gender')
     search_fields = ('name', 'team__short_name', 'team__long_name',
@@ -57,7 +58,7 @@ class SpeakerAdmin(admin.ModelAdmin):
 # ==============================================================================
 
 @admin.register(SpeakerCategory)
-class SpeakerCategoryAdmin(admin.ModelAdmin):
+class SpeakerCategoryAdmin(ModelAdmin):
     list_display = ('name', 'slug', 'seq', 'tournament', 'limit', 'public')
     list_filter = ('tournament', )
     ordering = ('tournament', 'seq')
@@ -115,7 +116,7 @@ class AdjudicatorTeamConflictInline(admin.TabularInline):
 
 
 @admin.register(Team)
-class TeamAdmin(admin.ModelAdmin):
+class TeamAdmin(ModelAdmin):
     form = TeamForm
     list_display = ('long_name', 'short_name', 'emoji', 'institution',
                     'tournament')
@@ -206,7 +207,7 @@ class AdjudicatorForm(forms.ModelForm):
 
 
 @admin.register(Adjudicator)
-class AdjudicatorAdmin(admin.ModelAdmin):
+class AdjudicatorAdmin(ModelAdmin):
     form = AdjudicatorForm
     list_display = ('name', 'institution', 'tournament', 'trainee',
                     'independent', 'adj_core', 'gender', 'base_score')

--- a/tabbycat/results/admin.py
+++ b/tabbycat/results/admin.py
@@ -5,7 +5,7 @@ from django.db.models import OuterRef, Prefetch, Subquery
 from django.utils.translation import gettext_lazy as _, ngettext_lazy
 
 from draw.models import DebateTeam
-from utils.admin import TabbycatModelAdminFieldsMixin
+from utils.admin import ModelAdmin, TabbycatModelAdminFieldsMixin
 
 from .models import BallotSubmission, SpeakerScore, SpeakerScoreByAdj, TeamScore, TeamScoreByAdj
 from .prefetch import populate_results
@@ -16,7 +16,7 @@ from .prefetch import populate_results
 # ==============================================================================
 
 @admin.register(BallotSubmission)
-class BallotSubmissionAdmin(TabbycatModelAdminFieldsMixin, admin.ModelAdmin):
+class BallotSubmissionAdmin(TabbycatModelAdminFieldsMixin, ModelAdmin):
     list_display = ('id', 'debate', 'version', 'get_round', 'timestamp',
             'submitter_type', 'submitter', 'confirmer', 'confirmed')
     list_editable = ('confirmed',)
@@ -52,7 +52,7 @@ class BallotSubmissionAdmin(TabbycatModelAdminFieldsMixin, admin.ModelAdmin):
 # ==============================================================================
 
 @admin.register(TeamScore)
-class TeamScoreAdmin(TabbycatModelAdminFieldsMixin, admin.ModelAdmin):
+class TeamScoreAdmin(TabbycatModelAdminFieldsMixin, ModelAdmin):
     list_display = ('id', 'ballot_submission', 'get_round', 'get_team', 'points', 'win', 'score')
     search_fields = ('debate_team__debate__round__seq', 'debate_team__debate__round__tournament__name',
                      'debate_team__team__reference', 'debate_team__team__institution__name')
@@ -72,7 +72,7 @@ class TeamScoreAdmin(TabbycatModelAdminFieldsMixin, admin.ModelAdmin):
 # ==============================================================================
 
 @admin.register(TeamScoreByAdj)
-class TeamScoreByAdjAdmin(TabbycatModelAdminFieldsMixin, admin.ModelAdmin):
+class TeamScoreByAdjAdmin(TabbycatModelAdminFieldsMixin, ModelAdmin):
     list_display = ('id', 'ballot_submission', 'get_round', 'get_adj_name', 'get_team', 'win', 'margin', 'score')
     search_fields = ('debate_team__debate__round__seq', 'debate_team__debate__round__tournament__name',
                      'debate_team__team__reference', 'debate_team__team__institution__name')
@@ -95,7 +95,7 @@ class TeamScoreByAdjAdmin(TabbycatModelAdminFieldsMixin, admin.ModelAdmin):
 # ==============================================================================
 
 @admin.register(SpeakerScore)
-class SpeakerScoreAdmin(TabbycatModelAdminFieldsMixin, admin.ModelAdmin):
+class SpeakerScoreAdmin(TabbycatModelAdminFieldsMixin, ModelAdmin):
     list_display = ('id', 'ballot_submission', 'get_round', 'get_team', 'position',
                     'get_speaker_name', 'score', 'ghost')
     search_fields = ('debate_team__debate__round__abbreviation',
@@ -118,7 +118,7 @@ class SpeakerScoreAdmin(TabbycatModelAdminFieldsMixin, admin.ModelAdmin):
 # ==============================================================================
 
 @admin.register(SpeakerScoreByAdj)
-class SpeakerScoreByAdjAdmin(TabbycatModelAdminFieldsMixin, admin.ModelAdmin):
+class SpeakerScoreByAdjAdmin(TabbycatModelAdminFieldsMixin, ModelAdmin):
     list_display = ('id', 'ballot_submission', 'get_round', 'get_adj_name', 'get_team',
                     'get_speaker_name', 'position', 'score')
     search_fields = ('debate_team__debate__round__seq',

--- a/tabbycat/tournaments/admin.py
+++ b/tabbycat/tournaments/admin.py
@@ -1,5 +1,7 @@
 from django.contrib import admin
 
+from utils.admin import ModelAdmin
+
 from .models import Round, Tournament
 
 
@@ -8,7 +10,7 @@ from .models import Round, Tournament
 # ==============================================================================
 
 @admin.register(Tournament)
-class TournamentAdmin(admin.ModelAdmin):
+class TournamentAdmin(ModelAdmin):
     list_display = ('name', 'slug', 'seq', 'short_name', 'current_round', 'active')
     ordering = ('seq', )
 
@@ -18,7 +20,7 @@ class TournamentAdmin(admin.ModelAdmin):
 # ==============================================================================
 
 @admin.register(Round)
-class RoundAdmin(admin.ModelAdmin):
+class RoundAdmin(ModelAdmin):
     list_display = ('name', 'tournament', 'seq', 'abbreviation', 'stage',
                     'draw_type', 'draw_status', 'feedback_weight', 'silent',
                     'motions_released', 'starts_at', 'completed')

--- a/tabbycat/venues/admin.py
+++ b/tabbycat/venues/admin.py
@@ -4,12 +4,13 @@ from django.contrib.contenttypes.admin import GenericTabularInline
 from gfklookupwidget.widgets import GfkLookupWidget
 
 from availability.admin import RoundAvailabilityInline
+from utils.admin import ModelAdmin
 
 from .models import Venue, VenueCategory, VenueConstraint
 
 
 @admin.register(Venue)
-class VenueAdmin(admin.ModelAdmin):
+class VenueAdmin(ModelAdmin):
     list_display = ('display_name', 'priority', 'tournament', 'categories_list')
     list_filter = ('venuecategory', 'priority', 'tournament')
     search_fields = ('name',)
@@ -24,7 +25,7 @@ class VenueAdmin(admin.ModelAdmin):
 
 
 @admin.register(VenueCategory)
-class VenueCategoryAdmin(admin.ModelAdmin):
+class VenueCategoryAdmin(ModelAdmin):
     list_display = ('name', 'description', 'display_in_venue_name',
             'display_in_public_tooltip', 'venues_list')
     ordering = ('name',)
@@ -49,7 +50,7 @@ class VenueConstraintModelForm(forms.ModelForm):
 
 
 @admin.register(VenueConstraint)
-class VenueConstraintAdmin(admin.ModelAdmin):
+class VenueConstraintAdmin(ModelAdmin):
     form = VenueConstraintModelForm
     list_display = ('subject', 'category', 'priority')
     search_fields = ('adjudicator__name', 'adjudicator__institution__code',


### PR DESCRIPTION
For better tracking of users' actions through the Database; add IP address to the message when using the Database. If the logs are downloaded, the IPs will appear. This would improve the current situation where usernames may not accurately show who performed an action if they are shared.

Fixes #1989.