### PR TITLE
Revert "Use updated template tags for translations (#1872)"

### DIFF
--- a/tabbycat/adjallocation/templates/preformed_index.html
+++ b/tabbycat/adjallocation/templates/preformed_index.html
@@ -2,21 +2,21 @@
 {% load debate_tags i18n %}
 
 {% block head-title %}
-  <span class="emoji">📦</span>{% translate "Preformed Panels" %}
+  <span class="emoji">📦</span>{% trans "Preformed Panels" %}
 {% endblock %}
 
 {% block page-alerts %}
 
-  {% blocktranslate trimmed asvar p1 %}
+  {% blocktrans trimmed asvar p1 %}
     A preformed panel is a defined group of adjudicators that is specified for a round before its
     draw has been generated. You can then manually or automatically apply these panels during the
     normal adjudicator allocation process. This can make allocations faster or allow you
     to create more considered panels of adjudicators.
-  {% endblocktranslate %}
-  {% blocktranslate trimmed asvar p2 %}
+  {% endblocktrans %}
+  {% blocktrans trimmed asvar p2 %}
     Note that only adjudicators who have been marked as 'available' for that round will be able to
     be allocated for that round, so you may need to set their availability in advance.
-  {% endblocktranslate %}
+  {% endblocktrans %}
 
   {% include "components/explainer-card.html" with type="info" %}
 
@@ -34,9 +34,9 @@
         {% endif %}
       {% endifchanged %}
 
-      {% blocktranslate trimmed asvar text with round=r.name %}
+      {% blocktrans trimmed asvar text with round=r.name %}
         Edit Preformed Panels for {{ round }}
-      {% endblocktranslate %}
+      {% endblocktrans %}
       {% roundurl 'edit-panel-adjudicators' r as url %}
       {% if r.draw_status == r.STATUS_CONFIRMED %}
         {% include "components/item-action.html" with type="dark" %}

--- a/tabbycat/adjfeedback/templates/add_feedback.html
+++ b/tabbycat/adjfeedback/templates/add_feedback.html
@@ -2,7 +2,7 @@
 {% load debate_tags i18n %}
 {% load static %}
 
-{% block head-title %}{% translate "Who is the feedback from?" %}{% endblock %}
-{% block page-title %}{% translate "Enter Feedback" %}{% endblock %}
+{% block head-title %}{% trans "Who is the feedback from?" %}{% endblock %}
+{% block page-title %}{% trans "Enter Feedback" %}{% endblock %}
 
 {% block page-subnav-actions %}{% endblock %}

--- a/tabbycat/adjfeedback/templates/enter_feedback.html
+++ b/tabbycat/adjfeedback/templates/enter_feedback.html
@@ -2,15 +2,15 @@
 
 {% load add_field_css i18n %}
 
-{% block page-title %}🙅 {% translate "Enter Feedback" %}{% endblock %}
+{% block page-title %}🙅 {% trans "Enter Feedback" %}{% endblock %}
 {% block head-title %}
   <span class="emoji">🙅</span>
   {% if source_name %}
-    {% blocktranslate trimmed with name=source_name %}
+    {% blocktrans trimmed with name=source_name %}
       Add Feedback from {{ name }}
-    {% endblocktranslate %}
+    {% endblocktrans %}
   {% else %}
-    {% translate "Add Feedback" %}
+    {% trans "Add Feedback" %}
   {% endif %}
 {% endblock %}
 {% block extra-head %}<meta name="robots" content="noindex" />{% endblock %}
@@ -18,15 +18,15 @@
 {% block content %}
 
   {% if no_rounds_released %} {# only set for public views #}
-    {% translate "There are no feedback options because no rounds have been released to the public yet. Check back when they have!" as message %}
+    {% trans "There are no feedback options because no rounds have been released to the public yet. Check back when they have!" as message %}
     {% include "components/alert.html" with type="info" %}
   {% endif %}
 
   {% if source_type == 'team' %}
     {% if pref.feedback_from_teams == 'orallist' %}
-      {% translate "This tournament expects you to submit feedback <strong>only on the adjudicator who delivered the adjudication</strong>. Do not submit feedback on other adjudicators." as message %}
+      {% trans "This tournament expects you to submit feedback <strong>only on the adjudicator who delivered the adjudication</strong>. Do not submit feedback on other adjudicators." as message %}
     {% else %}
-      {% translate "This tournament expects you to submit feedback on all of the adjudicators on the panel (including trainees)." as message %}
+      {% trans "This tournament expects you to submit feedback on all of the adjudicators on the panel (including trainees)." as message %}
     {% endif %}
     {% include "components/alert.html" with type="info" %}
   {% endif %}
@@ -40,7 +40,7 @@
         <div class="list-group-item pb-4">
 
           {% if form.errors %}
-            {% translate "There are some problems with this feedback submission. Please review and correct them." as message %}
+            {% trans "There are some problems with this feedback submission. Please review and correct them." as message %}
             {% include "components/form-errors.html" with errors=form.errors %}
           {% endif %}
 
@@ -55,7 +55,7 @@
 
         </div>
 
-        {% translate "When submitting this form your IP address will be stored for logging purposes." as subtitle %}
+        {% trans "When submitting this form your IP address will be stored for logging purposes." as subtitle %}
         {% include "components/form-submit.html" with title="Save Feedback" %}
 
       </div>

--- a/tabbycat/adjfeedback/templates/feedback_base.html
+++ b/tabbycat/adjfeedback/templates/feedback_base.html
@@ -5,40 +5,40 @@
   <div class="btn-group flex-wrap">
     <a class="btn btn-outline-primary {% if feedback_overview_nav %}active disabled{% endif %}"
        href="{% tournamenturl 'adjfeedback-overview' %}">
-      {% translate "Overview" %}
+      {% trans "Overview" %}
     </a>
     <a class="btn btn-outline-primary {% if feedback_latest_nav %}active disabled{% endif %}"
        href="{% tournamenturl 'adjfeedback-view-latest' %}">
-      {% translate "Latest" %}
+      {% trans "Latest" %}
     </a>
     <a class="btn btn-outline-primary {% if feedback_progress_nav %}active disabled{% endif %}"
        href="{% tournamenturl 'adjfeedback-progress' %}">
-      {% translate "Unsubmitted" %}
+      {% trans "Unsubmitted" %}
     </a>
     <a class="btn btn-outline-primary {% if feedback_important_nav %}active disabled{% endif %}"
        href="{% tournamenturl 'adjfeedback-view-important' %}">
-      {% translate "Important" %}
+      {% trans "Important" %}
     </a>
     <a class="btn btn-outline-primary {% if feedback_comments_nav %}active disabled{% endif %}"
        href="{% tournamenturl 'adjfeedback-view-comments' %}">
-      {% translate "Comments" %}
+      {% trans "Comments" %}
     </a>
     <a class="btn btn-outline-primary {% if feedback_source_nav %}active disabled{% endif %}"
        href="{% tournamenturl 'adjfeedback-view-by-source' %}">
-      {% translate "By Source" %}
+      {% trans "By Source" %}
     </a>
     <a class="btn btn-outline-primary {% if feedback_target_nav %}active disabled{% endif %}"
        href="{% tournamenturl 'adjfeedback-view-by-target' %}">
-      {% translate "By Target" %}
+      {% trans "By Target" %}
     </a>
   </div>
 {% endblock %}
 
 {% block page-subnav-actions %}
   <a class="btn btn-outline-success" href="{% tournamenturl 'adjfeedback-update-scores-bulk' %}">
-    {% translate "Bulk Update Scores" %}
+    {% trans "Bulk Update Scores" %}
   </a>
   <a class="btn btn-outline-success" href="{% tournamenturl 'adjfeedback-add-index' %}">
-    {% translate "Add Feedback" %}
+    {% trans "Add Feedback" %}
   </a>
 {% endblock %}

--- a/tabbycat/adjfeedback/templates/feedback_by_source.html
+++ b/tabbycat/adjfeedback/templates/feedback_by_source.html
@@ -1,22 +1,22 @@
 {% extends "feedback_base.html" %}
 {% load debate_tags i18n %}
 
-{% block head-title %}{% blocktranslate trimmed %}Feedback {{ source_type }} {{ source_name }}{% endblocktranslate %}{% endblock %}
-{% block page-title %}{% blocktranslate trimmed %}Feedback {{ source_type }} {{ source_name }}{% endblocktranslate %}{% endblock %}
+{% block head-title %}{% blocktrans trimmed %}Feedback {{ source_type }} {{ source_name }}{% endblocktrans %}{% endblock %}
+{% block page-title %}{% blocktrans trimmed %}Feedback {{ source_type }} {{ source_name }}{% endblocktrans %}{% endblock %}
 
 {% block content %}
 
   {% if feedbacks.count == 0 %}
 
     {% if source_type == 'from' %}
-      {% blocktranslate trimmed asvar message %}
+      {% blocktrans trimmed asvar message %}
         {{ source_name }} hasn't submitted any feedback yet.
-      {% endblocktranslate %}
+      {% endblocktrans %}
     {% endif %}
     {% if source_type == 'on' %}
-      {% blocktranslate trimmed asvar message %}
+      {% blocktrans trimmed asvar message %}
         {{ source_name }} hasn't received any feedback yet.
-      {% endblocktranslate %}
+      {% endblocktrans %}
     {% endif %}
     {% include "components/alert.html" with type="info" %}
 

--- a/tabbycat/adjfeedback/templates/feedback_card.html
+++ b/tabbycat/adjfeedback/templates/feedback_card.html
@@ -5,19 +5,19 @@
 
     {% if not feedback.confirmed %}
       <div class="list-group-item list-group-item-warning h6" data-toggle="tooltip"
-           title="{% translate 'This is most likely because the team or adjudicator who submitted this feedback has submitted several times on the same person; or because a team has submitted feedback on multiple panellists (rather than just the orallist).' %}">
-      {% translate "Unconfirmed; will not affect this adjudicator's score." %}
+           title="{% trans 'This is most likely because the team or adjudicator who submitted this feedback has submitted several times on the same person; or because a team has submitted feedback on multiple panellists (rather than just the orallist).' %}">
+      {% trans "Unconfirmed; will not affect this adjudicator's score." %}
       </div>
     {% endif %}
     {% if feedback.ignored %}
       <div class="list-group-item list-group-item-warning h6" data-toggle="tooltip"
-           title="{% translate 'The feedback is counted for the adjudicator, but is not taken into account when calculating scores.' %}">
-      {% translate "Ignored; will not affect this adjudicator's score." %}
+           title="{% trans 'The feedback is counted for the adjudicator, but is not taken into account when calculating scores.' %}">
+      {% trans "Ignored; will not affect this adjudicator's score." %}
       </div>
     {% endif %}
     {% if not feedback.debate_adjudicator.get_type_display %}
       <div class="list-group-item list-group-item-danger h6">
-        {% translate "This feedback is submitted on an adjudicator but it looks like they have been since been removed from the debate. You should probably go to the Edit Database area and delete this feedback." %}
+        {% trans "This feedback is submitted on an adjudicator but it looks like they have been since been removed from the debate. You should probably go to the Edit Database area and delete this feedback." %}
       </div>
     {% endif %}
     <div class="list-group-item h5">
@@ -26,36 +26,36 @@
             {% elif feedback.score <= score_thresholds.medium_score %}badge-warning
             {% elif feedback.score > score_thresholds.high_score %}badge-success
             {% else %}badge-primary{% endif %}" data-toggle="tooltip"
-            title="{% translate "The score given in this piece of feedback." %}">
-        {% blocktranslate trimmed with score=feedback.score round=feedback.round.abbreviation %}
+            title="{% trans "The score given in this piece of feedback." %}">
+        {% blocktrans trimmed with score=feedback.score round=feedback.round.abbreviation %}
           {{ round }} {{ score }}
-        {% endblocktranslate %}
+        {% endblocktrans %}
       </span>
-      {% blocktranslate trimmed with adjudicator=feedback.adjudicator.name %}
+      {% blocktrans trimmed with adjudicator=feedback.adjudicator.name %}
         On {{ adjudicator }}
-      {% endblocktranslate %}
+      {% endblocktrans %}
     </div>
     <div class="list-group-item h5">
-      {% blocktranslate trimmed with as=feedback.debate_adjudicator.get_type_display %}
+      {% blocktrans trimmed with as=feedback.debate_adjudicator.get_type_display %}
         <span class="text-secondary small">Received as {{ as }}</span>
-      {% endblocktranslate %}
+      {% endblocktrans %}
       <span class="badge float-right badge-secondary" data-toggle="tooltip">
-        {% blocktranslate trimmed with base=feedback.adjudicator.base_score|floatformat:"1" %}
+        {% blocktrans trimmed with base=feedback.adjudicator.base_score|floatformat:"1" %}
           Base {{ base }}
-        {% endblocktranslate %}
+        {% endblocktrans %}
       </span>
     </div>
     <div class="list-group-item h5">
       {% if feedback.source_adjudicator %}
-        {% blocktranslate trimmed with source=feedback.source_adjudicator.adjudicator.name relationship=feedback.source_adjudicator.get_type_display %}
+        {% blocktrans trimmed with source=feedback.source_adjudicator.adjudicator.name relationship=feedback.source_adjudicator.get_type_display %}
           From {{ source }} <span class="text-secondary small">(their {{ relationship }})</span>
-        {% endblocktranslate %}
+        {% endblocktrans %}
       {% elif feedback.source_team %}
-        {% blocktranslate trimmed with source=feedback.source_team.team.short_name relationship=feedback.source_team.get_result_display|safe side=feedback.source_team.get_side_abbr %}
+        {% blocktrans trimmed with source=feedback.source_team.team.short_name relationship=feedback.source_team.get_result_display|safe side=feedback.source_team.get_side_abbr %}
           From {{ source }} <span class="text-secondary small">({{ relationship }} from {{ side }})</span>
-        {% endblocktranslate %}
+        {% endblocktrans %}
       {% else %}
-        {% translate "From unknown" %}
+        {% trans "From unknown" %}
       {% endif %}
     </div>
     {% for item in feedback.items %}
@@ -85,27 +85,27 @@
     {% endfor %}
     <div class="list-group-item text-secondary">
       <span class="pt-3 small">
-        {% blocktranslate trimmed with time=feedback.timestamp|naturaltime %}
+        {% blocktrans trimmed with time=feedback.timestamp|naturaltime %}
           {{ time }}
-        {% endblocktranslate %}
+        {% endblocktrans %}
       </span>
       <span class="float-right" data-toggle="tooltip"
-            title="{% translate "Unconfirmed feedback is not counted as having been submitted and does not affect this adjudicator's score." %}">
+            title="{% trans "Unconfirmed feedback is not counted as having been submitted and does not affect this adjudicator's score." %}">
         <form method="POST" action="{% tournamenturl 'adjfeedback-confirm-feedback' feedback.id %}" class='text-secondary'>
           {% csrf_token %}
           <input type="hidden" name="next" value="{{ request.path }}">
           <button type="submit" class="btn btn-link text-muted pl-3 p-0">
-            <small>{% if feedback.confirmed %}{% translate "Un-confirm" %}{% else %}{% translate "Confirm" %}{% endif %}</small>
+            <small>{% if feedback.confirmed %}{% trans "Un-confirm" %}{% else %}{% trans "Confirm" %}{% endif %}</small>
           </button>
         </form>
       </span>
       <span class="float-right" data-toggle="tooltip"
-            title="{% translate "Ignored feedback is counted as having been submitted, but does not affect this adjudicator's score." %}">
+            title="{% trans "Ignored feedback is counted as having been submitted, but does not affect this adjudicator's score." %}">
         <form method="POST" action="{% tournamenturl 'adjfeedback-ignore-feedback' feedback.id %}" class='text-secondary'>
           {% csrf_token %}
           <input type="hidden" name="next" value="{{ request.path }}">
           <button type="submit" class="btn btn-link text-muted p-0">
-            <small>{% if feedback.ignored %}{% translate "Un-ignore" %}{% else %}{% translate "Ignore" %}{% endif %}</small>
+            <small>{% if feedback.ignored %}{% trans "Un-ignore" %}{% else %}{% trans "Ignore" %}{% endif %}</small>
           </button>
         </form>
       </span>

--- a/tabbycat/adjfeedback/templates/feedback_cards_list.html
+++ b/tabbycat/adjfeedback/templates/feedback_cards_list.html
@@ -14,7 +14,7 @@
 
   {% if not feedbacks %}
     <!-- Can't use empty as card-columns div messes up the alert -->
-    {% translate "No feedback has been submitted yet" as message %}
+    {% trans "No feedback has been submitted yet" as message %}
     {% include "components/alert.html" with type="info" %}
   {% endif %}
 

--- a/tabbycat/adjfeedback/templates/feedback_overview.html
+++ b/tabbycat/adjfeedback/templates/feedback_overview.html
@@ -1,33 +1,33 @@
 {% extends "feedback_base.html" %}
 {% load debate_tags i18n static %}
 
-{% block sub-title %}{% blocktranslate trimmed %}<span id="c_breaking">{{ c_breaking }}</span> marked as breaking{% endblocktranslate %}{% endblock %}
+{% block sub-title %}{% blocktrans trimmed %}<span id="c_breaking">{{ c_breaking }}</span> marked as breaking{% endblocktrans %}{% endblock %}
 
 {% block page-alerts %}
 
   {% tournamenturl 'options-tournament-section' section='feedback' as option_url %}
   {% if pref.feedback_paths == 'minimal' %}
-    {% blocktranslate trimmed asvar p1 %}
+    {% blocktrans trimmed asvar p1 %}
       The current <a href="{{ option_url }}" class="alert-link">feedback configuration</a> allows and expects only chairs to submit feedback (on their panellists and trainees).
-    {% endblocktranslate %}
+    {% endblocktrans %}
   {% elif pref.feedback_paths == 'with-p-on-c' %}
-    {% blocktranslate trimmed asvar p1 %}
+    {% blocktrans trimmed asvar p1 %}
       The current <a href="{{ option_url }}" class="alert-link">feedback configuration</a> allows and expects both chairs and panellists to submit feedback on each other, and also chairs to submit feedback on trainees.
-    {% endblocktranslate %}
+    {% endblocktrans %}
   {% elif pref.feedback_paths == 'with-t-on-c' %}
-    {% blocktranslate trimmed asvar p1 %}
+    {% blocktrans trimmed asvar p1 %}
       The current <a href="{{ option_url }}" class="alert-link">feedback configuration</a> allows and expects both panellists and trainees to submit feedback on chairs, and chairs to submit feedback on every other member of the panel (including trainees).
-    {% endblocktranslate %}
+    {% endblocktrans %}
   {% elif pref.feedback_paths == 'all-adjs' %}
-    {% blocktranslate trimmed asvar p1 %}
+    {% blocktrans trimmed asvar p1 %}
       The current <a href="{{ option_url }}" class="alert-link">feedback configuration</a> allows and expects all adjudicators (including trainees) to submit feedback on every other member of the panel (including trainees).
-    {% endblocktranslate %}
+    {% endblocktrans %}
   {% endif %}
   {% include "components/explainer-card.html" with type="info" %}
 
   {% if nadjs_outside_range > 0 %}
     {% tournamenturl 'options-tournament-section' section='feedback' as feedback_settings_url %}
-    {% blocktranslate trimmed with min_score=pref.adj_min_score max_score=pref.adj_max_score count nadjs_outside_range=nadjs_outside_range asvar message %}
+    {% blocktrans trimmed with min_score=pref.adj_min_score max_score=pref.adj_max_score count nadjs_outside_range=nadjs_outside_range asvar message %}
       There is <strong>{{ nadjs_outside_range }} adjudicator</strong> with
       a score <strong>outside the permitted range</strong> of adjudicator
       scores, which is currently set as {{ min_score }} to {{ max_score }}.
@@ -43,7 +43,7 @@
       If you'd like to use a wider score range, you can configure this in
       <a href="{{ feedback_settings_url }}" class="alert-link"> feedback
       settings</a>.
-    {% endblocktranslate %}
+    {% endblocktrans %}
     {% include "components/alert.html" with type="warning" %}
   {% endif %}
   {{ block.super }}

--- a/tabbycat/adjfeedback/templates/overview_breakdowns.html
+++ b/tabbycat/adjfeedback/templates/overview_breakdowns.html
@@ -10,13 +10,13 @@
             {% widthratio threshold.count c_total 100 as c_percentage %}
             <div class="progress-bar rank-display ranking-{{ threshold.class }}" role="progressbar"
                  style="width: {{ c_percentage }}%;" data-toggle="tooltip"
-                 title="{% blocktranslate trimmed with min=threshold.min max=threshold.max percent=c_percentage|floatformat:"0" count count=threshold.count %}
+                 title="{% blocktrans trimmed with min=threshold.min max=threshold.max percent=c_percentage|floatformat:"0" count count=threshold.count %}
                    {{ count }} adjudicator currently has a score equal to or above
                    {{ min }} and below {{ max }}. That is {{ percent }}% of the adjudicator pool.
                  {% plural %}
                    {{ count }} adjudicators currently have a score equal to or above
                    {{ min }} and below {{ max }}. That is {{ percent }}% of the adjudicator pool.
-                 {% endblocktranslate %}">
+                 {% endblocktrans %}">
               {{ threshold.min|floatformat:"0" }}-{{ threshold.max|floatformat:"0" }} <!-- too cramped if only a small % -->
             </div>
           {% endif %}
@@ -24,9 +24,9 @@
         {% endfor %}
       </div>
       <h6 class="pt-3 text-center text-secondary">
-        {% blocktranslate trimmed with min_score=pref.adj_min_score max_score=pref.adj_max_score %}
+        {% blocktrans trimmed with min_score=pref.adj_min_score max_score=pref.adj_max_score %}
           Score Distributions (range is {{ min_score }}–{{ max_score }})
-        {% endblocktranslate %}
+        {% endblocktrans %}
       </h6>
     </div>
   </div>
@@ -40,21 +40,21 @@
           <h5 class="mb-0 mt-2">
             {{ test_percent|floatformat:"0" }}%
           </h5>
-          <small>{% translate "Base" %}</small>
+          <small>{% trans "Base" %}</small>
         </div>
         <div class="col pl-0 mb-0">
           <h5 class="mb-0 mt-2">
             {{ feedback_percent|floatformat:"0" }}%
           </h5>
-          <small>{% translate "Feedback" %}</small>
+          <small>{% trans "Feedback" %}</small>
         </div>
       </div>
       <h6 class="pt-2 text-secondary" data-toggle="tooltip"
-          title="{% blocktranslate trimmed with round=current_round.abbreviation %}
+          title="{% blocktrans trimmed with round=current_round.abbreviation %}
             The proportion of an adjudicator's score determined by feedback vs the
-            test is set on a per-round basis. Click this link and edit the 'Feedback weight' field to modify this ratio for {{ round }}.{% endblocktranslate %}">
+            test is set on a per-round basis. Click this link and edit the 'Feedback weight' field to modify this ratio for {{ round }}.{% endblocktrans %}">
         <a href="{% url 'admin:tournaments_round_change' current_round.id %}" target="_blank">
-          {{ current_round.abbreviation }} {% translate "Score Ratio" %}
+          {{ current_round.abbreviation }} {% trans "Score Ratio" %}
         </a>
       </h6>
     </div>
@@ -69,60 +69,60 @@
           <div class="progress-bar position-display chair" role="progressbar"
                style="width: {% percentage c_chairs c_total %}%;" data-toggle="tooltip"
               {% if c_chairs == c_debates %}
-               title="{% blocktranslate trimmed count count=c_chairs %}
+               title="{% blocktrans trimmed count count=c_chairs %}
                   There is {{ c_chairs }} debate per round, so there needs to be {{ c_chairs }} chair.
                 {% plural %}
                   There are {{ c_chairs }} debates per round, so there need to be {{ c_chairs }} chairs.
-                {% endblocktranslate %}"
+                {% endblocktrans %}"
               {% else %}
-               title="{% blocktranslate trimmed count count=c_debates %}
+               title="{% blocktrans trimmed count count=c_debates %}
                   There is {{ c_debates }} debate per round, but only {{ c_chairs }} above the minimum voting score.
                 {% plural %}
                   There are {{ c_debates }} debates per round, but only {{ c_chairs }} above the minimum voting score.
-                {% endblocktranslate %}"
+                {% endblocktrans %}"
               {% endif %}
             >
-            {% blocktranslate trimmed count c_chairs=c_chairs %}
+            {% blocktrans trimmed count c_chairs=c_chairs %}
               {{ c_chairs }} chair
             {% plural %}
               {{ c_chairs }} chairs
-            {% endblocktranslate %}
+            {% endblocktrans %}
           </div>
         {% endif %}
         {% if c_panellists > 0 %}
           <div class="progress-bar position-display panellist" role="progressbar"
                style="width: {% percentage c_panellists c_total %}%;" data-toggle="tooltip"
-               title="{% blocktranslate trimmed %}
+               title="{% blocktrans trimmed %}
                 All adjudicators with a score high enough to vote, but who aren't allocated as chairs,
                 are allocated as panellists by the auto-allocator.
-               {% endblocktranslate %}">
-            {% blocktranslate trimmed count c_panellists=c_panellists %}
+               {% endblocktrans %}">
+            {% blocktrans trimmed count c_panellists=c_panellists %}
               {{ c_panellists }} panellist
             {% plural %}
               {{ c_panellists }} panellists
-            {% endblocktranslate %}
+            {% endblocktrans %}
           </div>
         {% endif %}
         {% if c_trainees > 0 %}
           <div class="progress-bar position-display trainee" role="progressbar"
                style="width: {% percentage c_trainees c_total %}%;" data-toggle="tooltip"
-               title="{% blocktranslate trimmed with min_voting=pref.adj_min_voting_score %}
+               title="{% blocktrans trimmed with min_voting=pref.adj_min_voting_score %}
                 Adjudicators are allocated as trainees by the auto-allocator if their score is less
                 than the 'minimum voting score' (currently {{ min_voting }}) set in this
                 tournament's Draw Rules configuration.
-               {% endblocktranslate %}">
-            {% blocktranslate trimmed count c_trainees=c_trainees %}
+               {% endblocktrans %}">
+            {% blocktrans trimmed count c_trainees=c_trainees %}
               {{ c_trainees }} trainee
             {% plural %}
               {{ c_trainees }} trainees
-            {% endblocktranslate %}
+            {% endblocktrans %}
           </div>
         {% endif %}
       </div>
       <h6 class="pt-3 text-center text-secondary">
-        {% blocktranslate trimmed with min_voting_score=pref.adj_min_voting_score %}
+        {% blocktrans trimmed with min_voting_score=pref.adj_min_voting_score %}
           Auto-Allocate Distributions ({{ min_voting_score }}+ to vote)
-        {% endblocktranslate %}
+        {% endblocktrans %}
       </h6>
     </div>
   </div>

--- a/tabbycat/adjfeedback/templates/overview_modals.html
+++ b/tabbycat/adjfeedback/templates/overview_modals.html
@@ -7,38 +7,38 @@
         <div class="modal-body pb-0 pt-0">
           <div class="list-group list-group-flush">
 
-            {% translate "Change Base Score" as title %}
+            {% trans "Change Base Score" as title %}
             {% include "components/form-title.html" %}
 
             {% csrf_token %}
 
             <div class="list-group-item text-info py-3">
               {% tournamenturl 'options-tournament-section' section='feedback' as feedback_options %}
-              {% blocktranslate trimmed with min_score=pref.adj_min_score max_score=pref.adj_max_score %}
+              {% blocktrans trimmed with min_score=pref.adj_min_score max_score=pref.adj_max_score %}
                 The score range for adjudicators is between <strong>{{ pref.adj_min_score }}</strong> and
                 <strong>{{ pref.adj_max_score }}</strong>. Decimals are permitted. This can be configured in
                 <a href="{{ feedback_options }}">Feedback settings</a>.
-              {% endblocktranslate %}
+              {% endblocktrans %}
             </div>
             <div class="list-group-item text-info py-3">
               {% tournamenturl 'options-tournament-section' section='draw_rules' as draw_rules %}
-              {% blocktranslate trimmed with min_voting_score=pref.adj_min_voting_score %}
+              {% blocktrans trimmed with min_voting_score=pref.adj_min_voting_score %}
                 The minimum score require to be allocated as a panellist or chair (when using the
                 auto-allocator) is <strong>{{ min_voting_score }}</strong>. This can be configured in
                 <a href="{{ draw_rules }}">Draw settings</a>.
-              {% endblocktranslate %}
+              {% endblocktrans %}
             </div>
             <div class="list-group-item">
               <input id="id_adj_id" name="adj_id" type="hidden" />
               <div class="form-group pb-3">
-                <label>{% translate "Base score" %}</label>
+                <label>{% trans "Base score" %}</label>
                 <input id="id_base_score" class="form-control" name="base_score" placeholder="3.5"
                        min="{{ pref.adj_min_score }}" max="{{ pref.adj_max_score }}"
                        type="number" step="any"></input>
               </div>
             </div>
 
-            {% translate "Save Base Score" as title %}
+            {% trans "Save Base Score" as title %}
             {% include "components/form-submit.html" %}
 
             </div>

--- a/tabbycat/adjfeedback/templates/public_add_feedback.html
+++ b/tabbycat/adjfeedback/templates/public_add_feedback.html
@@ -1,8 +1,8 @@
 {% extends "add_feedback.html" %}
 {% load debate_tags i18n %}
 
-{% block head-title %}{% translate "Who are you?" %}{% endblock %}
-{% block sub-title %}{% translate "click your name or your team on this list" %}{% endblock %}
+{% block head-title %}{% trans "Who are you?" %}{% endblock %}
+{% block sub-title %}{% trans "click your name or your team on this list" %}{% endblock %}
 
 {% block page-subnav-sections %}{% endblock %}
 {% block page-subnav-actions %}{% endblock %}
@@ -10,15 +10,15 @@
 
 {% block enter-feedback-adj-link %}
   <a href="{% tournamenturl 'adjfeedback-public-add-from-adjudicator-pk' adj.id %}">
-    {% blocktranslate trimmed with name=adj.name %}
+    {% blocktrans trimmed with name=adj.name %}
       Add Feedback from {{ name }}
-    {% endblocktranslate %}
+    {% endblocktrans %}
   </a>
 {% endblock %}
 {% block enter-feedback-team-link %}
   <a href="{% tournamenturl 'adjfeedback-public-add-from-team-pk' team.id %}">
-    {% blocktranslate trimmed with name=team.long_name %}
+    {% blocktrans trimmed with name=team.long_name %}
       Add Feedback from {{ name }}
-    {% endblocktranslate %}
+    {% endblocktrans %}
   </a>
 {% endblock %}

--- a/tabbycat/adjfeedback/templates/update_adjudicator_scores.html
+++ b/tabbycat/adjfeedback/templates/update_adjudicator_scores.html
@@ -1,19 +1,19 @@
 {% extends "base.html" %}
 {% load static debate_tags add_field_css i18n l10n %}
 
-{% block head-title %}<span class="emoji">🔟</span> {% translate "Update Adjudicator Scores" context "page title" %}
+{% block head-title %}<span class="emoji">🔟</span> {% trans "Update Adjudicator Scores" context "page title" %}
 {% endblock %}
-{% block page-title %}{% translate "Update Adjudicator Scores" context "page title" %}{% endblock %}
+{% block page-title %}{% trans "Update Adjudicator Scores" context "page title" %}{% endblock %}
 
 {% block page-alerts %}
   {% if no_adjs_in_database %}
     {% tournamenturl 'importer-simple-institutions' as import_url %}
-    {% blocktranslate trimmed asvar message %}
+    {% blocktrans trimmed asvar message %}
       There aren't any adjudicators in this tournament, so you can't
       update any scores. You might want to
       <a href="{{ import_url }}" class="alert-link">import some adjudicators</a>
       first.
-    {% endblocktranslate %}
+    {% endblocktrans %}
     {% include "components/alert.html" with type="warning" %}
   {% endif %}
 {% endblock %}
@@ -25,10 +25,10 @@
   {% csrf_token %}
 
     <div class="list-group-item text-info">
-    {% blocktranslate trimmed %}
+    {% blocktrans trimmed %}
       Paste a list of adjudicators' names and their new scores, in the format:
       <code>adjudicator,score</code>. For example:
-    {% endblocktranslate %}
+    {% endblocktrans %}
     </div>
 
     <div class="list-group-item list-group-item-secondary pb-0">
@@ -37,14 +37,14 @@
     </div>
 
     <div class="list-group-item text-info">
-      {% translate "The adjudicators' names must match their names in the tab system exactly." %}
+      {% trans "The adjudicators' names must match their names in the tab system exactly." %}
     </div>
 
     <div class="list-group-item pb-3 pt-3">
 
         {% if form.scores_raw.errors %}
           <div class="alert alert-danger">
-            <p>{% translate "There are some problems with the data on this form:" %}</p>
+            <p>{% trans "There are some problems with the data on this form:" %}</p>
             {{ form.scores_raw.errors }}
           </div>
         {% endif %}
@@ -55,7 +55,7 @@
 
     </div>
 
-    {% translate "Submit" as title %}
+    {% trans "Submit" as title %}
     {% include "components/form-submit.html" %}
 
 </form>

--- a/tabbycat/availability/templates/availability_index.html
+++ b/tabbycat/availability/templates/availability_index.html
@@ -8,23 +8,23 @@
       <form method="POST" action="{% roundurl 'availability-checkin-breaking-adjudicators' %}">
         {% csrf_token %}
         <button class="btn btn-primary " type="submit">
-          {% translate "Mark All Breaking Adjs as Available" %}
+          {% trans "Mark All Breaking Adjs as Available" %}
         </button>
       </form>
     {% else %}
       <form method="POST" action="{% roundurl 'availability-checkin-all' %}">
         {% csrf_token %}
         <button class="btn btn-primary " type="submit">
-          {% translate "Mark Everything as Available" %}
+          {% trans "Mark Everything as Available" %}
         </button>
       </form>
       {% if round.prev %}
         <form method="POST" action="{% roundurl 'availability-checkin-previous' %}">
           {% csrf_token %}
           <button class="btn btn-primary " type="submit">
-            {% blocktranslate trimmed with prev_round=round.prev.abbreviation %}
+            {% blocktrans trimmed with prev_round=round.prev.abbreviation %}
               Copy Availability from {{ prev_round }}
-            {% endblocktranslate %}
+            {% endblocktrans %}
           </button>
         </form>
       {% endif %}
@@ -37,53 +37,53 @@
 
   {% if round.draw_status != round.STATUS_NONE %}
     <a class="btn btn-outline-success " href="{% roundurl 'draw' round %}">
-      {% translate "View Draw" %} <i data-feather="chevron-right"></i>
+      {% trans "View Draw" %} <i data-feather="chevron-right"></i>
     </a>
   {% else %}
     {% if previous_unconfirmed %}
       <button class="btn btn-warning" id="createDraw"
-        data-toggle="tooltip" title="{% blocktranslate trimmed with round=round.prev.name %}{{ previous_unconfirmed }} debates from
-        {{ round }} do not have a completed ballot — this may lead to a draw that fails or is incorrect{% endblocktranslate %}">
-        {% translate "Generate Draw" %} <i data-feather="chevron-right"></i>
+        data-toggle="tooltip" title="{% blocktrans trimmed with round=round.prev.name %}{{ previous_unconfirmed }} debates from
+        {{ round }} do not have a completed ballot — this may lead to a draw that fails or is incorrect{% endblocktrans %}">
+        {% trans "Generate Draw" %} <i data-feather="chevron-right"></i>
       </button>
     {% elif availability_info.teams.in_now == 0 %}
       <button class="btn btn-danger disabled"
-        data-toggle="tooltip" title="{% translate "The draw cannot be generated until some teams have been marked as available." %}">
-        {% translate "Generate Draw" %} <i data-feather="chevron-right"></i>
+        data-toggle="tooltip" title="{% trans "The draw cannot be generated until some teams have been marked as available." %}">
+        {% trans "Generate Draw" %} <i data-feather="chevron-right"></i>
       </button>
     {% elif availability_info.adjs.in_now == 0 %}
       <button class="btn btn-danger disabled"
-        data-toggle="tooltip" title="{% translate "The draw cannot be generated until some adjudicators have been marked as available." %}">
-        {% translate "Generate Draw" %} <i data-feather="chevron-right"></i>
+        data-toggle="tooltip" title="{% trans "The draw cannot be generated until some adjudicators have been marked as available." %}">
+        {% trans "Generate Draw" %} <i data-feather="chevron-right"></i>
       </button>
     {% elif availability_info.venues.in_now == 0 %}
       <button class="btn btn-danger disabled"
-        data-toggle="tooltip" title="{% translate "The draw cannot be generated until some rooms have been marked as available." %}">
-        {% translate "Generate Draw" %} <i data-feather="chevron-right"></i>
+        data-toggle="tooltip" title="{% trans "The draw cannot be generated until some rooms have been marked as available." %}">
+        {% trans "Generate Draw" %} <i data-feather="chevron-right"></i>
       </button>
     {% elif min_venues > availability_info.venues.in_now %}
       <button class="btn btn-warning" id="createDraw"
-        data-toggle="tooltip" title="{% translate "There aren't enough rooms marked as available for the number of debates — the draw may not generate properly." %}">
-         {% translate "Generate Draw" %} <i data-feather="chevron-right"></i>
+        data-toggle="tooltip" title="{% trans "There aren't enough rooms marked as available for the number of debates — the draw may not generate properly." %}">
+         {% trans "Generate Draw" %} <i data-feather="chevron-right"></i>
        </button>
     {% elif min_adjudicators > availability_info.adjs.in_now %}
       <button class="btn btn-warning" id="createDraw"
-        data-toggle="tooltip" title="{% translate "There aren't enough adjudicators marked as available for the number of debates — the draw may not generate properly." %}">
-        {% translate "Generate Draw" %} <i data-feather="chevron-right"></i>
+        data-toggle="tooltip" title="{% trans "There aren't enough adjudicators marked as available for the number of debates — the draw may not generate properly." %}">
+        {% trans "Generate Draw" %} <i data-feather="chevron-right"></i>
       </button>
     {% elif pref.teams_in_debate == 'two' and not availability_info.teams.in_now|divisibleby:2  %}
       <button class="btn btn-warning" id="createDraw"
-        data-toggle="tooltip" title="{% translate "There is an uneven number of teams marked as available — the draw may not generate properly." %}">
-        {% translate "Generate Draw" %} <i data-feather="chevron-right"></i>
+        data-toggle="tooltip" title="{% trans "There is an uneven number of teams marked as available — the draw may not generate properly." %}">
+        {% trans "Generate Draw" %} <i data-feather="chevron-right"></i>
       </button>
     {% elif pref.teams_in_debate == 'bp' and not availability_info.teams.in_now|divisibleby:4  %}
       <button class="btn btn-warning" id="createDraw"
-        data-toggle="tooltip" title="{% translate "The number of teams marked as available is not a multiple of 4 — the draw may not generate properly." %}">
-        {% translate "Generate Draw" %} <i data-feather="chevron-right"></i>
+        data-toggle="tooltip" title="{% trans "The number of teams marked as available is not a multiple of 4 — the draw may not generate properly." %}">
+        {% trans "Generate Draw" %} <i data-feather="chevron-right"></i>
       </button>
     {% else %}
       <button class="btn btn-success" id="createDraw">
-        {% translate "Generate Draw" %} <i data-feather="chevron-right"></i>
+        {% trans "Generate Draw" %} <i data-feather="chevron-right"></i>
       </button>
     {% endif %}
   {% endif %}
@@ -96,7 +96,7 @@
     <div class="alert alert-danger">
       <i data-feather="alert-circle"></i>
       {% roundurl 'results-round-list' round=round.prev as prev_round_results_url %}
-      {% blocktranslate trimmed with prev_round=round.prev.name count previous_unconfirmed=previous_unconfirmed %}
+      {% blocktrans trimmed with prev_round=round.prev.name count previous_unconfirmed=previous_unconfirmed %}
         One debate from {{ prev_round }}
         <strong>does not have a completed ballot</strong>. This may lead to a
         draw that fails or is incorrect, depending on your draw rules.
@@ -110,7 +110,7 @@
         <a href="{{ prev_round_results_url }}" class="alert-link">
           Enter results from {{ prev_round }}.
         </a>
-      {% endblocktranslate %}
+      {% endblocktrans %}
     </div>
   {% endif %}
 
@@ -118,13 +118,13 @@
     <div class="alert alert-warning">
       <i data-feather="alert-circle"></i>
       {% roundurl 'tournament-complete-round-check' round.prev as complete_prev_round_url %}
-      {% blocktranslate trimmed with round=round.name prev_round=round.prev.name %}
+      {% blocktrans trimmed with round=round.name prev_round=round.prev.name %}
         This is a page for <strong>{{ round }}</strong>, but the previous
         round is still not marked as completed. Did you forget to
         <a href="{{ complete_prev_round_url }}" class="alert-link">
           mark {{ prev_round }} as completed?
         </a>
-      {% endblocktranslate %}
+      {% endblocktrans %}
     </div>
   {% endif %}
 
@@ -134,69 +134,69 @@
   {% if not round.prev and round.draw_type == round.DRAW_POWERPAIRED %}
     <div class="alert alert-warning">
       <i data-feather="alert-circle"></i>
-      {% blocktranslate trimmed with draw_type=round.get_draw_type_display|lower %}
+      {% blocktrans trimmed with draw_type=round.get_draw_type_display|lower %}
         This is the first round, but its draw type is
         <strong>{{ draw_type }}</strong>. Did you intend for it
         to be <strong>Random</strong> instead? You can
         <a href="{{ change_round_url }}" class="alert-link">
           edit this round's draw type in the Edit Database area.</a>
-      {% endblocktranslate %}
+      {% endblocktrans %}
     </div>
   {% endif %}
 
   {% if error_type == 'no_break_category' %}
     <div class="alert alert-danger">
       <i data-feather="alert-circle"></i>
-      {% blocktranslate trimmed with draw_type=round.get_draw_type_display|lower %}
+      {% blocktrans trimmed with draw_type=round.get_draw_type_display|lower %}
         This is an elimination round, but it doesn't have a break category.
         Elimination rounds must be associated with a break category. Please
         <a href="{{ change_round_url }}" class="alert-link">
           set this round's break category in the Edit Database area.</a>
-      {% endblocktranslate %}
+      {% endblocktrans %}
     </div>
   {% endif %}
 
   {% if round.is_break_round and round.draw_type != round.DRAW_ELIMINATION %}
     <div class="alert alert-danger">
       <i data-feather="alert-circle"></i>
-      {% blocktranslate trimmed with draw_type=round.get_draw_type_display|lower %}
+      {% blocktrans trimmed with draw_type=round.get_draw_type_display|lower %}
         This is an elimination round, but its draw type is
         <strong>{{ draw_type }}</strong>.
         The draw type of all elimination rounds must be "Elimination". Please
         <a href="{{ change_round_url }}" class="alert-link">
           change this round's draw type in the Edit Database area.</a>
-      {% endblocktranslate %}
+      {% endblocktrans %}
     </div>
   {% endif %}
 
   {% if round.is_break_round and not round.prev.is_break_round and availability_info.teams.total == 0 %}
     <div class="alert alert-warning">
       <i data-feather="alert-circle"></i>
-      {% blocktranslate trimmed with break_category=round.break_category.name %}
+      {% blocktrans trimmed with break_category=round.break_category.name %}
         There don't appear to be any teams breaking in the {{ break_category }}
         Break. Have you
         <a href="{{ breakqual_teams_url }}" class="alert-link">
           generated the break for the {{ break_category }} Break</a> yet?
-      {% endblocktranslate %}
+      {% endblocktrans %}
     </div>
   {% endif %}
 
   {% if round.is_break_round and availability_info.teams.total == 1 %}
     <div class="alert alert-warning">
       <i data-feather="alert-circle"></i>
-      {% blocktranslate trimmed with break_category=round.break_category.name %}
+      {% blocktrans trimmed with break_category=round.break_category.name %}
         There's only one team breaking in the {{ break_category }} Break.
         You can't generate an elimination round draw with only one team — you might
         like to
         <a href="{{ breakqual_teams_url }}" class="alert-link">
           review the break for the {{ break_category }} Break</a>.
-      {% endblocktranslate %}
+      {% endblocktrans %}
     </div>
   {% endif %}
 
   {% if pref.team_standings_precedence|length == 0 %}
     {% tournamenturl 'options-tournament-section' section='standings' as standings_config_url %}
-    {% blocktranslate trimmed asvar message %}
+    {% blocktrans trimmed asvar message %}
       The team standings precedence is empty. This means that teams aren't
       ranked according to any metrics, so all teams will be in a single bracket
       containing everyone. If this isn't what you intended, set the team
@@ -204,7 +204,7 @@
       <a href="{{ standings_config_url }}" class="alert-link">Standings section
       of this tournament's configuration</a> before creating the draw. In most
       tournaments, the first metric should be points or wins.
-    {% endblocktranslate %}
+    {% endblocktrans %}
     {% include "components/alert.html" with type="warning" icon="alert-circle" %}
   {% endif %}
 

--- a/tabbycat/availability/templates/base_availability.html
+++ b/tabbycat/availability/templates/base_availability.html
@@ -35,12 +35,12 @@
       },
       hideAutoSave: false,
       translations: {
-        'Select All': '{% translate "Select All" %}',
-        'Select None': '{% translate "Select None" %}',
-        'Check-Ins': '{% translate "Check-Ins" %}',
-        'Check In All Breaking': '{% translate "Check In All Breaking" %}',
-        'Copy from Previous': '{% translate "Copy from Previous" %}',
-        'Save Selected': '{% translate "Save Selected" %}'
+        'Select All': '{% trans "Select All" %}',
+        'Select None': '{% trans "Select None" %}',
+        'Check-Ins': '{% trans "Check-Ins" %}',
+        'Check In All Breaking': '{% trans "Check In All Breaking" %}',
+        'Copy from Previous': '{% trans "Copy from Previous" %}',
+        'Save Selected': '{% trans "Save Selected" %}'
       },
       navigation: [
         { title: 'Overview', url: '{% roundurl "availability-index" round %}', back: true }

--- a/tabbycat/availability/templates/checkin_progress.html
+++ b/tabbycat/availability/templates/checkin_progress.html
@@ -4,9 +4,9 @@
 
   <div class="card-body">
     <h5 class="card-title mb-0">
-      {% if type == "teams" %}{% translate "Teams" %}
-      {% elif type == "adjs" %}{% translate "Adjudicators" %}
-      {% elif type == "venues" %}{% translate "Rooms" %}
+      {% if type == "teams" %}{% trans "Teams" %}
+      {% elif type == "adjs" %}{% trans "Adjudicators" %}
+      {% elif type == "venues" %}{% trans "Rooms" %}
       {% endif %}
     </h5>
   </div>
@@ -40,23 +40,23 @@
     {% if type == "teams" %}
 
       {% roundurl 'availability-teams' round as url %}
-      {% translate "Mark teams as available" as title_text %}
+      {% trans "Mark teams as available" as title_text %}
 
       {% if round.is_break_round %}
-        {% translate "No need to set team availability" as title_text %}
+        {% trans "No need to set team availability" as title_text %}
         {% include "components/item-info.html" with text=title_text type="secondary" nopad=True %}
       {% elif pref.teams_in_debate == 'two' and not availability_info.teams.in_now|divisibleby:2  %}
-        {% translate "There is an uneven number of teams marked as available for this round." as text %}
+        {% trans "There is an uneven number of teams marked as available for this round." as text %}
         {% include "components/item-info.html" with type="danger" nopad=True %}
         {% include "components/item-action.html" with alone=True text=title_text type="success" to_complete=True %}
       {% elif pref.teams_in_debate == 'bp' and not availability_info.teams.in_now|divisibleby:4  %}
-        {% translate "The number of teams marked as available for this round is not a multiple of 4." as text %}
+        {% trans "The number of teams marked as available for this round is not a multiple of 4." as text %}
         {% include "components/item-info.html" with type="danger" nopad=True %}
         {% include "components/item-action.html" with alone=True text=title_text type="success" to_complete=True %}
       {% elif info.in_now == 0 and not round.is_break_round %}
         {% include "components/item-action.html" with alone=True text=title_text type="success" to_complete=True %}
       {% else %}
-        {% translate "Edit team availability" as title_text %}
+        {% trans "Edit team availability" as title_text %}
         {% include "components/item-action.html" with alone=True text=title_text type="primary" %}
       {% endif %}
 
@@ -65,60 +65,60 @@
       {% roundurl 'availability-adjudicators' round as url %}
 
       {% if adjs_no_t > 0 %}
-        {% blocktranslate trimmed asvar text count count=adjs_no_t %}
+        {% blocktrans trimmed asvar text count count=adjs_no_t %}
           One adjudicator does not have an associated tournament. Set their 'Tournament' field in the Edit Database area if you want them to be marked as available.
         {% plural %}
           {{ count }} adjudicators do not have an associated tournament. Set their 'Tournament' field in the Edit Database area if you want them to be marked as available.
-        {% endblocktranslate %}
+        {% endblocktrans %}
         {% include "components/item-info.html" with type="info" nopad=True %}
       {% endif %}
 
       {% if new_adjs|length > 10 %}
-        {% blocktranslate trimmed asvar text count count=new_adjs|length %}
+        {% blocktrans trimmed asvar text count count=new_adjs|length %}
           {{ count }} adjudicator who was not available last round, is available this round.
         {% plural %}
           {{ count }} adjudicators who were not available last round, are available this round.
-        {% endblocktranslate %}
+        {% endblocktrans %}
         {% include "components/item-info.html" with type="info" nopad=True %}
       {% elif new_adjs %}
-        {% blocktranslate trimmed asvar text count count=new_adjs|length with adjs_list=new_adjs|join:", " %}
+        {% blocktrans trimmed asvar text count count=new_adjs|length with adjs_list=new_adjs|join:", " %}
           The following {{ count }} adjudicator, who was not available last round, is available this round: {{ adjs_list }}
         {% plural %}
           The following {{ count }} adjudicators, who were not available last round, are available this round: {{ adjs_list }}
-        {% endblocktranslate %}
+        {% endblocktrans %}
         {% include "components/item-info.html" with type="info" nopad=True %}
       {% endif %}
 
       {% if lost_adjs|length > 10 %}
-        {% blocktranslate trimmed asvar text count count=lost_adjs|length %}
+        {% blocktrans trimmed asvar text count count=lost_adjs|length %}
           {{ count }} adjudicator who was available last round, is not available this round.
         {% plural %}
           {{ count }} adjudicators who were available last round, are not available this round.
-        {% endblocktranslate %}
+        {% endblocktrans %}
         {% include "components/item-info.html" with type="info" nopad=True %}
       {% elif lost_adjs %}
-        {% blocktranslate trimmed asvar text count count=lost_adjs|length with adjs_list=lost_adjs|join:", " %}
+        {% blocktrans trimmed asvar text count count=lost_adjs|length with adjs_list=lost_adjs|join:", " %}
           The following {{ count }} adjudicator, who was available last round, is not available this round: {{ adjs_list }}
         {% plural %}
           The following {{ count }} adjudicators, who were available last round, are not available this round: {{ adjs_list }}
-        {% endblocktranslate %}
+        {% endblocktrans %}
         {% include "components/item-info.html" with type="info" nopad=True %}
       {% endif %}
 
-      {% translate "Mark adjudicators as available" as title_text %}
+      {% trans "Mark adjudicators as available" as title_text %}
       {% if min_adjudicators > availability_info.adjs.in_now %}
         {# Translators: required_count is a word for a number (e.g. "two", "three", etc.) #}
-        {% blocktranslate trimmed asvar text with required_count=min_adjudicators|apnumber count count=min_adjudicators %}
+        {% blocktrans trimmed asvar text with required_count=min_adjudicators|apnumber count count=min_adjudicators %}
           There needs to be at least one adjudicator marked as available, given the number of debates.
         {% plural %}
           There need to be at least {{ required_count }} adjudicators marked as available, given the number of debates.
-        {% endblocktranslate %}
+        {% endblocktrans %}
         {% include "components/item-info.html" with type="danger" nopad=True %}
         {% include "components/item-action.html" with alone=True text=title_text type="success" to_complete=True %}
       {% elif info.in_now == 0 %}
         {% include "components/item-action.html" with alone=True text=title_text type="success" to_complete=True %}
       {% else %}
-        {% translate "Edit adjudicator availability" as title_text %}
+        {% trans "Edit adjudicator availability" as title_text %}
         {% include "components/item-action.html" with alone=True text=title_text type="primary" %}
       {% endif %}
 
@@ -127,62 +127,62 @@
       {% roundurl 'availability-venues' round as url %}
 
       {% if new_venues|length > 10 %}
-        {% blocktranslate trimmed asvar text count count=new_venues|length %}
+        {% blocktrans trimmed asvar text count count=new_venues|length %}
           {{ count }} room that was not available last round, is available this round.
         {% plural %}
           {{ count }} rooms that were not available last round, are available this round.
-        {% endblocktranslate %}
+        {% endblocktrans %}
         {% include "components/item-info.html" with type="info" nopad=True %}
       {% elif new_venues %}
-        {% blocktranslate trimmed asvar text count count=new_venues|length with rooms_list=new_venues|join:", " %}
+        {% blocktrans trimmed asvar text count count=new_venues|length with rooms_list=new_venues|join:", " %}
           The following {{ count }} room, which was not available last round, is available this round: {{ rooms_list }}
         {% plural %}
           The following {{ count }} rooms, which were not available last round, are available this round: {{ rooms_list }}
-        {% endblocktranslate %}
+        {% endblocktrans %}
         {% include "components/item-info.html" with type="info" nopad=True %}
       {% endif %}
 
       {% if lost_venues|length > 10 %}
-        {% blocktranslate trimmed asvar text count count=lost_venues|length %}
+        {% blocktrans trimmed asvar text count count=lost_venues|length %}
           {{ count }} room that was available last round, is not available this round.
         {% plural %}
           {{ count }} rooms that were available last round, are not available this round.
-        {% endblocktranslate %}
+        {% endblocktrans %}
         {% include "components/item-info.html" with type="info" nopad=True %}
       {% elif lost_venues %}
-        {% blocktranslate trimmed asvar text count count=lost_venues|length with rooms_list=lost_venues|join:", " %}
+        {% blocktrans trimmed asvar text count count=lost_venues|length with rooms_list=lost_venues|join:", " %}
           The following {{ count }} room, which was available last round, is not available this round: {{ rooms_list }}
         {% plural %}
           The following {{ count }} rooms, which were available last round, are not available this round: {{ rooms_list }}
-        {% endblocktranslate %}
+        {% endblocktrans %}
         {% include "components/item-info.html" with type="info" nopad=True %}
       {% endif %}
 
       {% if venues_no_t > 0 %}
-        {% blocktranslate trimmed asvar text count count=venues_no_t %}
+        {% blocktrans trimmed asvar text count count=venues_no_t %}
           One room does not have an associated tournament. Set its 'Tournament' field in the Edit Database area if you want it to be marked as available.
         {% plural %}
           {{ count }} rooms do not have an associated tournament. Set their 'Tournament' field in the Edit Database area if you want them to be marked as available.
-        {% endblocktranslate %}
+        {% endblocktrans %}
         {% include "components/item-info.html" with type="info" nopad=True %}
       {% endif %}
 
-      {% translate "Mark rooms as available" as title_text %}
+      {% trans "Mark rooms as available" as title_text %}
       {% if min_venues > availability_info.venues.in_now %}
         {# Translators: required_count is a word for a number (e.g. "two", "three", etc.) #}
-        {% blocktranslate trimmed asvar text with required_count=min_venues|apnumber count count=min_venues %}
+        {% blocktrans trimmed asvar text with required_count=min_venues|apnumber count count=min_venues %}
           There needs to be at least one room marked as available, given the number of
           debates.
         {% plural %}
           There need to be at least {{ required_count }} rooms marked as available, given
           the number of debates.
-        {% endblocktranslate %}
+        {% endblocktrans %}
         {% include "components/item-info.html" with type="danger" nopad=True %}
         {% include "components/item-action.html" with alone=True text=title_text type="success" to_complete=True %}
       {% elif info.in_now == 0 %}
         {% include "components/item-action.html" with alone=True text=title_text type="success" to_complete=True %}
       {% else %}
-        {% translate "Edit room availability" as title_text %}
+        {% trans "Edit room availability" as title_text %}
         {% include "components/item-action.html" with alone=True text=title_text type="primary" %}
       {% endif %}
 

--- a/tabbycat/breakqual/templates/break_categories_edit.html
+++ b/tabbycat/breakqual/templates/break_categories_edit.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 {% load add_field_css debate_tags i18n %}
 
-{% block head-title %}<span class="emoji">👑</span>{% translate "Break Categories" %}{% endblock %}
-{% block page-title %}{% translate "Break Categories" %}{% endblock %}
+{% block head-title %}<span class="emoji">👑</span>{% trans "Break Categories" %}{% endblock %}
+{% block page-title %}{% trans "Break Categories" %}{% endblock %}
 
 {% block page-subnav-sections %}
   {% include "breakqual_subnav.html" %}
@@ -14,21 +14,21 @@
     {# Translators: Translate "ESL" to the acronym "<target language> as a second/foreign language", not the translation of "English as a second language". #}
     <div class="card-body">
       {% tournamenturl 'breakqual-edit-eligibility' as eligibility_url %}
-      {% blocktranslate trimmed %}
+      {% blocktrans trimmed %}
         Break categories allow category-specific break rounds,
         <i>e.g.</i>, for novice or ESL categories. On this page, you can define
         what break categories exist. After you've defined the categories, the
         break rounds will be automatically generated, and you can set team
         eligibility on the <a href="{{ eligibility_url }}">Eligibility</a> page.
-      {% endblocktranslate %}
+      {% endblocktrans %}
       {% url 'admin:breakqual_breakcategory_changelist' as edit_db_url %}
-      {% blocktranslate trimmed %}
+      {% blocktrans trimmed %}
         If you want to delete break categories, use the <a href="{{ edit_db_url }}" class="alert-link">Edit Database</a> area.
-      {% endblocktranslate %}
+      {% endblocktrans %}
     </div>
   </div>
 
-  {% translate "Save Break Categories" as save_text %}
+  {% trans "Save Break Categories" as save_text %}
   {% include "components/formset.html" with double=True %}
 
 {% endblock content %}

--- a/tabbycat/breakqual/templates/breaking_adjs.html
+++ b/tabbycat/breakqual/templates/breaking_adjs.html
@@ -5,9 +5,9 @@
   <div class="alert alert-info">
   	{% tournamenturl 'adjfeedback-overview' as feedback_url %}
     <i data-feather="alert-circle"></i>
-    {% blocktranslate trimmed %}
+    {% blocktrans trimmed %}
 	    Adjudicators can be marked as breaking in the <a href="{{ feedback_url }}">Feedback Overview</a> section.
-    {% endblocktranslate %}
+    {% endblocktrans %}
   </div>
 {% endblock %}
 

--- a/tabbycat/breakqual/templates/breaking_index.html
+++ b/tabbycat/breakqual/templates/breaking_index.html
@@ -1,20 +1,20 @@
 {% extends "base.html" %}
 {% load static debate_tags i18n %}
 
-{% block head-title %}<span class="emoji">👑</span> {% translate "Breaks" %}{% endblock %}
-{% block page-title %}{% translate "Breaks" %}{% endblock %}
+{% block head-title %}<span class="emoji">👑</span> {% trans "Breaks" %}{% endblock %}
+{% block page-title %}{% trans "Breaks" %}{% endblock %}
 
 {% block page-alerts %}
   {% if not categories.exists %}
 
-    {% blocktranslate trimmed asvar message %}
+    {% blocktrans trimmed asvar message %}
       This tournament does not have any break categories set up. You can read
        about how to create breaks
       <a href="http://tabbycat.readthedocs.io/en/stable/features/breaks.html"
           class="alert-link" target="_blank">
         at our documentation.
       </a>
-    {% endblocktranslate %}
+    {% endblocktrans %}
     {% include "components/alert.html" with type="warning" %}
 
   {% endif %}
@@ -27,10 +27,10 @@
 {% block page-subnav-actions %}
   <div class="btn-group btn-group">
     <a class="btn btn-outline-primary" href="{% tournamenturl 'break-categories-edit' %}">
-      {% translate "Break Categories" %}
+      {% trans "Break Categories" %}
     </a>
     <a class="btn btn-outline-primary" href="{% tournamenturl 'breakqual-edit-eligibility' %}">
-      {% translate "Team Eligibility" %}
+      {% trans "Team Eligibility" %}
     </a>
   </div>
 {% endblock %}
@@ -46,14 +46,14 @@
 
             <div class="list-group-item">
               <h4 class="card-title mb-0">
-                {% blocktranslate trimmed with category=category.name %}
+                {% blocktrans trimmed with category=category.name %}
                   {{ category }} Break
-                {% endblocktranslate %}
-              {% blocktranslate trimmed with size=category.break_size %}
+                {% endblocktrans %}
+              {% blocktrans trimmed with size=category.break_size %}
               <span class="badge float-right badge-light">
                 {{ size }} Spots
               </span>
-              {% endblocktranslate %}
+              {% endblocktrans %}
               </h4>
             </div>
 
@@ -61,7 +61,7 @@
 
               <div class="list-group-item">
                 <div class="d-flex justify-content-end">
-                  <span class="mr-auto">{% translate "Teams Eligible" %}</span>
+                  <span class="mr-auto">{% trans "Teams Eligible" %}</span>
                   <strong>{{ category.eligible }}/{{ teams_in_tournament }}</strong>
                 </div>
                 {% include "components/progress-bar.html" with value=category.eligible total=teams_in_tournament type="secondary" %}
@@ -73,7 +73,7 @@
 
                 <div class="list-group-item">
                   <div class="d-flex justify-content-end">
-                    <span class="mr-auto">{% translate "Breaking" %}</span>
+                    <span class="mr-auto">{% trans "Breaking" %}</span>
                     <strong>{{ category.breaking }}</strong>
                   </div>
                   {% include "components/progress-bar.html" with value=category.breaking type="success" %}
@@ -81,7 +81,7 @@
 
                 <div class="list-group-item">
                   <div class="d-flex justify-content-end">
-                    <span class="mr-auto">{% translate "Excluded" %}</span>
+                    <span class="mr-auto">{% trans "Excluded" %}</span>
                     <strong>{{ category.excluded }}</strong>
                   </div>
                   {% include "components/progress-bar.html" with value=category.excluded type="warning" %}
@@ -89,7 +89,7 @@
 
                 <div class="list-group-item">
                   <div class="d-flex justify-content-end">
-                    <span class="mr-auto">{% translate "Eligible" %}</span>
+                    <span class="mr-auto">{% trans "Eligible" %}</span>
                     <strong>{{ category.eligible }}</strong>
                   </div>
                   {% include "components/progress-bar.html" with value=category.eligible type="info" %}
@@ -101,15 +101,15 @@
 
             {% if category.eligible == 0 %}
               {% tournamenturl 'breakqual-edit-eligibility' as url %}
-              {% translate "Mark teams as eligible" as text %}
+              {% trans "Mark teams as eligible" as text %}
               {% include "components/item-action.html" with alone=True type="success" to_complete=True %}
             {% else %}
               {% tournamenturl 'breakqual-teams' category.slug as url %}
               {% if category.breaking == 0 %}
-                {% translate "Generate this break" as text %}
+                {% trans "Generate this break" as text %}
                 {% include "components/item-action.html" with alone=True type="success" to_complete=True %}
               {% else %}
-                {% translate "View this break" as text %}
+                {% trans "View this break" as text %}
                 {% include "components/item-action.html" with  type="primary" %}
               {% endif %}
             {% endif %}

--- a/tabbycat/breakqual/templates/breaking_teams.html
+++ b/tabbycat/breakqual/templates/breaking_teams.html
@@ -1,19 +1,19 @@
 {% extends "tables/base_vue_table.html" %}
 {% load static debate_tags i18n add_field_css %}
 
-{% block head-title %}{% blocktranslate trimmed with category=category.name %}
+{% block head-title %}{% blocktrans trimmed with category=category.name %}
   {{ category }} Break
-{% endblocktranslate %}{% endblock %}
+{% endblocktrans %}{% endblock %}
 {% block sub-title %}
   {% if pref.public_breaking_teams %}
-    {% translate "publicly visible" %}
+    {% trans "publicly visible" %}
   {% else %}
-    {% translate "not publicly visible" %}
+    {% trans "not publicly visible" %}
   {% endif %}
 {% endblock %}
-{% block page-title %}👑 {% blocktranslate trimmed with category=category.name %}
+{% block page-title %}👑 {% blocktrans trimmed with category=category.name %}
   {{ category }} Break
-{% endblocktranslate %}{% endblock %}
+{% endblocktrans %}{% endblock %}
 
 {% block page-subnav-sections %}
   {% include "breakqual_subnav.html" %}
@@ -24,7 +24,7 @@
     <form action="{% tournamenturl 'breakqual-generate-all' category.slug %}" class="form-inline" method="POST">
       {% csrf_token %}
       <button class="btn btn-danger" id="generateBreakingTeams" type="submit">
-        {% translate "Delete and Regenerate All Breaks" %} <i data-feather="repeat"></i>
+        {% trans "Delete and Regenerate All Breaks" %} <i data-feather="repeat"></i>
       </button>
     </form>
   {% else %}
@@ -33,7 +33,7 @@
         {% csrf_token %}
         <button class="btn btn-{{ pref.public_breaking_teams|yesno:"danger,success" }} form-control"
                 id="generateBreakingTeams" type="submit">
-          {% translate "Generate the Break for All Categories" %} <i data-feather="chevron-right"></i>
+          {% trans "Generate the Break for All Categories" %} <i data-feather="chevron-right"></i>
         </button>
       </form>
     </div>
@@ -45,11 +45,11 @@
   {% if category.team_set.count == 0 %}
 
     {% tournamenturl 'breakqual-edit-eligibility' as url %}
-    {% blocktranslate trimmed asvar message %}
+    {% blocktrans trimmed asvar message %}
     There are <strong>0 teams marked as eligible</strong> for this category — you will need to
        <a href="{{ url }}" class="alert-link">
       add some eligible teams</a> for this break to generate correctly.
-    {% endblocktranslate %}
+    {% endblocktrans %}
     {% include "components/alert.html" with type="warning" %}
 
   {% endif %}
@@ -57,15 +57,15 @@
   {% if generated %}
 
     {% url 'admin:breakqual_breakcategory_change' category.id as url %}
-    {% blocktranslate trimmed asvar p1 with category=category.get_rule_display %}
+    {% blocktrans trimmed asvar p1 with category=category.get_rule_display %}
       This break uses the <strong>{{ category }}</strong> rule — if you intended to use a different rule, you should <a href="{{ url }}"> edit the rule for this break category in the Edit Database area</a>, then delete and regenerate all breaks. Please double-check this before announcing the break or releasing it to the public. The code that generates the break is not robustly tested for corner cases.
-    {% endblocktranslate %}
+    {% endblocktrans %}
     {% include "components/explainer-card.html" with type="warning" %}
 
     {% url 'admin:breakqual_breakingteam_changelist' as url %}
-    {% blocktranslate trimmed asvar p1 %}
+    {% blocktrans trimmed asvar p1 %}
       To edit the break use the remarks in the right-hand column. Any team with a remark will be excluded from this break (the break generator will sometimes insert its own remarks). Then, click the appropriate Save Remarks and Update button below. If you have complicated break rules (for example, if some teams are allowed to choose their preferred category) then you may have to update remarks a few times to get the correct break. As a last resort, you can <a href="{{ url }}"> edit the breaking teams list directly in the Edit Database area</a>.
-    {% endblocktranslate %}
+    {% endblocktrans %}
     {% include "components/explainer-card.html" with type="info" %}
 
   {% else %}
@@ -73,7 +73,7 @@
       <div class="alert alert-danger">
         <i data-feather="alert-circle"></i>
         {% tournamenturl 'options-tournament-index' as options_url %}
-        {% blocktranslate trimmed %}
+        {% blocktrans trimmed %}
           The <strong>public breaking teams</strong> configuration setting is
           enabled. As soon as you click the button, the breaking teams list will
           be visible on the public site, before you have a chance to
@@ -81,13 +81,13 @@
           setting on the <a href="{{ options_url }}">
           tournament configuration page</a> before generating the team
           breaks.
-        {% endblocktranslate %}
+        {% endblocktrans %}
       </div>
     {% else %}
 
-      {% blocktranslate trimmed asvar p1 %}
+      {% blocktrans trimmed asvar p1 %}
         The break hasn't yet been generated. Would you like to generate the break for all categories? It's safe to generate the break before all preliminary rounds are complete, if you're curious — you can regenerate it later.
-      {% endblocktranslate %}
+      {% endblocktrans %}
       {% include "components/explainer-card.html" with type="info" %}
 
     {% endif %}
@@ -104,11 +104,11 @@
 
     {% if pref.public_breaking_teams %}
 
-      {% blocktranslate trimmed asvar message %}
+      {% blocktrans trimmed asvar message %}
         <strong>Caution!</strong> The "public breaking teams" option is turned on, so the break
         is publicly visible. If you update the break(s), the changes will become visible
         <strong>immediately</strong>, <strong>without a chance for you to review them</strong>.
-      {% endblocktranslate %}
+      {% endblocktrans %}
       {% include "components/alert.html" with type="danger" %}
 
     {% endif %}
@@ -117,14 +117,14 @@
       <div class="card-body row">
         <div class="form-inline col-md-6">
           <button class="btn btn-primary btn-block btn-success" type="submit" name="save_update_all">
-            {% translate "Save Remarks and Update All Breaks" %}
+            {% trans "Save Remarks and Update All Breaks" %}
           </button>
         </div>
         <div class="form-inline col-md-6">
           <button class="btn btn-primary btn-block btn-success" type="submit" name="save_update_one">
-            {% blocktranslate trimmed with category=category.name %}
+            {% blocktrans trimmed with category=category.name %}
               Save Remarks and Update the {{ category }} Break
-            {% endblocktranslate %}
+            {% endblocktrans %}
           </button>
         </div>
       </div>
@@ -134,10 +134,10 @@
 {% else %}
   <div id="vueMount"></div><!-- Prevent unfound item error for Vue -->
   {% tournamenturl 'breakqual-edit-eligibility' as url %}
-  {% blocktranslate trimmed asvar text with count=category.team_set.count %}
+  {% blocktrans trimmed asvar text with count=category.team_set.count %}
     There are <strong>{{ count }} teams marked as eligible</strong> for this
     category. Would you like to add more eligible teams?
-  {% endblocktranslate %}
+  {% endblocktrans %}
   {% include "components/item-action.html" with type="primary" url=url to_complete=true %}
 
 {% endif %}

--- a/tabbycat/breakqual/templates/breakqual_subnav.html
+++ b/tabbycat/breakqual/templates/breakqual_subnav.html
@@ -2,16 +2,16 @@
 
 <div class="btn-group">
   <a class="btn btn-outline-primary" href="{% tournamenturl 'breakqual-index' %}">
-    {% translate "Overview" %}
+    {% trans "Overview" %}
   </a>
   {% for category in tournament.breakcategory_set.all %}
     <a class="btn btn-outline-primary" href="{% tournamenturl 'breakqual-teams' category.slug %}">
-      {% blocktranslate trimmed with category=category.name %}
+      {% blocktrans trimmed with category=category.name %}
         {{ category }} Break
-      {% endblocktranslate %}
+      {% endblocktrans %}
     </a>
   {% endfor %}
   <a class="btn btn-outline-primary" href="{% tournamenturl 'breakqual-adjudicators' %}">
-    {% translate "Adjudicators' Break" %}
+    {% trans "Adjudicators' Break" %}
   </a>
 </div>

--- a/tabbycat/breakqual/templates/edit_break_eligibility.html
+++ b/tabbycat/breakqual/templates/edit_break_eligibility.html
@@ -4,11 +4,11 @@
 {% block page-alerts %}
   {% if break_categories_length == 0 %}
     {% url 'admin:breakqual_breakcategory_changelist' as categories_url %}
-    {% blocktranslate trimmed asvar message %}
+    {% blocktrans trimmed asvar message %}
       It looks like there aren't any break categories are defined. If you'd like to create new
       break categories you'll need to first <a href="{{ categories_url }}" class="alert-link">
       add them in the Edit Database area</a>, then return to this page to set team's eligibility.
-    {% endblocktranslate %}
+    {% endblocktrans %}
     {% include 'components/alert.html' with type='warning' %}
   {% endif %}
 {% endblock %}

--- a/tabbycat/breakqual/templates/public_break_index.html
+++ b/tabbycat/breakqual/templates/public_break_index.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 {% load debate_tags i18n %}
 
-{% block head-title %}<span class="emoji">👑</span> {% translate "Break" %}{% endblock %}
-{% block page-title %}{% translate "Break" %}{% endblock %}
+{% block head-title %}<span class="emoji">👑</span> {% trans "Break" %}{% endblock %}
+{% block page-title %}{% trans "Break" %}{% endblock %}
 
 {% block content %}
 
@@ -12,15 +12,15 @@
     {% if pref.public_breaking_teams %}
       {% for category in tournament.breakcategory_set.all %}
       <li class="list-group-item"><a  href="{% tournamenturl 'breakqual-public-teams' category.slug %}">
-        {% blocktranslate trimmed with category=category.name %}
+        {% blocktrans trimmed with category=category.name %}
           {{ category }} Break
-        {% endblocktranslate %}
+        {% endblocktrans %}
       </a></li>
       {% endfor %}
     {% endif %}
     {% if pref.public_breaking_adjs %}
       <li class="list-group-item"><a href="{% tournamenturl 'breakqual-public-adjs' %}">
-        {% translate "Adjudicators" %}
+        {% trans "Adjudicators" %}
       </a></li>
     {% endif %}
     </ul>

--- a/tabbycat/checkins/templates/checkin_ids.html
+++ b/tabbycat/checkins/templates/checkin_ids.html
@@ -15,7 +15,7 @@
 
             <div class="list-group-item">
               <div class="d-flex justify-content-end">
-                <span class="mr-auto">{% translate "With identifiers" %}</span>
+                <span class="mr-auto">{% trans "With identifiers" %}</span>
                 <strong>{{ check_info.in }}/{{ check_info.total }}</strong>
               </div>
               {% include "components/progress-bar.html" with value=check_info.in total=check_info.total type="success" %}
@@ -27,15 +27,15 @@
               {% else %}
                 {% tournamenturl "assistant-checkin-print" kind=check_key as url %}
               {% endif %}
-              {% translate "View as barcodes" as text %}
+              {% trans "View as barcodes" as text %}
               {% include "components/item-action.html" with type="primary" blank=True %}
             {% endif %}
 
             {% if check_info.in != check_info.total and user_role == "admin" %}
               {% if check_info.in > 0 %}
-                {% translate "Generate missing identifiers" as text %}
+                {% trans "Generate missing identifiers" as text %}
               {% else %}
-                {% translate "Generate all identifiers" as text %}
+                {% trans "Generate all identifiers" as text %}
               {% endif %}
               <div class="list-item-group">
                 <form action={% tournamenturl "admin-checkin-generate" kind=check_key %} method="POST">
@@ -46,7 +46,7 @@
             {% endif %}
 
             {% if user_role == "assistant" and check_info.in == 0 %}
-              {% translate "There are no identifiers available to view. An admin will need to generate them." as text %}
+              {% trans "There are no identifiers available to view. An admin will need to generate them." as text %}
               {% include "components/item-info.html" with type="info" %}
             {% endif %}
 

--- a/tabbycat/checkins/templates/checkin_printables.html
+++ b/tabbycat/checkins/templates/checkin_printables.html
@@ -7,14 +7,14 @@
 
 {% block page-alerts %}
 
-  {% blocktranslate trimmed asvar p1 %}
+  {% blocktrans trimmed asvar p1 %}
     Each of the barcodes below is also an image file that can be download individually. If you want to download them all at once try using a 'bulk downloader' extension/plugin for your browser, such as <a href="https://chrome.google.com/webstore/detail/svg-export/naeaaedieihlkmdajjefioajbbdbdjgp?hl=en-GB">this one (for Chrome)</a>. To download them as a list you can go to Check-Ins section of the Edit Database area and copy/paste from the relevant table.
-  {% endblocktranslate %}
+  {% endblocktrans %}
   {% include "components/explainer-card.html" with type="info" %}
 
-  {% blocktranslate trimmed asvar p1 %}
+  {% blocktrans trimmed asvar p1 %}
     You can use Ctrl+P for printing or saving the barcodes PDF. Be sure to set the appropriate <strong>page orientation</strong>, to turn off <strong>headers/footers</strong> and turn on <strong>background graphics</strong>. Works best in Chrome.
-  {% endblocktranslate %}
+  {% endblocktrans %}
   {% include "components/explainer-card.html" with type="info" %}
 
 {% endblock %}

--- a/tabbycat/checkins/templates/checkin_scan.html
+++ b/tabbycat/checkins/templates/checkin_scan.html
@@ -15,7 +15,7 @@
 {% block content %}
 
   <div class="d-none d-md-block">
-    {% translate "To scan an identifier type the number below (it will auto-submit). You can also use a barcode scanner (configured to work as a keyboard) or scan from a webcam or phone camera using the button below." as message %}
+    {% trans "To scan an identifier type the number below (it will auto-submit). You can also use a barcode scanner (configured to work as a keyboard) or scan from a webcam or phone camera using the button below." as message %}
     {% include "components/alert.html" with type="info" %}
   </div>
 

--- a/tabbycat/draw/templates/admin/draw/debateteam/delete_warning.html
+++ b/tabbycat/draw/templates/admin/draw/debateteam/delete_warning.html
@@ -2,19 +2,19 @@
 
 <div id="debate-team-warning" style="background-color: #f0dada; padding: 15px 15px 5px; margin-bottom: 20px; border-radius: 4px;">
   <p style="font-weight: bold; color: #c14747;">
-  {% blocktranslate trimmed %}
+  {% blocktrans trimmed %}
   STOP!!! Read this first! Deleting debate teams from the database may crash Tabbycat!
-  {% endblocktranslate %}
+  {% endblocktrans %}
   </p>
   <p>
-  {% blocktranslate trimmed %}
+  {% blocktrans trimmed %}
   Tabbycat requires that all debates have <strong>exactly</strong> one debate team for each side, and no other debate teams, at all times. If you delete any debate teams, you must then either replace each one with a new debate team in the same debate, or delete the associated debate objects. If you don't do this correctly, many pages <strong>will</strong> crash.
-  {% endblocktranslate %}
+  {% endblocktrans %}
   </p>
   <p>
-  {% blocktranslate trimmed %}
+  {% blocktrans trimmed %}
   This is a common source of errors. If it happens to you, check the debates (under the Draw section in this Edit Database area) and ensure that all of them have exactly one affirmative and one negative team.
-  {% endblocktranslate %}
+  {% endblocktrans %}
   </p>
 </div>
 

--- a/tabbycat/draw/templates/admin/draw/debateteam/edit_warning.html
+++ b/tabbycat/draw/templates/admin/draw/debateteam/edit_warning.html
@@ -2,18 +2,18 @@
 
 <div id="debate-team-warning" style="background-color: #f0dada; padding: 15px 30px 5px;">
   <p style="font-weight: bold; color: #c14747;">
-  {% blocktranslate trimmed %}
+  {% blocktrans trimmed %}
   WARNING!!! If you are editing debate teams, read this first!
-  {% endblocktranslate %}
+  {% endblocktrans %}
   </p>
   <p>
-  {% blocktranslate trimmed %}
+  {% blocktrans trimmed %}
   Tabbycat requires that there be <strong>exactly</strong> one debate team for each side, and no other debate teams, in each debate. If you edit debate teams in the database, you must ensure that this remains the case. If you don't do this correctly, many pages <strong>will</strong> crash.
-  {% endblocktranslate %}
+  {% endblocktrans %}
   </p>
   <p>
-  {% blocktranslate trimmed %}
+  {% blocktrans trimmed %}
   This is a common source of errors. If it happens to you, check the debates (under the Draw section in this Edit Database area) and ensure that all of them have exactly one affirmative and one negative team.
-  {% endblocktranslate %}
+  {% endblocktrans %}
   </p>
 </div>

--- a/tabbycat/draw/templates/draw_alerts_adjudicators.html
+++ b/tabbycat/draw/templates/draw_alerts_adjudicators.html
@@ -3,56 +3,56 @@
 {% with no_chair=round.num_debates_without_chair even_panel=round.num_debates_with_even_panel duplicates=round.duplicate_panellists unavailable_allocated=round.unavailable_adjudicators_allocated unallocated=round.num_available_adjudicators_not_allocated %}
 
   {% if no_chair > 0 %}
-    {% blocktranslate trimmed asvar text count ndebates=no_chair %}
+    {% blocktrans trimmed asvar text count ndebates=no_chair %}
       1 debate does not have a chair.
     {% plural %}
       {{ ndebates }} debates do not have a chair.
-    {% endblocktranslate %}
+    {% endblocktrans %}
     {% include "components/item-info.html" with nopad=True type="danger" %}
   {% endif %}
 
   {% if duplicates %}
-    {% blocktranslate trimmed asvar text with adjudicators=duplicates|join:", " count nadjs=duplicates|length %}
+    {% blocktrans trimmed asvar text with adjudicators=duplicates|join:", " count nadjs=duplicates|length %}
       <strong>{{ adjudicators }}</strong> is adjudicating multiple debates.
     {% plural %}
       The following <strong>{{ nadjs }}</strong> adjudicators are adjudicating multiple debates: <strong>{{ adjudicators }}</strong>
-    {% endblocktranslate %}
+    {% endblocktrans %}
     {% include "components/item-info.html" with nopad=True type="danger" %}
   {% endif %}
 
   {% if round.ballots_per_debate == 'per-adj' and even_panel > 0 %}
-    {% blocktranslate trimmed asvar text count ndebates=even_panel %}
+    {% blocktrans trimmed asvar text count ndebates=even_panel %}
       1 debate has a panel with an even number of adjudicators.
     {% plural %}
       {{ ndebates }} debates have panels with an even number of adjudicators.
-    {% endblocktranslate %}
+    {% endblocktrans %}
     {% include "components/item-info.html" with nopad=True type="warning" %}
   {% endif %}
 
   {% if debates_with_adj_conflicts > 0 %}
-    {% blocktranslate trimmed asvar text count ndebates=debates_with_adj_conflicts %}
+    {% blocktrans trimmed asvar text count ndebates=debates_with_adj_conflicts %}
       1 debate has an adjudicator conflict.
     {% plural %}
       {{ ndebates }} debates have adjudicator conflicts.
-    {% endblocktranslate %}
+    {% endblocktrans %}
     {% include "components/item-info.html" with nopad=True type="warning" %}
   {% endif %}
 
   {% if unavailable_allocated %}
-    {% blocktranslate trimmed asvar text with adjudicators=unavailable_allocated|join:", " count nadjs=unavailable_allocated|length %}
+    {% blocktrans trimmed asvar text with adjudicators=unavailable_allocated|join:", " count nadjs=unavailable_allocated|length %}
       <strong>{{ adjudicators }}</strong> is unavailable this round, but is assigned to a debate.
     {% plural %}
       The following <strong>{{ nadjs }}</strong> adjudicators are unavailable this round, but are assigned to debates: <strong>{{ adjudicators }}</strong>
-    {% endblocktranslate %}
+    {% endblocktrans %}
     {% include "components/item-info.html" with nopad=True type="danger" %}
   {% endif %}
 
   {% if unallocated > 0 %}
-    {% blocktranslate trimmed asvar text count ndebates=unallocated %}
+    {% blocktrans trimmed asvar text count ndebates=unallocated %}
       1 adjudicator is available but not assigned to a debate.
     {% plural %}
       {{ ndebates }} adjudicators are available but not assigned to a debate.
-    {% endblocktranslate %}
+    {% endblocktrans %}
     {% include "components/item-info.html" with nopad=True type="warning" %}
   {% endif %}
 

--- a/tabbycat/draw/templates/draw_alerts_teams.html
+++ b/tabbycat/draw/templates/draw_alerts_teams.html
@@ -3,11 +3,11 @@
 {% with duplicates=round.duplicate_team_names %}
 
   {% if duplicates %}
-    {% blocktranslate trimmed asvar text with teams=duplicates|join:", " count nteams=duplicates|length %}
+    {% blocktrans trimmed asvar text with teams=duplicates|join:", " count nteams=duplicates|length %}
       <strong>{{ teams }}</strong> is competing in multiple debates.
     {% plural %}
       The following <strong>{{ nteams }}</strong> teams are competing in multiple debates: <strong>{{ teams }}</strong>
-    {% endblocktranslate %}
+    {% endblocktrans %}
     {% include "components/item-info.html" with type="danger" %}
   {% endif %}
 

--- a/tabbycat/draw/templates/draw_alerts_venues.html
+++ b/tabbycat/draw/templates/draw_alerts_venues.html
@@ -2,29 +2,29 @@
 {% with no_venue=round.num_debates_without_venue duplicates=round.duplicate_venues %}
 
   {% if no_venue > 0 %}
-    {% blocktranslate trimmed asvar text count ndebates=no_venue %}
+    {% blocktrans trimmed asvar text count ndebates=no_venue %}
       1 debate does not have a room.
     {% plural %}
       {{ ndebates }} debates do not have a room.
-    {% endblocktranslate %}
+    {% endblocktrans %}
     {% include "components/item-info.html" with nopad=True type="danger" %}
   {% endif %}
 
   {% if duplicates %}
-    {% blocktranslate trimmed asvar text with rooms=duplicates|join:", " count ndebates=duplicates|length %}
+    {% blocktrans trimmed asvar text with rooms=duplicates|join:", " count ndebates=duplicates|length %}
       There are multiple debates in <strong>{{ rooms }}</strong>.
     {% plural %}
       The following <strong>{{ ndebates }}</strong> rooms have multiple debates in them: <strong>{{ rooms }}</strong>
-    {% endblocktranslate %}
+    {% endblocktrans %}
     {% include "components/item-info.html" with nopad=True type="danger" %}
   {% endif %}
 
   {% if debates_with_venue_conflicts > 0 %}
-    {% blocktranslate trimmed asvar text count ndebates=debates_with_venue_conflicts %}
+    {% blocktrans trimmed asvar text count ndebates=debates_with_venue_conflicts %}
       1 debate has a room constraint violation.
     {% plural %}
       {{ ndebates }} debates have room constraint violations.
-    {% endblocktranslate %}
+    {% endblocktrans %}
     {% include "components/item-info.html" with nopad=True type="danger" %}
   {% endif %}
 

--- a/tabbycat/draw/templates/draw_base.html
+++ b/tabbycat/draw/templates/draw_base.html
@@ -3,24 +3,24 @@
 
 {% block page-subnav-sections %}
   <a class="btn btn-outline-primary " href="{% roundurl 'availability-index' %}">
-    <i data-feather="chevron-left"></i> {% translate "Availability" %}
+    <i data-feather="chevron-left"></i> {% trans "Availability" %}
   </a>
 
   <div class="btn-group flex-wrap" role="group">
     <a href="{% roundurl 'edit-debate-teams' round %}" class="btn btn-outline-primary">
-      {% translate "Edit Sides/Matchups" %}
+      {% trans "Edit Sides/Matchups" %}
     </a>
   </div>
   <div class="btn-group flex-wrap" role="group">
     <a href="{% roundurl 'draw-confirm-regenerate' %}" class="btn btn-outline-primary">
-      {% translate "Redo Draw" %}
+      {% trans "Redo Draw" %}
     </a>
     <a href="{% roundurl 'draw-details' %}" class="btn btn-outline-primary">
-      {% translate "Draw Details" %}
+      {% trans "Draw Details" %}
     </a>
     {% if pref.teams_in_debate == 'bp' and round.prev and not round.is_break_round %}
       <a href="{% roundurl 'draw-position-balance' %}" class="btn btn-outline-primary">
-        {% translate "Position Balance" %}
+        {% trans "Position Balance" %}
       </a>
     {% endif %}
   </div>
@@ -28,6 +28,6 @@
 
 {% block page-subnav-actions %}
   <a href="{% roundurl 'draw-display' %}" class="btn btn-outline-success">
-    {% translate "Display Draw" %}<i data-feather="chevron-right"></i>
+    {% trans "Display Draw" %}<i data-feather="chevron-right"></i>
   </a>
 {% endblock %}

--- a/tabbycat/draw/templates/draw_confirm_regeneration.html
+++ b/tabbycat/draw/templates/draw_confirm_regeneration.html
@@ -2,37 +2,37 @@
 {% load debate_tags i18n %}
 
 {% block page-title %}
-  {% translate "Confirm draw regeneration" %}
+  {% trans "Confirm draw regeneration" %}
 {% endblock %}
 
 {% block page-subnav-sections %}
   <a class="btn btn-outline-primary " href="{% roundurl 'draw' %}">
-    <i data-feather="chevron-left"></i>{% translate "Back to Draw" %}
+    <i data-feather="chevron-left"></i>{% trans "Back to Draw" %}
   </a>
 {% endblock %}
 
 {% block head-title %}
   <span class="emoji">🔥</span>
-  {% blocktranslate trimmed with round=round.name %}Confirm Draw Deletion for {{ round }}{% endblocktranslate %}
+  {% blocktrans trimmed with round=round.name %}Confirm Draw Deletion for {{ round }}{% endblocktrans %}
 {% endblock %}
 
 {% block page-alerts %}
 
   <div class="alert alert-warning">
-    {% blocktranslate trimmed with round=round.name %}
+    {% blocktrans trimmed with round=round.name %}
     Do you really want to regenerate the draw for {{ round }}? This will
     delete <strong>all the debates in the current draw</strong> —  including
     their ballots and adjudicator allocations — and cannot be undone.
     You probably don't want to do this if any results have been entered!
-    {% endblocktranslate %}
+    {% endblocktrans %}
   </div>
 
   <form method="POST" action="{% roundurl 'draw-regenerate' %}">
     {% csrf_token %}
     <button class="btn btn-block btn-danger " type="submit">
-      {% blocktranslate trimmed with round=round.name %}
+      {% blocktrans trimmed with round=round.name %}
       Yes, I want to delete the current draw for {{ round }}
-      {% endblocktranslate %}
+      {% endblocktrans %}
     </button>
   </form>
 

--- a/tabbycat/draw/templates/draw_display_admin.html
+++ b/tabbycat/draw/templates/draw_display_admin.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 {% load debate_tags i18n %}
 
-{% block head-title %}📺 {% translate "Display Draw" %}{% endblock %}
-{% block page-title %}{% translate "Display Draw" %}{% endblock %}
+{% block head-title %}📺 {% trans "Display Draw" %}{% endblock %}
+{% block page-title %}{% trans "Display Draw" %}{% endblock %}
 
 {% block page-alerts %}
   <div class="mb-3">
@@ -14,24 +14,24 @@
 
 {% block page-subnav-sections %}
   <a class="btn btn-outline-primary " href="{% roundurl 'draw' %}">
-    <i data-feather="chevron-left"></i> {% translate "View Draw" %}
+    <i data-feather="chevron-left"></i> {% trans "View Draw" %}
   </a>
 
   <a href="" class="btn {% if round.starts_at %}btn-outline-primary{% else %}btn-primary{% endif %}"
      data-toggle="modal" data-target="#editStartTime">
     {% if round.starts_at %}
-      {% blocktranslate trimmed with start_time=round.starts_at %}
+      {% blocktrans trimmed with start_time=round.starts_at %}
         Debates start at {{ start_time }}
-      {% endblocktranslate %}
+      {% endblocktrans %}
     {% else %}
-      {% translate "Add Start Time" %}
+      {% trans "Add Start Time" %}
     {% endif %}
   </a>
 {% endblock %}
 
 {% block page-subnav-actions %}
   <a href="{% roundurl 'results-round-list' %}" class="btn btn-outline-success">
-    {% translate "Enter Results" %}<i data-feather="chevron-right"></i>
+    {% trans "Enter Results" %}<i data-feather="chevron-right"></i>
   </a>
 {% endblock %}
 
@@ -43,7 +43,7 @@
     <div class="card">
 
       <div class="card-body">
-        <h5 class="card-title mb-0">{% translate "Motion Details" %}</h5>
+        <h5 class="card-title mb-0">{% trans "Motion Details" %}</h5>
       </div>
       <div class="list-group list-group-flush">
         {% roundurl 'motions-edit' round as url %}
@@ -51,18 +51,18 @@
 
           {# Motions enabled, so we expect there to be several. #}
           {% if round.motion_set.exists %}
-            {% blocktranslate trimmed asvar text count motions_count=round.motion_set.count %}
+            {% blocktrans trimmed asvar text count motions_count=round.motion_set.count %}
               {{ motions_count }} motion has been entered.
             {% plural %}
               {{ motions_count }} motions have been entered.
-            {% endblocktranslate %}
+            {% endblocktrans %}
             {% include "components/item-info.html" with nopad=True type="secondary" %}
-            {% translate "Edit motions" as edit_text %}
+            {% trans "Edit motions" as edit_text %}
             {% include "components/item-action.html" with text=edit_text type="primary" %}
           {% else %}
-            {% translate "Your configuration/format requires motions to be specified as part of ballot entry. Make sure they are added before results come in!" as text %}
+            {% trans "Your configuration/format requires motions to be specified as part of ballot entry. Make sure they are added before results come in!" as text %}
             {% include "components/item-info.html" with nopad=True type="danger" %}
-            {% translate "Enter motions" as enter_text %}
+            {% trans "Enter motions" as enter_text %}
             {% include "components/item-action.html" with text=enter_text type="success" to_complete=True  %}
           {% endif %}
 
@@ -72,24 +72,24 @@
           {% if round.motion_set.exists %}
             {% if round.motion_set.count == 1 %}
               {# As expected. #}
-              {% translate "The motion has been entered." as text %}
+              {% trans "The motion has been entered." as text %}
               {% include "components/item-info.html" with nopad=True type="" %}
             {% else %}
               {# The singular below never gets used, but is required for i18n. #}
               {# Translators: Used when only one motion is expected, but there is more than one. #}
-              {% blocktranslate trimmed asvar text count motions_count=round.motion_set.count %}
+              {% blocktrans trimmed asvar text count motions_count=round.motion_set.count %}
                 {{ motions_count }} motion has been entered.
               {% plural %}
                 {{ motions_count }} motions have been entered.
-              {% endblocktranslate %}
+              {% endblocktrans %}
               {% include "components/item-info.html" with nopad=True type="secondary" %}
             {% endif %}
-            {% translate "Edit the motion" as edit_text %}
+            {% trans "Edit the motion" as edit_text %}
             {% include "components/item-action.html" with text=edit_text type="primary" %}
           {% else %}
-            {% translate "A motion should be added if you want to display it to the auditorium or print in on your ballots (using the links below) or to display it (later) on the public motions page." as text %}
+            {% trans "A motion should be added if you want to display it to the auditorium or print in on your ballots (using the links below) or to display it (later) on the public motions page." as text %}
             {% include "components/item-info.html" with nopad=True type="warning" %}
-            {% translate "Enter a motion" as enter_text %}
+            {% trans "Enter a motion" as enter_text %}
             {% include "components/item-action.html" with text=enter_text type="success" to_complete=True %}
           {% endif %}
 
@@ -103,31 +103,31 @@
     <div class="card">
 
       <div class="card-body">
-        <h5 class="card-title mb-0">{% translate "Release Draw" %}</h5>
+        <h5 class="card-title mb-0">{% trans "Release Draw" %}</h5>
       </div>
       <div class="list-group list-group-flush">
 
         {% if round.draw_status == round.STATUS_NONE %}
 
-          {% translate "You have not generated a draw for this round yet. There is nothing to release." as text %}
+          {% trans "You have not generated a draw for this round yet. There is nothing to release." as text %}
           {% include "components/item-info.html" with nopad=True type="info" %}
 
         {% elif round.draw_status == round.STATUS_DRAFT %}
 
-          {% translate "The draw for this round is still in a draft state. Confirm the draw before releasing it." as text %}
+          {% trans "The draw for this round is still in a draft state. Confirm the draw before releasing it." as text %}
           {% include "components/item-info.html" with nopad=True type="warning" %}
 
         {% elif round.draw_status == round.STATUS_RELEASED %}
 
-          {% translate "Unrelease draw to public" as un_release_text %}
+          {% trans "Unrelease draw to public" as un_release_text %}
           <form id="releaseDrawForm" method="POST" action="{% roundurl 'draw-unrelease' %}">{% csrf_token %}</form>
           {% tournamenturl 'options-tournament-section' section='public_features' as alert_link %}
 
           {% if pref.public_draw != 'off' %}
-            {% translate "The draw has been released publicly." as text %}
+            {% trans "The draw has been released publicly." as text %}
             {% include "components/item-info.html" with nopad=True type="" %}
 
-            {% translate "View public draw page" as text %}
+            {% trans "View public draw page" as text %}
             {% if pref.public_draw == 'current' and round == current_round %}
               {% tournamenturl 'draw-public-current-rounds' as public_link %}
               {% include "components/item-action.html" with type="info" url=public_link icon="eye" %}
@@ -136,14 +136,14 @@
               {% include "components/item-action.html" with type="info" url=public_link icon="eye" %}
             {% endif %}
           {% elif pref.participant_ballots != 'off' or pref.participant_feedback != 'off' %}
-            {% blocktranslate trimmed asvar text %}
+            {% blocktrans trimmed asvar text %}
               You have released the draw, so ballots and/or feedback can be submitted from the public forms (if enabled). However, the draw itself will not show to the public unless the "public view of draw" setting is enabled in <a class="alert-link" href="{{ alert_link }}"> this tournament's configuration</a>.
-            {% endblocktranslate %}
+            {% endblocktrans %}
             {% include "components/item-info.html" with nopad=True type="" %}
           {% else %}
-            {% blocktranslate trimmed asvar text %}
+            {% blocktrans trimmed asvar text %}
               You have released the draw, but it will not show to the public unless the "public view of draw" setting is enabled in <a class="alert-link" href="{{ alert_link }}"> this tournament's configuration</a>.
-            {% endblocktranslate %}
+            {% endblocktrans %}
             {% include "components/item-info.html" with nopad=True type="warning" %}
           {% endif %}
 
@@ -151,23 +151,23 @@
 
         {% else %}
 
-          {% translate "Release draw to public" as release_text %}
+          {% trans "Release draw to public" as release_text %}
           <form id="releaseDrawForm" method="POST" action="{% roundurl 'draw-release' %}">{% csrf_token %}</form>
 
           {% if pref.participant_ballots != 'off' or pref.participant_feedback != 'off' or pref.public_draw != 'off' %}
 
             {% if pref.participant_ballots != 'off' and pref.participant_feedback != 'off' %}
-              {% translate "Your tournament allows ballots and feedback to be submitted online by adjudicators. The draw must be released before they can do so." as text %}
+              {% trans "Your tournament allows ballots and feedback to be submitted online by adjudicators. The draw must be released before they can do so." as text %}
               {% include "components/item-info.html" with nopad=True type="danger" %}
             {% elif pref.participant_ballots != 'off' %}
-              {% translate "Your tournament allows ballots to be submitted online by adjudicators. The draw must be released before they can do so." as text %}
+              {% trans "Your tournament allows ballots to be submitted online by adjudicators. The draw must be released before they can do so." as text %}
               {% include "components/item-info.html" with nopad=True type="danger" %}
             {% elif pref.participant_feedback != 'off' %}
-              {% translate "Your tournament allows feedback to be submitted online by participants. The draw must be released before they can do so." as text %}
+              {% trans "Your tournament allows feedback to be submitted online by participants. The draw must be released before they can do so." as text %}
               {% include "components/item-info.html" with nopad=True type="danger" %}
             {% endif %}
             {% if pref.public_draw != 'off' %}
-              {% translate "Your tournament is configured to show the draw publicly. Releasing a draw will allow it to show it on the public page." as text %}
+              {% trans "Your tournament is configured to show the draw publicly. Releasing a draw will allow it to show it on the public page." as text %}
               {% include "components/item-info.html" with nopad=True type="info" %}
             {% endif %}
 
@@ -175,7 +175,7 @@
 
           {% else %}
 
-            {% translate "Your configuration doesn't have a public draw page or feedback/ballot submissions. There's no reason to release the draw." as text %}
+            {% trans "Your configuration doesn't have a public draw page or feedback/ballot submissions. There's no reason to release the draw." as text %}
             {% include "components/item-info.html" with nopad=True type="secondary" %}
 
             {% include "components/item-action.html" with id="triggerReleaseDrawForm" text=release_text url="" %}
@@ -193,13 +193,13 @@
     <div class="card">
 
       {% if pref.enable_motions or pref.motion_vetoes_enabled %}
-        {% translate "Release Motions" as release_motions_title %}
-        {% translate "Release motions to public" as release_text %}
-        {% translate "Unrelease motions to public" as unrelease_text %}
+        {% trans "Release Motions" as release_motions_title %}
+        {% trans "Release motions to public" as release_text %}
+        {% trans "Unrelease motions to public" as unrelease_text %}
       {% else %}
-        {% translate "Release Motion" as release_motions_title %}
-        {% translate "Release motion to public" as release_text %}
-        {% translate "Unrelease motion to public" as unrelease_text %}
+        {% trans "Release Motion" as release_motions_title %}
+        {% trans "Release motion to public" as release_text %}
+        {% trans "Unrelease motion to public" as unrelease_text %}
       {% endif %}
 
       <div class="card-body">
@@ -213,19 +213,19 @@
                 action="{% roundurl 'motions-release' %}">{% csrf_token %}</form>
 
           {% if pref.participant_ballots != 'off' and pref.enable_motions %}
-            {% translate "Your tournament is configured to require motions to be selected in ballots and to allow ballots to be submitted by adjudicators. Ensure that you release the motions before debates finish, otherwise ballots will not be able to be submitted." as text %}
+            {% trans "Your tournament is configured to require motions to be selected in ballots and to allow ballots to be submitted by adjudicators. Ensure that you release the motions before debates finish, otherwise ballots will not be able to be submitted." as text %}
             {% include "components/item-info.html" with nopad=True type="danger" %}
             {% include "components/item-action.html" with type="success" id="triggerReleaseMotionsForm" text=release_text url="" to_complete=True %}
           {% elif pref.participant_ballots != 'off' and pref.motion_vetoes_enabled %}
-            {% translate "Your tournament is configured to allow motions to be vetoed and to allow ballots to be submitted by adjudicators. Ensure that you release the motions before debates finish, otherwise ballots will not be able to nominate vetoes." as text %}
+            {% trans "Your tournament is configured to allow motions to be vetoed and to allow ballots to be submitted by adjudicators. Ensure that you release the motions before debates finish, otherwise ballots will not be able to nominate vetoes." as text %}
             {% include "components/item-info.html" with nopad=True type="danger" %}
             {% include "components/item-action.html" with type="success" id="triggerReleaseMotionsForm" text=release_text url="" to_complete=True %}
           {% elif pref.public_motions %}
-            {% translate "Your tournament is configured to show the motion(s) for each round on the public site. You'll need to first release the motion(s) for it to show there." as text %}
+            {% trans "Your tournament is configured to show the motion(s) for each round on the public site. You'll need to first release the motion(s) for it to show there." as text %}
             {% include "components/item-info.html" with nopad=True type="" %}
             {% include "components/item-action.html" with type="success" id="triggerReleaseMotionsForm" text=release_text url="" to_complete=True %}
           {% else %}
-            {% translate "Your tournament is not configured to show the motion(s) for each round on the public site. There's no need to release the motion(s)." as text %}
+            {% trans "Your tournament is not configured to show the motion(s) for each round on the public site. There's no need to release the motion(s)." as text %}
             {% include "components/item-info.html" with nopad=True type="secondary" %}
             {% include "components/item-action.html" with id="triggerReleaseMotionsForm" text=release_text url="" %}
           {% endif %}
@@ -237,21 +237,21 @@
           {# "and" takes precedence over "or" #}
           {% if pref.public_motions or pref.participant_ballots != 'off' and pref.enable_motions or pref.participant_ballots != 'off' and pref.motion_vetoes_enabled %}
             {% if pref.enable_motions or pref.motion_vetoes_enabled %}
-              {% translate "Motions have been released publicly." as text %}
+              {% trans "Motions have been released publicly." as text %}
             {% else %}
-              {% translate "The motion has been released publicly." as text %}
+              {% trans "The motion has been released publicly." as text %}
             {% endif %}
             {% include "components/item-info.html" with nopad=True type="" %}
-            {% translate "View public motions page" as text %}
+            {% trans "View public motions page" as text %}
             {% tournamenturl 'motions-public' as public_link %}
             {% include "components/item-action.html" with type="info" url=public_link icon="eye" %}
           {% else %}
             {% tournamenturl 'options-tournament-section' section='public_features' as alert_link %}
-            {% blocktranslate trimmed asvar text %}
+            {% blocktrans trimmed asvar text %}
               You have released the motions, but they will not show to the public unless
               the "public view of motions" setting is enabled in
               <a class="alert-link" href="{{ alert_link }}">this tournament's configuration</a>.
-            {% endblocktranslate %}
+            {% endblocktrans %}
             {% include "components/item-info.html" with nopad=True type="warning" %}
           {% endif %}
 
@@ -269,44 +269,44 @@
   <div class="col-md-12">
     <ul class="list-group">
 
-      {% translate "(for the briefing room)" as briefing_room_subtext %}
+      {% trans "(for the briefing room)" as briefing_room_subtext %}
 
       {% if round.is_current and tournament.current_rounds|length == 1 %}
 
         {% tournamenturl 'draw-display-current-rounds-by-venue' as url %}
-        {% translate "Display Draw ordered by Room" as text %}
+        {% trans "Display Draw ordered by Room" as text %}
         {% include "components/item-action.html" with subtext=briefing_room_subtext emoji="🏫" blank=True %}
 
         {% tournamenturl 'draw-display-current-rounds-by-team' as url %}
-        {% translate "Display Draw ordered by Team" as text %}
+        {% trans "Display Draw ordered by Team" as text %}
         {% include "components/item-action.html" with subtext=briefing_room_subtext emoji="👭" blank=True %}
 
       {% else %}
 
         {% tournamenturl 'draw-display-current-rounds-by-venue' as url %}
-        {% translate "Display Draws for <strong>All Current Rounds</strong> ordered by Room" as text %}
+        {% trans "Display Draws for <strong>All Current Rounds</strong> ordered by Room" as text %}
         {% include "components/item-action.html" with subtext=briefing_room_subtext emoji="🏫" blank=True %}
 
         {% tournamenturl 'draw-display-current-rounds-by-team' as url %}
-        {% translate "Display Draws for <strong>All Current Rounds</strong> ordered by Team" as text %}
+        {% trans "Display Draws for <strong>All Current Rounds</strong> ordered by Team" as text %}
         {% include "components/item-action.html" with subtext=briefing_room_subtext emoji="👭" blank=True %}
 
         {% roundurl 'draw-display-specific-round-by-venue' as url %}
-        {% blocktranslate trimmed with round=round.name asvar text %}
+        {% blocktrans trimmed with round=round.name asvar text %}
           Display Draw for <strong>{{ round }}</strong> ordered by Room
-        {% endblocktranslate %}
+        {% endblocktrans %}
         {% include "components/item-action.html" with subtext=briefing_room_subtext emoji="🏫" blank=True %}
 
         {% roundurl 'draw-display-specific-round-by-team' as url %}
-        {% blocktranslate trimmed with round=round.name asvar text %}
+        {% blocktrans trimmed with round=round.name asvar text %}
           Display Draw for <strong>{{ round }}</strong> ordered by Team
-        {% endblocktranslate %}
+        {% endblocktrans %}
         {% include "components/item-action.html" with subtext=briefing_room_subtext emoji="👭" blank=True %}
 
       {% endif %}
 
       {% roundurl 'motions-display' round as url %}
-      {% translate "Display Motions" as text %}
+      {% trans "Display Motions" as text %}
       {% include "components/item-action.html" with subtext=briefing_room_subtext emoji="📃" blank=True %}
 
     </ul>
@@ -325,9 +325,9 @@
       {% roundurl 'draw-team-email' as url %}
       {% include "components/item-action.html" with text="Email Draw" subtext="(to active teams)" emoji="✉️" %}
       {% if pref.enable_motions or pref.motion_vetoes_enabled %}
-        {% translate "Email Motions" as text %}
+        {% trans "Email Motions" as text %}
       {% else %}
-        {% translate "Email Motion" as text %}
+        {% trans "Email Motion" as text %}
       {% endif %}
       {% roundurl 'motions-email' as url %}
       {% include "components/item-action.html" with emoji="📇" %}
@@ -347,7 +347,7 @@
 
           <div class="list-group-item pb-3">
             <div class="form-group">
-              <label>{% translate "Start at" %}</label>
+              <label>{% trans "Start at" %}</label>
               <input class="form-control" placeholder="{{ round.starts_at|time:'H:i' }}" name="start_time"></input>
             </div>
           </div>

--- a/tabbycat/draw/templates/draw_display_assistant.html
+++ b/tabbycat/draw/templates/draw_display_assistant.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 {% load debate_tags i18n %}
 
-{% block head-title %}📺 {% translate "Display Draw" %}{% endblock %}
-{% block page-title %}{% translate "Display Draw" %}{% endblock %}
+{% block head-title %}📺 {% trans "Display Draw" %}{% endblock %}
+{% block page-title %}{% trans "Display Draw" %}{% endblock %}
 
 {% block content %}
 
@@ -10,40 +10,40 @@
   <div class="col-md-12">
     <ul class="list-group">
 
-      {% translate "(for the briefing room)" as briefing_room_subtext %}
+      {% trans "(for the briefing room)" as briefing_room_subtext %}
 
       {% if tournament.current_rounds|length == 1 %}
 
         {% tournamenturl 'draw-assistant-display-current-rounds-by-venue' as url %}
-        {% translate "Display Draw ordered by Room" as text %}
+        {% trans "Display Draw ordered by Room" as text %}
         {% include "components/item-action.html" with subtext=briefing_room_subtext emoji="🏫" blank=True %}
 
         {% tournamenturl 'draw-assistant-display-current-rounds-by-team' as url %}
-        {% translate "Display Draw ordered by Team" as text %}
+        {% trans "Display Draw ordered by Team" as text %}
         {% include "components/item-action.html" with subtext=briefing_room_subtext emoji="👭" blank=True %}
 
       {% else %}
 
         {% tournamenturl 'draw-assistant-display-current-rounds-by-venue' as url %}
-        {% translate "Display Draws for <strong>All Current Rounds</strong> ordered by Room" as text %}
+        {% trans "Display Draws for <strong>All Current Rounds</strong> ordered by Room" as text %}
         {% include "components/item-action.html" with subtext=briefing_room_subtext emoji="🏫" blank=True %}
 
         {% tournamenturl 'draw-assistant-display-current-rounds-by-team' as url %}
-        {% translate "Display Draws for <strong>All Current Rounds</strong> ordered by Team" as text %}
+        {% trans "Display Draws for <strong>All Current Rounds</strong> ordered by Team" as text %}
         {% include "components/item-action.html" with subtext=briefing_room_subtext emoji="👭" blank=True %}
 
         {% for round in tournament.current_rounds %}
 
           {% roundurl 'draw-assistant-display-specific-round-by-venue' round as url %}
-          {% blocktranslate trimmed with round=round.name asvar text %}
+          {% blocktrans trimmed with round=round.name asvar text %}
             Display Draw for <strong>{{ round }}</strong> ordered by Room
-          {% endblocktranslate %}
+          {% endblocktrans %}
           {% include "components/item-action.html" with subtext=briefing_room_subtext emoji="🏫" blank=True %}
 
           {% roundurl 'draw-assistant-display-specific-round-by-team' round as url %}
-          {% blocktranslate trimmed with round=round.name asvar text %}
+          {% blocktrans trimmed with round=round.name asvar text %}
             Display Draw for <strong>{{ round }}</strong> ordered by Team
-          {% endblocktranslate %}
+          {% endblocktrans %}
           {% include "components/item-action.html" with subtext=briefing_room_subtext emoji="👭" blank=True %}
 
         {% endfor %}
@@ -52,23 +52,23 @@
 
       {% if pref.assistant_access == "all_areas" %}
         {% tournamenturl 'motions-assistant-display' as url %}
-        {% translate "Display Motions" as text %}
+        {% trans "Display Motions" as text %}
         {% include "components/item-action.html" with subtext=briefing_room_subtext emoji="📃" blank=True %}
       {% endif %}
 
     </ul>
     <ul class="list-group mt-3">
 
-      {% translate "(for printing)" as printing_subtext %}
+      {% trans "(for printing)" as printing_subtext %}
 
       {% if pref.assistant_access == "all_areas" %}
         {% tournamenturl 'printing-assistant-scoresheets' as url %}
-        {% translate "View Ballot Forms" as text %}
+        {% trans "View Ballot Forms" as text %}
         {% include "components/item-action.html" with subtext=printing_subtext emoji="💯" %}
       {% endif %}
 
       {% tournamenturl 'printing-assistant-feedback' as url %}
-      {% translate "View Feedback Forms" as text %}
+      {% trans "View Feedback Forms" as text %}
       {% include "components/item-action.html" with subtext=printing_subtext emoji="🙅" %}
 
     </ul>

--- a/tabbycat/draw/templates/draw_display_by.html
+++ b/tabbycat/draw/templates/draw_display_by.html
@@ -14,55 +14,55 @@
 
   <div class="btn-group scroll-speeds d-none d-md-flex">
     <div class="btn btn-outline-secondary">
-      {% translate "Scroll Speed" %}
+      {% trans "Scroll Speed" %}
     </div>
     <div class="btn btn-outline-primary" data-target="0.07" id="scroll_draw1">
-      {% translate "Fast" %}
+      {% trans "Fast" %}
     </div>
     <div class="btn btn-outline-primary" data-target="0.055" id="scroll_draw2">
-      {% translate "Medium" %}
+      {% trans "Medium" %}
     </div>
     <div class="btn btn-outline-primary" data-target="0.04" id="scroll_draw3">
-      {% translate "Slow" %}
+      {% trans "Slow" %}
     </div>
     <div class="btn btn-outline-primary" data-target="0.025" id="scroll_draw4">
-      {% translate "Extra Slow" %}
+      {% trans "Extra Slow" %}
     </div>
   </div>
 
   <div class="d-none d-md-flex">
     <div class="btn btn-outline-primary" id="hide_adjudicators">
-      {% translate "Hide Adjudicators" %}
+      {% trans "Hide Adjudicators" %}
     </div>
     <div class="btn btn-outline-primary" id="show_adjudicators" style="display: none;">
-      {% translate "Show Adjudicators" %}
+      {% trans "Show Adjudicators" %}
     </div>
   </div>
 
   <div class="btn-group text-size d-none d-md-flex">
     <div class="btn btn-outline-secondary">
-      {% translate "Text Size" %}
+      {% trans "Text Size" %}
     </div>
     <div class="btn btn-outline-primary" data-target="draw-xs" id="tiny_text">
-      {% translate "Tiny" %}
+      {% trans "Tiny" %}
     </div>
     <div class="btn btn-outline-primary" data-target="draw-s" id="small_text">
-      {% translate "Small" %}
+      {% trans "Small" %}
     </div>
     <div class="btn btn-outline-primary" data-target="draw-m" id="medium_text">
-      {% translate "Medium" %}
+      {% trans "Medium" %}
     </div>
     <div class="btn btn-outline-primary" data-target="draw-l" id="large_text">
-      {% translate "Large" %}
+      {% trans "Large" %}
     </div>
     <div class="btn btn-outline-primary" data-target="draw-xl" id="huge_text">
-      {% translate "Huge" %}
+      {% trans "Huge" %}
     </div>
   </div>
 
   <div class="btn btn-secondary btn-sm btn btn-stop-scrolling fixed-top text-white mt-2 mr-2"
      data-target="draw-xs" id="stop_scrolling">
-    {% translate "Stop Scroll" %}
+    {% trans "Stop Scroll" %}
   </div>
 
 {% endblock %}

--- a/tabbycat/draw/templates/draw_not_released.html
+++ b/tabbycat/draw/templates/draw_not_released.html
@@ -4,11 +4,11 @@
 {% block page-alerts %}
 
   {% if round %}
-    {% blocktranslate trimmed with round=round.name asvar message %}
+    {% blocktrans trimmed with round=round.name asvar message %}
       The draw for {{ round }} has yet to be released.
-    {% endblocktranslate %}
+    {% endblocktrans %}
   {% else %}
-    {% translate "The draw for the next round has yet to be released." as message %}
+    {% trans "The draw for the next round has yet to be released." as message %}
   {% endif %}
   {% include "components/alert.html" with type="info" icon="alert-circle" %}
 

--- a/tabbycat/draw/templates/draw_status_confirmed.html
+++ b/tabbycat/draw/templates/draw_status_confirmed.html
@@ -15,7 +15,7 @@
       <div class="card">
 
         <div class="card-body">
-          <h5 class="card-title mb-0">{% translate "Adjudicator Allocations" %}</h5>
+          <h5 class="card-title mb-0">{% trans "Adjudicator Allocations" %}</h5>
         </div>
 
         <div class="list-group list-group-flush">
@@ -23,7 +23,7 @@
 
             {% if active_adjs < debates_in_round %}
 
-              {% translate "There are currently fewer adjudicators checked in than there are rooms." as message %}
+              {% trans "There are currently fewer adjudicators checked in than there are rooms." as message %}
               {% include "components/item-info.html" with nopad=True type="danger" text=message %}
 
             {% else %}
@@ -34,10 +34,10 @@
 
             {% roundurl 'edit-debate-adjudicators' as url %}
             {% if active_adjs < debates_in_round or no_chair > 0 or round.ballots_per_debate == 'per-adj' and even_panel > 0 %}
-              {% translate "Allocate adjudicators" as title %}
+              {% trans "Allocate adjudicators" as title %}
               {% include "components/item-action.html" with text=title type="success" to_complete=True %}
             {% else %}
-              {% translate "Edit adjudicator allocation" as title %}
+              {% trans "Edit adjudicator allocation" as title %}
               {% include "components/item-action.html" with text=title type="primary" %}
             {% endif %}
 
@@ -51,7 +51,7 @@
       <div class="card">
 
         <div class="card-body">
-          <h5 class="card-title mb-0">{% translate "Room Allocations" %}</h5>
+          <h5 class="card-title mb-0">{% trans "Room Allocations" %}</h5>
         </div>
         <div class="list-group list-group-flush">
 
@@ -59,10 +59,10 @@
 
           {% roundurl 'edit-debate-venues' round as url %}
           {% if round.num_debates_without_venue > 0 %}
-            {% translate "Allocate rooms" as title %}
+            {% trans "Allocate rooms" as title %}
             {% include "components/item-action.html" with text=title type="success" to_complete=True %}
           {% else %}
-            {% translate "Edit room allocation" as title %}
+            {% trans "Edit room allocation" as title %}
             {% include "components/item-action.html" with text=title type="primary" %}
           {% endif %}
 
@@ -75,34 +75,34 @@
       <div class="card">
 
         <div class="card-body">
-          <h5 class="card-title mb-0">{% translate "Preformed Panels" %}</h5>
+          <h5 class="card-title mb-0">{% trans "Preformed Panels" %}</h5>
         </div>
 
         <div class="list-group list-group-flush">
 
           {% if preformed_panels_in_round > 0 %}
-            {% blocktranslate trimmed asvar message count npanels=preformed_panels_in_round %}
+            {% blocktrans trimmed asvar message count npanels=preformed_panels_in_round %}
               There is {{ npanels }} preformed panel available for this round.
             {% plural %}
               There are {{ npanels }} preformed panels available for this round.
-            {% endblocktranslate %}
+            {% endblocktrans %}
             {% include "components/item-info.html" with nopad=True type="info" text=message %}
           {% else %}
-            {% translate "There are no preformed panels available for this round" as message %}
+            {% trans "There are no preformed panels available for this round" as message %}
             {% include "components/item-info.html" with nopad=True type="secondary" text=message %}
           {% endif %}
 
           {% roundurl 'edit-panel-adjudicators' as url %}
-          {% blocktranslate trimmed asvar text with round=round.abbreviation %}
+          {% blocktrans trimmed asvar text with round=round.abbreviation %}
             Edit preformed panels for {{ round }}
-          {% endblocktranslate %}
+          {% endblocktrans %}
           {% include "components/item-action.html" with text=text type="primary" %}
 
           {% if round.next %}
             {% roundurl 'edit-panel-adjudicators' round.next as url %}
-            {% blocktranslate trimmed asvar text with round=round.next.abbreviation %}
+            {% blocktrans trimmed asvar text with round=round.next.abbreviation %}
               Edit preformed panels for {{ round }}
-            {% endblocktranslate %}
+            {% endblocktrans %}
             {% include "components/item-action.html" with text=text type="primary" %}
           {% endif %}
 
@@ -117,16 +117,16 @@
           <div class="card">
 
             <div class="card-body">
-              <h5 class="card-title mb-0">{% translate "Side Allocations" %}</h5>
+              <h5 class="card-title mb-0">{% trans "Side Allocations" %}</h5>
             </div>
 
             <div class="list-group list-group-flush">
 
-              {% blocktranslate trimmed asvar text count ndebates=sides_unconfirmed %}
+              {% blocktrans trimmed asvar text count ndebates=sides_unconfirmed %}
                 1 debate does not have its sides confirmed.
               {% plural %}
                 {{ ndebates }} debates do not have their sides confirmed.
-              {% endblocktranslate %}
+              {% endblocktrans %}
               {% include "components/item-info.html" with  nopad=True type="danger" %}
 
               {% roundurl 'edit-debate-teams' as url %}

--- a/tabbycat/draw/templates/draw_status_draft.html
+++ b/tabbycat/draw/templates/draw_status_draft.html
@@ -3,10 +3,10 @@
 
 {% block page-subnav-sections %}
   <a href="{% roundurl 'draw-confirm-regenerate' %}" class="btn btn-outline-danger">
-    <i data-feather="chevron-left"></i> {% translate "Delete Draw" %}
+    <i data-feather="chevron-left"></i> {% trans "Delete Draw" %}
   </a>
   <a href="{% roundurl 'edit-debate-teams' round %}" class="btn btn-outline-primary">
-    {% translate "Edit Sides/Matchups" %}
+    {% trans "Edit Sides/Matchups" %}
   </a>
 {% endblock %}
 
@@ -14,7 +14,7 @@
   <form id="confirmForm" method="POST" action="{% roundurl 'draw-confirm' %}">
     {% csrf_token %}
     <button id="confirmDraw" class="btn btn-success" type="submit">
-      {% translate "Confirm Draw" %}<i data-feather="chevron-right"></i>
+      {% trans "Confirm Draw" %}<i data-feather="chevron-right"></i>
     </button>
   </form>
 {% endblock %}
@@ -22,7 +22,7 @@
 {% block page-alerts %}
   {% if pref.team_standings_precedence|length == 0 %}
     {% tournamenturl 'options-tournament-section' section='standings' as standings_config_url %}
-    {% blocktranslate trimmed asvar message %}
+    {% blocktrans trimmed asvar message %}
       The team standings precedence is empty. This means that teams aren't
       ranked according to any metrics, so all teams are in a single bracket
       containing everyone. If this isn't what you intended, set the team
@@ -31,39 +31,39 @@
       of this tournament's configuration</a>,
       then delete and recreate the draw. In most
       tournaments, the first metric should be points or wins.
-    {% endblocktranslate %}
+    {% endblocktrans %}
     {# Now just 'info' because the user already clicked through the 'warning' when creating the draw. #}
     {% include "components/alert.html" with type="info" icon="alert-circle" %}
   {% endif %}
 
   {% if pref.teams_in_debate == 'bp' and pref.team_standings_precedence|length > 0 and pref.team_standings_precedence.0 != 'points' %}
     {% tournamenturl 'options-tournament-section' section='standings' as standings_config_url %}
-    {% blocktranslate trimmed asvar message with metric=pref.team_standings_precedence.0|teammetricname %}
+    {% blocktrans trimmed asvar message with metric=pref.team_standings_precedence.0|teammetricname %}
       Brackets are formed using the first metric in the team standings precedence, which is currently
       set to <strong>{{ metric }}</strong>, rather than team points, which is the more usual convention.
       If this isn't what you wanted, you can
       <a href="{{ standings_config_url }}" class="alert-link">change the team standings precedence
       in the standings configuration page</a>.
-    {% endblocktranslate %}
+    {% endblocktrans %}
     {% include "components/alert.html" with type="info" icon='alert-circle' %}
   {% endif %}
 
   {% if round.draw_type == round.DRAW_MANUAL and round.debate_set.count == 0 %}
     {% roundurl 'edit-debate-teams' round as edit_matchups_url %}
-    {% blocktranslate trimmed asvar message %}
+    {% blocktrans trimmed asvar message %}
       The draw type for this round is set to <strong>manual</strong>, so Tabbycat has just made a
       blank draw. Head on over to
       <a href="{{ edit_matchups_url }}" class="alert-link">Edit Sides/Matchups</a>
       to fill it in.
-    {% endblocktranslate %}
+    {% endblocktrans %}
     {% include "components/alert.html" with type="info" icon='alert-circle' %}
   {% endif %}
 
   {% if pref.adj_min_score == pref.adj_max_score %}
     {% tournamenturl 'options-tournament-section' section='feedback' as feedback_config_url %}
-    {% blocktranslate trimmed asvar message %}
+    {% blocktrans trimmed asvar message %}
       The adjudicator score range is 0, and so adjudicator scores will be ignored when allocating. You can <a href="{{ feedback_config_url }}" class="alert-link">change the adjudicator score range in the feedback configuration page</a>.
-    {% endblocktranslate %}
+    {% endblocktrans %}
     {% include "components/alert.html" with type="info" icon='alert-circle' %}
   {% endif %}
 {% endblock %}
@@ -71,14 +71,14 @@
 {% block content %}
 
   {% if round.is_break_round %}
-    {% blocktranslate trimmed asvar p1 %}
+    {% blocktrans trimmed asvar p1 %}
       Tabbycat assigns sides in elimination rounds randomly. However, because in elimination rounds, many tournaments draw lots for sides in front of an audience, the sides are marked as "unconfirmed", so that it doesn't look like sides have been pre-assigned. After you confirm the draw, you'll need to confirm sides on the "Edit Sides/Matchups" page, even if you wish to accept Tabbycat's random assignment.
-    {% endblocktranslate %}
+    {% endblocktrans %}
     {% include "components/explainer-card.html" with type="warning" %}
   {% endif %}
 
   {% if round.draw_status == 'D' and round.prev and not round.is_break_round and pref.teams_in_debate == 'bp' and highlighted_cells_exist %}
-      {% blocktranslate trimmed asvar p1 %}
+      {% blocktrans trimmed asvar p1 %}
         Highlighted cells relate to changes in position balance, as follows:
         <ul>
           <li>Red cells indicates that the team could not be allocated a position that maintains
@@ -87,7 +87,7 @@
            possible in this draw, but is nonetheless still imbalanced.</li>
           <li>Green cells indicate that the team's previous imbalance is resolved with this draw.</li>
         </ul>
-      {% endblocktranslate %}
+      {% endblocktrans %}
       {% include "components/explainer-card.html" with type="info" %}
   {% endif %}
 

--- a/tabbycat/draw/templates/draw_status_none.html
+++ b/tabbycat/draw/templates/draw_status_none.html
@@ -3,9 +3,9 @@
 
 {% block page-alerts %}
   {% roundurl 'availability-index' as availability_url %}
-  {% blocktranslate trimmed asvar message with round=round.name %}
+  {% blocktrans trimmed asvar message with round=round.name %}
     A draw for {{ round }} hasn't yet been generated. To generate one, go
     to the <a href="{{ availability_url }}" class="alert-link">Availability section</a>.
-  {% endblocktranslate %}
+  {% endblocktrans %}
   {% include 'components/alert.html' with type="warning" %}
 {% endblock %}

--- a/tabbycat/draw/templates/draw_subpage.html
+++ b/tabbycat/draw/templates/draw_subpage.html
@@ -3,6 +3,6 @@
 
 {% block page-subnav-sections %}
   <a class="btn btn-outline-primary " href="{% roundurl 'draw' %}">
-    <i data-feather="chevron-left"></i>{% translate "Back to Draw" %}
+    <i data-feather="chevron-left"></i>{% trans "Back to Draw" %}
   </a>
 {% endblock %}

--- a/tabbycat/draw/templates/position_balance.html
+++ b/tabbycat/draw/templates/position_balance.html
@@ -3,18 +3,18 @@
 
 {% block page-alerts %}
   {% if round.num_debates_with_sides_unconfirmed > 0 %}
-    {% blocktranslate trimmed asvar message %}
+    {% blocktrans trimmed asvar message %}
       It looks like sides aren't confirmed for some debates in this round. This position balance report is generated using the "unconfirmed sides" in the database, and as a consequence, may not make much sense. It's best to confirm sides in all debates before looking at this report.
-    {% endblocktranslate %}
+    {% endblocktrans %}
     {% include "components/alert.html" with type="warning" %}
   {% endif %}
 {% endblock %}
 
 {% block content %}
 
-  {% blocktranslate trimmed asvar p1 with exponent=pref.bp_position_cost_exponent %}
+  {% blocktrans trimmed asvar p1 with exponent=pref.bp_position_cost_exponent %}
     Your current position cost function is <strong>{{ cost_func }}</strong>, raised to an exponent of <strong>{{ exponent }}</strong>. <a href="http://tabbycat.readthedocs.io/en/latest/features/draw-generation-bp.html#position-cost-options" target=_"blank">Read more about how position cost functions work</a> in our documentation.
-  {% endblocktranslate %}
+  {% endblocktrans %}
   {% include "components/explainer-card.html" with type="info" %}
 
   {{ block.super }}

--- a/tabbycat/draw/templates/position_balance_break.html
+++ b/tabbycat/draw/templates/position_balance_break.html
@@ -3,6 +3,6 @@
 
 {% block page-alerts %}
   {% roundurl 'availability-index' as checkins_url %}
-  {% translate "Position balance reports aren't computed for elimination rounds." as message %}
+  {% trans "Position balance reports aren't computed for elimination rounds." as message %}
   {% include 'components/alert.html' with type="info" %}
 {% endblock %}

--- a/tabbycat/draw/templates/position_balance_nonbp.html
+++ b/tabbycat/draw/templates/position_balance_nonbp.html
@@ -3,6 +3,6 @@
 
 {% block page-alerts %}
   {% roundurl 'availability-index' as checkins_url %}
-  {% translate "Position balance reports are only available for British Parliamentary tournaments." as message %}
+  {% trans "Position balance reports are only available for British Parliamentary tournaments." as message %}
   {% include 'components/alert.html' with type="info" %}
 {% endblock %}

--- a/tabbycat/draw/templates/position_balance_round1.html
+++ b/tabbycat/draw/templates/position_balance_round1.html
@@ -3,6 +3,6 @@
 
 {% block page-alerts %}
   {% roundurl 'availability-index' as checkins_url %}
-  {% translate "Position balance reports aren't computed for the first round of a tournament." as message %}
+  {% trans "Position balance reports aren't computed for the first round of a tournament." as message %}
   {% include 'components/alert.html' with type="info" %}
 {% endblock %}

--- a/tabbycat/importer/templates/archive_export_index.html
+++ b/tabbycat/importer/templates/archive_export_index.html
@@ -1,20 +1,20 @@
 {% extends "base.html" %}
 {% load debate_tags i18n %}
 
-{% block head-title %}<span class="emoji">🗂️</span> {% translate "Export Tournament Archive" %}{% endblock %}
-{% block page-title %}{% translate "Export Tournament Archive" %}{% endblock %}
+{% block head-title %}<span class="emoji">🗂️</span> {% trans "Export Tournament Archive" %}{% endblock %}
+{% block page-title %}{% trans "Export Tournament Archive" %}{% endblock %}
 
 {% block content %}
 
-  {% blocktranslate trimmed asvar text %}
+  {% blocktrans trimmed asvar text %}
     Tournaments can be exported in an <a href="https://en.wikipedia.org/wiki/XML">XML format</a> for use outside Tabbycat.
-  {% endblocktranslate %}
+  {% endblocktrans %}
   {% include "components/explainer-card.html" with type="info" %}
 
   <ul class="list-group mt-3">
 
     {% tournamenturl 'exporter-archive-all' as url %}
-    {% translate "Export all data" as text %}
+    {% trans "Export all data" as text %}
     {% include "components/item-action.html" with emoji="🗂️"%}
 
   </ul>

--- a/tabbycat/importer/templates/archive_importer.html
+++ b/tabbycat/importer/templates/archive_importer.html
@@ -3,7 +3,7 @@
 
 {% block head-title %}{% endblock %}
 {% block nav %}{% endblock %}
-{% block page-title %}{% translate "Import Tournament Archive" context "page title" %}{% endblock %}
+{% block page-title %}{% trans "Import Tournament Archive" context "page title" %}{% endblock %}
 
 {% block content %}
 
@@ -15,14 +15,14 @@
       <form action="." method="POST">
       {% csrf_token %}
 
-      {% translate "Import Tournament Archive" context "page title" as title %}
-      {% translate "This form will create a tournament with the data provided as a Debate XML format." as text %}
+      {% trans "Import Tournament Archive" context "page title" as title %}
+      {% trans "This form will create a tournament with the data provided as a Debate XML format." as text %}
       {% include "components/form-title.html" with emoji="🗂️" %}
 
       {% include "components/form-main.html" %}
 
-      {% translate "Import" as title %}
-      {% translate "Go back to the site home page" as subtitle %}
+      {% trans "Import" as title %}
+      {% trans "Go back to the site home page" as subtitle %}
       {% url 'tabbycat-index' as suburl %}
       {% include "components/form-submit.html" %}
 

--- a/tabbycat/importer/templates/simple_import_adjudicators_details.html
+++ b/tabbycat/importer/templates/simple_import_adjudicators_details.html
@@ -1,28 +1,28 @@
 {% extends "base.html" %}
 {% load static debate_tags add_field_css i18n %}
 
-{% block head-title %}<span class="emoji">👯</span> {% translate 'Add Adjudicators' context 'page title' %}
-{% blocktranslate trimmed with step=wizard.steps.step1 count=wizard.steps.count %}(Step {{ step }} of {{ count }}){% endblocktranslate %}{% endblock %}
-{% block page-title %}{% translate 'Add Adjudicators' context 'page title' %}{% endblock %}
+{% block head-title %}<span class="emoji">👯</span> {% trans 'Add Adjudicators' context 'page title' %}
+{% blocktrans trimmed with step=wizard.steps.step1 count=wizard.steps.count %}(Step {{ step }} of {{ count }}){% endblocktrans %}{% endblock %}
+{% block page-title %}{% trans 'Add Adjudicators' context 'page title' %}{% endblock %}
 
 {% block content %}
 
 <form method="POST">
 
   <div class="mb-4">
-    <button type="submit" class="btn btn-outline-primary" name="wizard_goto_step" value="{{ wizard.steps.prev }}"><i data-feather="chevron-left"></i>{% translate "Previous Step" %}</button>
+    <button type="submit" class="btn btn-outline-primary" name="wizard_goto_step" value="{{ wizard.steps.prev }}"><i data-feather="chevron-left"></i>{% trans "Previous Step" %}</button>
   </div>
 
   {% tournamenturl 'options-tournament-section' section='feedback' as options_feedback %}
   {% tournamenturl 'privateurls-list' as privateurls_url %}
-  {% blocktranslate trimmed asvar settings_info with min=pref.adj_min_score max=pref.adj_max_score %}
+  {% blocktrans trimmed asvar settings_info with min=pref.adj_min_score max=pref.adj_max_score %}
     As per <a href="{{ options_feedback }}" class="alert-link">this tournament's
     configuration</a>, an adjudicator's rating must be between
     <strong>{{ min }}</strong> and <strong>{{ max }}</strong>.
     Providing email addresses is optional but can be useful if
     using <a href="{{ privateurls_url }}" class="alert-link">private URLs</a>
     for feedback or ballots.
-  {% endblocktranslate %}
+  {% endblocktrans %}
 
   {% include "components/explainer-card.html" with type="info" p1=settings_info p2=shared_info %}
 
@@ -45,11 +45,11 @@
         <div class="card mt-3">
 
           {% if forms.grouper.name %}
-            {% blocktranslate trimmed asvar title with institution=forms.grouper.name %}
+            {% blocktrans trimmed asvar title with institution=forms.grouper.name %}
               Adjudicators for {{ institution }}
-            {% endblocktranslate %}
+            {% endblocktrans %}
           {% else %}
-            {% translate "Unaffiliated Adjudicators" as title %}
+            {% trans "Unaffiliated Adjudicators" as title %}
           {% endif %}
           {% include "components/form-title.html" %}
 
@@ -69,7 +69,7 @@
   {% endfor %}
 
   <div class="card mt-3">
-    {% translate 'Save All Adjudicators' as title %}
+    {% trans 'Save All Adjudicators' as title %}
     {% include "components/form-submit.html" %}
   </div>
 

--- a/tabbycat/importer/templates/simple_import_adjudicators_numbers.html
+++ b/tabbycat/importer/templates/simple_import_adjudicators_numbers.html
@@ -1,9 +1,9 @@
 {% extends "base.html" %}
 {% load static debate_tags add_field_css i18n %}
 
-{% block head-title %}<span class="emoji">👯</span> {% translate 'Add Adjudicators' context 'page title' %}
-{% blocktranslate trimmed with step=wizard.steps.step1 count=wizard.steps.count %}(Step {{ step }} of {{ count }}){% endblocktranslate %}{% endblock %}
-{% block page-title %}{% translate 'Add Adjudicators' context 'page title' %}{% endblock %}
+{% block head-title %}<span class="emoji">👯</span> {% trans 'Add Adjudicators' context 'page title' %}
+{% blocktrans trimmed with step=wizard.steps.step1 count=wizard.steps.count %}(Step {{ step }} of {{ count }}){% endblocktrans %}{% endblock %}
+{% block page-title %}{% trans 'Add Adjudicators' context 'page title' %}{% endblock %}
 
 {% block content %}
 
@@ -11,24 +11,24 @@
 
   <div class="alert alert-warning" role="alert">
     {% tournamenturl 'importer-simple-institutions' as import_institutions_url %}
-    {% blocktranslate trimmed %}
+    {% blocktrans trimmed %}
       You need to
       <a href="{{ import_institutions_url }}" class="alert-link">add institutions</a>
       before adding adjudicators.
-    {% endblocktranslate %}
+    {% endblocktrans %}
   </div>
 
 {% else %}
 
-  {% blocktranslate trimmed asvar p1 %}
+  {% blocktrans trimmed asvar p1 %}
     Specify the number of new adjudicators to add per institution.
     In the next step you can specify their names and ratings.
-  {% endblocktranslate %}
-  {% blocktranslate trimmed asvar p2 %}
+  {% endblocktrans %}
+  {% blocktrans trimmed asvar p2 %}
     You can add up to 198 adjudicators at a time. If you have more than 198
     adjudicators, split them into chunks. (Please don't try to add more than 198
     in one go; the system will crash and you will lose data.)
-  {% endblocktranslate %}
+  {% endblocktrans %}
   {% include "components/explainer-card.html" with type="info" %}
 
   <form method="POST">
@@ -56,7 +56,7 @@
           </li>
         {% endfor %}
 
-        {% translate "Next Step" context "button" as title %}
+        {% trans "Next Step" context "button" as title %}
         {% include "components/form-submit.html" %}
 
       </ul>

--- a/tabbycat/importer/templates/simple_import_index.html
+++ b/tabbycat/importer/templates/simple_import_index.html
@@ -1,73 +1,73 @@
 {% extends "base.html" %}
 {% load debate_tags i18n %}
 
-{% block head-title %}<span class="emoji">📑</span> {% translate "Simple Importer" %}{% endblock %}
-{% block page-title %}{% translate "Simple Importer" %}{% endblock %}
+{% block head-title %}<span class="emoji">📑</span> {% trans "Simple Importer" %}{% endblock %}
+{% block page-title %}{% trans "Simple Importer" %}{% endblock %}
 
 {% block content %}
 
-  {% blocktranslate trimmed asvar text %}
+  {% blocktrans trimmed asvar text %}
     There are <a href="https://tabbycat.readthedocs.io/en/stable/use/importing-data.html" target="_blank">several ways to import data into Tabbycat</a>. Which one is best depends on the size of your tournament and your technical background. This <strong>simple importer</strong> is the easiest to use and works well for small- and medium-sized tournaments.
-  {% endblocktranslate %}
+  {% endblocktrans %}
   {% include "components/explainer-card.html" with type="info" %}
 
   <ul class="list-group mt-3">
 
-    {% translate "Add Institutions" as text %}
+    {% trans "Add Institutions" as text %}
     {% tournamenturl 'importer-simple-institutions' as url %}
     {% include "components/item-action.html" with emoji="🏫"%}
 
     {% tournamenturl 'importer-simple-teams' as url %}
-    {% translate "Add Teams" as text %}
+    {% trans "Add Teams" as text %}
     {% include "components/item-action.html" with emoji="👯" %}
 
     {% tournamenturl 'importer-simple-adjudicators' as url %}
-    {% translate "Add Adjudicators" as text %}
+    {% trans "Add Adjudicators" as text %}
     {% include "components/item-action.html" with emoji="👂" %}
 
     {% tournamenturl 'importer-simple-venues' as url %}
-    {% translate "Add Rooms" as text %}
+    {% trans "Add Rooms" as text %}
     {% include "components/item-action.html" with emoji="🎪" %}
 
   </ul>
   <ul class="list-group mt-3">
 
     {% tournamenturl 'venues-categories' as url %}
-    {% translate "Add/Edit Room Categories" as text %}
+    {% trans "Add/Edit Room Categories" as text %}
     {% include "components/item-action.html" with emoji="🏪" %}
 
     {% tournamenturl 'venues-constraints' as url %}
-    {% translate "Add/Edit Room Constraints" as text %}
+    {% trans "Add/Edit Room Constraints" as text %}
     {% include "components/item-action.html" with emoji="🏰" %}
 
   </ul>
   <ul class="list-group mt-3">
 
     {% tournamenturl 'adjallocation-conflicts-adj-team' as url %}
-    {% translate "Add/Edit Adjudicator-Team Conflicts" as text %}
+    {% trans "Add/Edit Adjudicator-Team Conflicts" as text %}
     {% include "components/item-action.html" with emoji="🙉" %}
 
     {% tournamenturl 'adjallocation-conflicts-adj-adj' as url %}
-    {% translate "Add/Edit Adjudicator-Adjudicator Conflicts" as text %}
+    {% trans "Add/Edit Adjudicator-Adjudicator Conflicts" as text %}
     {% include "components/item-action.html" with emoji="🙊" %}
 
     {% tournamenturl 'adjallocation-conflicts-adj-inst' as url %}
-    {% translate "Add/Edit Adjudicator-Institution Conflicts" as text %}
+    {% trans "Add/Edit Adjudicator-Institution Conflicts" as text %}
     {% include "components/item-action.html" with emoji="🙈" %}
 
     {% tournamenturl 'adjallocation-conflicts-team-inst' as url %}
-    {% translate "Add/Edit Team-Institution Conflicts" as text %}
+    {% trans "Add/Edit Team-Institution Conflicts" as text %}
     {% include "components/item-action.html" with emoji="🐒" %}
 
   </ul>
   <ul class="list-group mt-3">
 
     {% tournamenturl 'break-categories-edit' as url %}
-    {% translate "Add/Edit Break Categories" as text %}
+    {% trans "Add/Edit Break Categories" as text %}
     {% include "components/item-action.html" with emoji="🎯" %}
 
     {% tournamenturl 'participants-speaker-categories-edit' as url %}
-    {% translate "Add/Edit Speaker Categories" as text %}
+    {% trans "Add/Edit Speaker Categories" as text %}
     {% include "components/item-action.html" with emoji="🏆" %}
 
   </ul>

--- a/tabbycat/importer/templates/simple_import_institutions_details.html
+++ b/tabbycat/importer/templates/simple_import_institutions_details.html
@@ -1,9 +1,9 @@
 {% extends "base.html" %}
 {% load add_field_css static debate_tags i18n %}
 
-{% block head-title %}<span class="emoji">🏫</span> {% translate "Add Institutions" context "page title" %}
-{% blocktranslate trimmed with step=wizard.steps.step1 count=wizard.steps.count %}(Step {{ step }} of {{ count }}){% endblocktranslate %}{% endblock %}
-{% block page-title %}{% translate "Add Institutions" context "page title" %}{% endblock %}
+{% block head-title %}<span class="emoji">🏫</span> {% trans "Add Institutions" context "page title" %}
+{% blocktrans trimmed with step=wizard.steps.step1 count=wizard.steps.count %}(Step {{ step }} of {{ count }}){% endblocktrans %}{% endblock %}
+{% block page-title %}{% trans "Add Institutions" context "page title" %}{% endblock %}
 
 {% block content %}
 
@@ -14,7 +14,7 @@
   {{ wizard.form.management_form }}
 
   <div class="mb-3">
-    <button type="submit" class="btn btn-outline-primary" name="wizard_goto_step" value="{{ wizard.steps.prev }}"><i data-feather="chevron-left"></i>{% translate "Previous Step" %}</button>
+    <button type="submit" class="btn btn-outline-primary" name="wizard_goto_step" value="{{ wizard.steps.prev }}"><i data-feather="chevron-left"></i>{% trans "Previous Step" %}</button>
   </div>
 
   <div class="row">
@@ -34,7 +34,7 @@
 
         {% endfor %}
 
-        {% translate "Save All Institutions" as title %}
+        {% trans "Save All Institutions" as title %}
         {% include "components/form-submit.html" %}
 
       </div>

--- a/tabbycat/importer/templates/simple_import_institutions_raw.html
+++ b/tabbycat/importer/templates/simple_import_institutions_raw.html
@@ -1,9 +1,9 @@
 {% extends "base.html" %}
 {% load static debate_tags add_field_css i18n %}
 
-{% block head-title %}<span class="emoji">🏫</span> {% translate "Add Institutions" context "page title" %}
-{% blocktranslate trimmed with step=wizard.steps.step1 count=wizard.steps.count %}(Step {{ step }} of {{ count }}){% endblocktranslate %}{% endblock %}
-{% block page-title %}{% translate "Add Institutions" context "page title" %}{% endblock %}
+{% block head-title %}<span class="emoji">🏫</span> {% trans "Add Institutions" context "page title" %}
+{% blocktrans trimmed with step=wizard.steps.step1 count=wizard.steps.count %}(Step {{ step }} of {{ count }}){% endblocktrans %}{% endblock %}
+{% block page-title %}{% trans "Add Institutions" context "page title" %}{% endblock %}
 
 {% block content %}
 
@@ -27,7 +27,7 @@ Universiti Teknologi MARA,UTMARA</code></pre>
 
         {% if wizard.form.institutions_raw.errors %}
           <div class="alert alert-danger">
-            <p>{% translate "There are some problems with the data on this form:" %}</p>
+            <p>{% trans "There are some problems with the data on this form:" %}</p>
             {{ wizard.form.institutions_raw.errors }}
           </div>
         {% endif %}
@@ -38,7 +38,7 @@ Universiti Teknologi MARA,UTMARA</code></pre>
 
       </div>
 
-      {% translate "Next Step" as title %}
+      {% trans "Next Step" as title %}
       {% include "components/form-submit.html" %}
 
     </div>

--- a/tabbycat/importer/templates/simple_import_teams_details.html
+++ b/tabbycat/importer/templates/simple_import_teams_details.html
@@ -1,9 +1,9 @@
 {% extends "base.html" %}
 {% load static debate_tags add_field_css i18n %}
 
-{% block head-title %}<span class="emoji">👯</span> {% translate 'Add Teams' context 'page title' %}
-{% blocktranslate trimmed with step=wizard.steps.step1 count=wizard.steps.count %}(Step {{ step }} of {{ count }}){% endblocktranslate %}{% endblock %}
-{% block page-title %}{% translate 'Add Teams' context 'page title' %}{% endblock %}
+{% block head-title %}<span class="emoji">👯</span> {% trans 'Add Teams' context 'page title' %}
+{% blocktrans trimmed with step=wizard.steps.step1 count=wizard.steps.count %}(Step {{ step }} of {{ count }}){% endblocktrans %}{% endblock %}
+{% block page-title %}{% trans 'Add Teams' context 'page title' %}{% endblock %}
 
 {% block content %}
 
@@ -14,7 +14,7 @@
   {{ wizard.form.management_form }}
 
   <div class="mb-3">
-    <button type="submit" class="btn btn-outline-primary" name="wizard_goto_step" value="{{ wizard.steps.prev }}"><i data-feather="chevron-left"></i>{% translate "Previous Step" %}</button>
+    <button type="submit" class="btn btn-outline-primary" name="wizard_goto_step" value="{{ wizard.steps.prev }}"><i data-feather="chevron-left"></i>{% trans "Previous Step" %}</button>
   </div>
 
   {% if wizard.form.errors %}
@@ -30,11 +30,11 @@
       <div class="list-group-item card-title pb-1">
         <h4>
         {% if forms.grouper.name %}
-          {% blocktranslate trimmed with institution=forms.grouper.name %}
+          {% blocktrans trimmed with institution=forms.grouper.name %}
             Teams for {{ institution }}
-          {% endblocktranslate %}
+          {% endblocktrans %}
         {% else %}
-          {% translate "Unaffiliated Teams" %}
+          {% trans "Unaffiliated Teams" %}
         {% endif %}
         </h4>
       </div>
@@ -48,7 +48,7 @@
   {% endfor %}
 
   <div class="card mt-3">
-    {% translate "Save All Teams" as title %}
+    {% trans "Save All Teams" as title %}
     {% include "components/form-submit.html" %}
   </div>
 

--- a/tabbycat/importer/templates/simple_import_teams_numbers.html
+++ b/tabbycat/importer/templates/simple_import_teams_numbers.html
@@ -1,9 +1,9 @@
 {% extends "base.html" %}
 {% load static debate_tags add_field_css i18n %}
 
-{% block head-title %}<span class="emoji">👯</span> {% translate 'Add Teams' context 'page title' %}
-{% blocktranslate trimmed with step=wizard.steps.step1 count=wizard.steps.count %}(Step {{ step }} of {{ count }}){% endblocktranslate %}{% endblock %}
-{% block page-title %}{% translate 'Add Teams' context 'page title' %}{% endblock %}
+{% block head-title %}<span class="emoji">👯</span> {% trans 'Add Teams' context 'page title' %}
+{% blocktrans trimmed with step=wizard.steps.step1 count=wizard.steps.count %}(Step {{ step }} of {{ count }}){% endblocktrans %}{% endblock %}
+{% block page-title %}{% trans 'Add Teams' context 'page title' %}{% endblock %}
 
 {% block content %}
 
@@ -12,24 +12,24 @@
   <div class="alert alert-warning" role="alert">
     <i data-feather="alert-circle"></i>
     {% tournamenturl 'importer-simple-institutions' as import_institutions_url %}
-    {% blocktranslate trimmed %}
+    {% blocktrans trimmed %}
       You need to
       <a href="{{ import_institutions_url }}" class="alert-link">add institutions</a>
       before adding teams.
-    {% endblocktranslate %}
+    {% endblocktrans %}
   </div>
 
 {% else %}
 
-  {% blocktranslate trimmed asvar p1 %}
+  {% blocktrans trimmed asvar p1 %}
     Specify the number of new teams to add per institution. In the next step
     you can specify team and speaker names.
-  {% endblocktranslate %}
-  {% blocktranslate trimmed asvar p2 %}
+  {% endblocktrans %}
+  {% blocktrans trimmed asvar p2 %}
     You can add up to 141 teams at a time. If you have more than 141 teams,
     split them into chunks. (Please don't try to add more than 141 in one go;
     the system will crash and you will lose data.)
-  {% endblocktranslate %}
+  {% endblocktrans %}
   {% include "components/explainer-card.html" with type="info" %}
 
   <form method="POST">
@@ -57,7 +57,7 @@
           </li>
         {% endfor %}
 
-        {% translate "Next Step" context "button" as title %}
+        {% trans "Next Step" context "button" as title %}
         {% include "components/form-submit.html" %}
 
       </ul>

--- a/tabbycat/importer/templates/simple_import_venues_details.html
+++ b/tabbycat/importer/templates/simple_import_venues_details.html
@@ -1,21 +1,21 @@
 {% extends "base.html" %}
 {% load static debate_tags add_field_css i18n %}
 
-{% block head-title %}<span class="emoji">🎪</span> {% translate "Add Rooms" context 'page title' %}
-{% blocktranslate trimmed with step=wizard.steps.step1 count=wizard.steps.count %}(Step {{ step }} of {{ count }}){% endblocktranslate %}{% endblock %}
-{% block page-title %}{% translate "Add Rooms" context 'page title' %}{% endblock %}
+{% block head-title %}<span class="emoji">🎪</span> {% trans "Add Rooms" context 'page title' %}
+{% blocktrans trimmed with step=wizard.steps.step1 count=wizard.steps.count %}(Step {{ step }} of {{ count }}){% endblocktrans %}{% endblock %}
+{% block page-title %}{% trans "Add Rooms" context 'page title' %}{% endblock %}
 
 {% block content %}
 
 <form method="POST">
 
   <div class="mb-3">
-    <button type="submit" class="btn btn-outline-primary" name="wizard_goto_step" value="{{ wizard.steps.prev }}"><i data-feather="chevron-left"></i>{% translate "Previous Step" %}</button>
+    <button type="submit" class="btn btn-outline-primary" name="wizard_goto_step" value="{{ wizard.steps.prev }}"><i data-feather="chevron-left"></i>{% trans "Previous Step" %}</button>
   </div>
 
-  {% blocktranslate trimmed asvar p1 %}
+  {% blocktrans trimmed asvar p1 %}
     Priorities indicate how much you want to use the room. Larger numbers indicate higher priority. If you have more rooms than debates, the rooms with the lowest priorities will not be used.
-  {% endblocktranslate %}
+  {% endblocktrans %}
   {% include "components/explainer-card.html" with type="info" %}
 
   {% csrf_token %}
@@ -30,7 +30,7 @@
     {% for form in wizard.form.forms %}
       {% include "components/form-main.html" with double=True %}
     {% endfor %}
-    {% translate 'Save All Rooms' as title %}
+    {% trans 'Save All Rooms' as title %}
     {% include "components/form-submit.html" %}
   </div>
 

--- a/tabbycat/importer/templates/simple_import_venues_raw.html
+++ b/tabbycat/importer/templates/simple_import_venues_raw.html
@@ -1,9 +1,9 @@
 {% extends "base.html" %}
 {% load static debate_tags add_field_css i18n %}
 
-{% block head-title %}<span class="emoji">🎪</span> {% translate "Add Rooms" context "page title" %}
-{% blocktranslate trimmed with step=wizard.steps.step1 count=wizard.steps.count %}(Step {{ step }} of {{ count }}){% endblocktranslate %}{% endblock %}
-{% block page-title %}{% translate "Add Rooms" context "page title" %}{% endblock %}
+{% block head-title %}<span class="emoji">🎪</span> {% trans "Add Rooms" context "page title" %}
+{% blocktrans trimmed with step=wizard.steps.step1 count=wizard.steps.count %}(Step {{ step }} of {{ count }}){% endblocktrans %}{% endblock %}
+{% block page-title %}{% trans "Add Rooms" context "page title" %}{% endblock %}
 
 {% block content %}
 
@@ -12,7 +12,7 @@
   {% csrf_token %}
 
     <div class="list-group-item text-info">
-      {% translate "Paste a list of rooms with one room per line and following the format of: <code>name,priority</code>. For example:" %}
+      {% trans "Paste a list of rooms with one room per line and following the format of: <code>name,priority</code>. For example:" %}
     </div>
 
     <div class="list-group-item list-group-item-secondary pb-0">
@@ -27,7 +27,7 @@
 
       {% if wizard.form.venues_raw.errors %}
         <div class="alert alert-danger">
-          <p>{% translate "There are some problems with the data on this form:" %}</p>
+          <p>{% trans "There are some problems with the data on this form:" %}</p>
           {{ wizard.form.venues_raw.errors }}
         </div>
       {% endif %}
@@ -38,7 +38,7 @@
 
     </div>
 
-    {% translate "Next Step" as title %}
+    {% trans "Next Step" as title %}
     {% include "components/form-submit.html" %}
 
 </form>

--- a/tabbycat/motions/templates/motion_global_statistics.html
+++ b/tabbycat/motions/templates/motion_global_statistics.html
@@ -19,7 +19,7 @@
       {% if motion.info_slide %}
         <span class="h6 badge badge-light text-secondary mx-auto mb-3 mt-0 hover-target"
               data-toggle="modal" data-target="#info_{{ motion.id }}">
-          {% translate "View Info Slide" %}
+          {% trans "View Info Slide" %}
         </span>
         {% include 'motions_info.html' %}
       {% endif %}

--- a/tabbycat/motions/templates/motion_round_statistics.html
+++ b/tabbycat/motions/templates/motion_round_statistics.html
@@ -28,7 +28,7 @@
         {% if motion.info_slide %}
           <span class="h6 badge badge-light text-secondary mx-auto mb-3 mt-0 hover-target"
                 data-toggle="modal" data-target="#info_{{ motion.id }}">
-            {% translate "View Info Slide" %}
+            {% trans "View Info Slide" %}
           </span>
           {% include 'motions_info.html' %}
         {% endif %}

--- a/tabbycat/motions/templates/motion_statistics_bp_elim.html
+++ b/tabbycat/motions/templates/motion_statistics_bp_elim.html
@@ -7,11 +7,11 @@
   <div class="row">
     <div class="col">
       <h6 class="mt-2 text-center text-muted">
-        {% blocktranslate trimmed count ndebates=motion.ndebates %}
+        {% blocktrans trimmed count ndebates=motion.ndebates %}
           results from {{ ndebates }} debate
         {% plural %}
           results from {{ ndebates }} debates
-        {% endblocktranslate %}
+        {% endblocktrans %}
       </h6>
     </div>
   </div>
@@ -23,41 +23,41 @@
       <div class="col-md-3 mb-3">
         <div class="progress">
 
-          {% blocktranslate trimmed with side=side.upper percentage=advancing_pc|floatformat count ndebates=motion.ndebates asvar advancing_tooltip_text %}
+          {% blocktrans trimmed with side=side.upper percentage=advancing_pc|floatformat count ndebates=motion.ndebates asvar advancing_tooltip_text %}
             {{ advancing }} of {{ ndebates }} team on {{ side }} ({{ percentage }}%) advanced
           {% plural %}
             {{ advancing }} of {{ ndebates }} teams on {{ side }} ({{ percentage }}%) advanced
-          {% endblocktranslate %}
-          {% blocktranslate trimmed with side=side.upper percentage=eliminated_pc|floatformat count ndebates=motion.ndebates asvar eliminated_tooltip_text %}
+          {% endblocktrans %}
+          {% blocktrans trimmed with side=side.upper percentage=eliminated_pc|floatformat count ndebates=motion.ndebates asvar eliminated_tooltip_text %}
             {{ eliminated }} of {{ ndebates }} team on {{ side }} ({{ percentage }}%) were eliminated
           {% plural %}
             {{ eliminated }} of {{ ndebates }} teams on {{ side }} ({{ percentage }}%) were eliminated
-          {% endblocktranslate %}
+          {% endblocktrans %}
 
           <div class="progress-bar progress-bar-advancing"
                style="width: {{ advancing_pc|unlocalize }}%" data-toggle="tooltip"
                title="{{ advancing_tooltip_text }}">
             {% if advancing_pc >= 25 %}
-              {% translate "advanced" %}
+              {% trans "advanced" %}
             {% else %}
-              {% translate "adv." context "abbreviation for 'advanced', used when not enough space" %}
+              {% trans "adv." context "abbreviation for 'advanced', used when not enough space" %}
             {% endif %}
           </div>
           <div class="progress-bar progress-bar-eliminated"
                style="width: {{ eliminated_pc|unlocalize }}%" data-toggle="tooltip"
                title="{{ eliminated_tooltip_text }}">
             {% if eliminated_pc >= 25 %}
-              {% translate "eliminated" %}
+              {% trans "eliminated" %}
             {% else %}
-              {% translate "elim." context "abbreviation for 'eliminated', used when not enough space" %}
+              {% trans "elim." context "abbreviation for 'eliminated', used when not enough space" %}
             {% endif %}
           </div>
 
         </div>
         <h6 class="mt-2 text-center text-{{ side }}">
-          {% blocktranslate trimmed with side=side.upper %}
+          {% blocktrans trimmed with side=side.upper %}
             {{ side }} results distribution
-          {% endblocktranslate %}
+          {% endblocktrans %}
         </h6>
       </div>
 
@@ -69,7 +69,7 @@
 
   <div class="row mb-2">
     <div class="col text-muted">
-      {% translate "No results for this motion" %}
+      {% trans "No results for this motion" %}
     </div>
   </div>
 

--- a/tabbycat/motions/templates/motion_statistics_bp_prelim.html
+++ b/tabbycat/motions/templates/motion_statistics_bp_prelim.html
@@ -10,15 +10,15 @@
       <div class="progress">
         <div class="progress-bar progress-bar-gov"
              style="width: {% percentage motion.counts_by_bench.gov 3 %}%">
-          {% translate "Government" %} {{ motion.counts_by_bench.gov|floatformat:2 }}
+          {% trans "Government" %} {{ motion.counts_by_bench.gov|floatformat:2 }}
         </div>
         <div class="progress-bar progress-bar-opp"
              style="width: {% percentage motion.counts_by_bench.opp 3 %}%">
-          {% translate "Opposition" %} {{ motion.counts_by_bench.opp|floatformat:2 }}
+          {% trans "Opposition" %} {{ motion.counts_by_bench.opp|floatformat:2 }}
         </div>
       </div>
       <h6 class="mt-2 text-center text-muted">
-        {% translate "Average Points per bench" %}
+        {% trans "Average Points per bench" %}
       </h6>
     </div>
 
@@ -26,15 +26,15 @@
       <div class="progress">
         <div class="progress-bar progress-bar-opening"
              style="width: {% percentage motion.counts_by_half.top 3 %}%">
-          {% translate "Opening" %} {{ motion.counts_by_half.top|floatformat:2 }}
+          {% trans "Opening" %} {{ motion.counts_by_half.top|floatformat:2 }}
         </div>
         <div class="progress-bar progress-bar-closing"
              style="width: {% percentage motion.counts_by_half.bottom 3 %}%">
-          {% translate "Closing" %} {{ motion.counts_by_half.bottom|floatformat:2 }}
+          {% trans "Closing" %} {{ motion.counts_by_half.bottom|floatformat:2 }}
         </div>
       </div>
       <h6 class="mt-2 text-center text-muted">
-        {% translate "Average Points per half" %}
+        {% trans "Average Points per half" %}
       </h6>
     </div>
 
@@ -57,11 +57,11 @@
         {% endfor %}
       </div>
       <h6 class="mt-2 text-center text-muted">
-        {% blocktranslate trimmed count ndebates=motion.ndebates %}
+        {% blocktrans trimmed count ndebates=motion.ndebates %}
           average points per position ({{ ndebates }} debate)
         {% plural %}
           average points per position ({{ ndebates }} debates)
-        {% endblocktranslate %}
+        {% endblocktrans %}
       </h6>
     </div>
   </div>
@@ -75,11 +75,11 @@
 
           {% for points, count, percentage in counts_dict %}
 
-            {% blocktranslate trimmed with side=side.upper percentage=percentage|floatformat count count=count asvar tooltip_text %}
+            {% blocktrans trimmed with side=side.upper percentage=percentage|floatformat count count=count asvar tooltip_text %}
               {{ count }} result for {{ side }} ({{ percentage }}%) were for {{ points }} points
             {% plural %}
               {{ count }} results for {{ side }} ({{ percentage }}%) were for {{ points }} points
-            {% endblocktranslate %}
+            {% endblocktrans %}
 
             <div class="progress-bar progress-points-{{ points }}"
                  style="width: {{ percentage|unlocalize }}%" data-toggle="tooltip"
@@ -98,9 +98,9 @@
 
         </div>
         <h6 class="mt-2 text-center text-{{ side }}">
-          {% blocktranslate trimmed with side=side.upper %}
+          {% blocktrans trimmed with side=side.upper %}
             {{ side }} results
-          {% endblocktranslate %}
+          {% endblocktrans %}
         </h6>
       </div>
 
@@ -112,7 +112,7 @@
 
   <div class="row">
     <div class="col text-muted">
-      {% translate "No results for this motion" %}
+      {% trans "No results for this motion" %}
     </div>
   </div>
 

--- a/tabbycat/motions/templates/motion_statistics_twoteam.html
+++ b/tabbycat/motions/templates/motion_statistics_twoteam.html
@@ -28,18 +28,18 @@
 
       <div class="col text-left h6">
         <span class="text-aff pr-1 d-md-inline d-block">
-          {% blocktranslate trimmed with side=side_names.0 count count=motion.aff_wins %}
+          {% blocktrans trimmed with side=side_names.0 count count=motion.aff_wins %}
             {{ count }} {{ side }} win
           {% plural %}
             {{ count }} {{ side }} wins
-          {% endblocktranslate %}
+          {% endblocktrans %}
         </span>
         <span class="text-neg pr-1 d-md-inline d-block">
-          {% blocktranslate trimmed with side=side_names.1 count count=motion.neg_wins %}
+          {% blocktrans trimmed with side=side_names.1 count count=motion.neg_wins %}
             {{ count }} {{ side }} win
           {% plural %}
             {{ count }} {{ side }} wins
-          {% endblocktranslate %}
+          {% endblocktrans %}
         </span>
       </div>
 
@@ -50,7 +50,7 @@
     {% else %}
 
       <div class="col text-muted h6">
-        {% translate "No teams debated this motion" %}
+        {% trans "No teams debated this motion" %}
       </div>
 
     {% endif %}
@@ -88,18 +88,18 @@
 
         <div class="col text-left h6">
           <span class="text-aff pr-1 d-md-inline d-block">
-            {% blocktranslate trimmed with side=side_names.0 count count=motion.aff_vetoes %}
+            {% blocktrans trimmed with side=side_names.0 count count=motion.aff_vetoes %}
               {{ count }} {{ side }} veto
             {% plural %}
               {{ count }} {{ side }} vetoes
-            {% endblocktranslate %}
+            {% endblocktrans %}
           </span>
           <span class="text-neg pr-1 d-md-inline d-block">
-            {% blocktranslate trimmed with side=side_names.1 count count=motion.neg_vetoes %}
+            {% blocktrans trimmed with side=side_names.1 count count=motion.neg_vetoes %}
               {{ count }} {{ side }} veto
             {% plural %}
               {{ count }} {{ side }} vetoes
-            {% endblocktranslate %}
+            {% endblocktrans %}
           </span>
         </div>
 
@@ -110,7 +110,7 @@
       {% else %}
 
         <div class="col text-muted text-right h6">
-          {% translate "No teams vetoed this motion" %}
+          {% trans "No teams vetoed this motion" %}
         </div>
 
       {% endif %}

--- a/tabbycat/motions/templates/motions_edit.html
+++ b/tabbycat/motions/templates/motions_edit.html
@@ -1,21 +1,21 @@
 {% extends "base.html" %}
 {% load add_field_css debate_tags i18n %}
 
-{% block head-title %}{% blocktranslate trimmed count nmotions=formset|length %}
+{% block head-title %}{% blocktrans trimmed count nmotions=formset|length %}
   Edit Motion
 {% plural %}
   Edit Motions
-{% endblocktranslate %}{% endblock %}
+{% endblocktrans %}{% endblock %}
 
-{% block page-title %}{% blocktranslate trimmed count nmotions=formset|length %}
+{% block page-title %}{% blocktrans trimmed count nmotions=formset|length %}
   Edit Motion
 {% plural %}
   Edit Motions
-{% endblocktranslate %}{% endblock %}
+{% endblocktrans %}{% endblock %}
 
 {% block page-subnav-sections %}
   <a class="btn btn-outline-primary " href="{% roundurl 'draw-display' %}">
-    <i data-feather="chevron-left"></i> {% translate "Display Draw" %}
+    <i data-feather="chevron-left"></i> {% trans "Display Draw" %}
   </a>
 
   {% if pref.enable_motion_reuse %}
@@ -25,14 +25,14 @@
         {% if round.roundmotion_set.all.length == 0 %}
           <button class="btn btn-outline-primary" id="repeatMotions" type="submit">
         {% else %}
-          <button class="btn btn-outline-primary" id="repeatMotions" type="submit" data-toggle="tooltip" title="{% translate "This will replace all existing motions for this round. The motions themselves will still be in the database." %}">
+          <button class="btn btn-outline-primary" id="repeatMotions" type="submit" data-toggle="tooltip" title="{% trans "This will replace all existing motions for this round. The motions themselves will still be in the database." %}">
         {% endif %}
-          {% translate "Reuse Motions from Last Round" %}
+          {% trans "Reuse Motions from Last Round" %}
         </button>
       </form>
 
       <a href="{% roundurl 'motions-copy' %}" class="btn btn-outline-primary">
-        {% translate "Use Existing Motions" %}
+        {% trans "Use Existing Motions" %}
       </a>
     </div>
   {% endif %}
@@ -71,11 +71,11 @@
 
     </div>
 
-    {% blocktranslate trimmed asvar button_text count nmotions=formset|length %}
+    {% blocktrans trimmed asvar button_text count nmotions=formset|length %}
       Save Motion
     {% plural %}
       Save Motions
-    {% endblocktranslate %}
+    {% endblocktrans %}
     {% include "components/form-submit.html" with title=button_text %}
 
   </form>

--- a/tabbycat/motions/templates/motions_info.html
+++ b/tabbycat/motions/templates/motions_info.html
@@ -5,7 +5,7 @@
   <div class="modal-dialog modal-dialog-centered modal-lg" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title">{% translate "Info Slide" %}</h5>
+        <h5 class="modal-title">{% trans "Info Slide" %}</h5>
         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">&times;</span>
         </button>

--- a/tabbycat/motions/templates/public_motions.html
+++ b/tabbycat/motions/templates/public_motions.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 {% load static i18n %}
 
-{% block head-title %}{% translate "Motions" %}{% endblock %}
-{% block page-title %}{% translate "Motions" %}{% endblock %}
+{% block head-title %}{% trans "Motions" %}{% endblock %}
+{% block page-title %}{% trans "Motions" %}{% endblock %}
 
 {% block content %}
 
@@ -29,7 +29,7 @@
                 <div class="pt-md-0 pt-2">
                   <button class="btn btn-sm btn-secondary btn-block"
                           data-toggle="modal" data-target="#info_{{ motion.id }}">
-                    {% translate "View Info Slide" %}
+                    {% trans "View Info Slide" %}
                   </button>
                   {% include 'motions_info.html' %}
                 </div>
@@ -38,18 +38,18 @@
             {% endwith %}
           {% empty %}
             <li class="list-group-item list-group-item-secondary">
-              {% translate "There are no motions available for this round." %}
+              {% trans "There are no motions available for this round." %}
             </li>
           {% endfor %}
         {% elif pref.enable_motions %}
           {# Translators: Used when there are expected to be several motions per round (e.g. Australs) #}
           <li class="list-group-item list-group-item-secondary">
-            {% translate "The motions for this round have not been released." %}
+            {% trans "The motions for this round have not been released." %}
           </li>
         {% else %}
           {# Translators: Used when there is expected to be one motion per round (e.g. WUDC) #}
           <li class="list-group-item list-group-item-secondary">
-            {% translate "The motion for this round has not been released." %}
+            {% trans "The motion for this round has not been released." %}
           </li>
         {% endif %}
       </div>

--- a/tabbycat/motions/templates/show.html
+++ b/tabbycat/motions/templates/show.html
@@ -13,19 +13,19 @@
     <div>
       {% if infos %}
         <button class="btn btn-lg btn-info btn-block mb-5" data-toggle="modal" data-target="#infoPop">
-          {% blocktranslate trimmed with round=round.name count ninfos=infos|length %}
+          {% blocktrans trimmed with round=round.name count ninfos=infos|length %}
             Reveal Info Slide for {{ round }}
           {% plural %}
             Reveal Info Slides for {{ round }}
-          {% endblocktranslate %}
+          {% endblocktrans %}
         </button>
       {% endif %}
       <button class="btn btn-lg btn-success btn-block" data-toggle="modal" data-target="#motionPop">
-        {% blocktranslate trimmed with round=round.name count nmotions=motions|length %}
+        {% blocktrans trimmed with round=round.name count nmotions=motions|length %}
           Reveal Motion for {{ round }}
         {% plural %}
           Reveal Motions for {{ round }}
-        {% endblocktranslate %}
+        {% endblocktrans %}
       </button>
     </div>
   </div>
@@ -38,7 +38,7 @@
 
           <div class="modal-body d-flex align-items-center justify-content-center">
             <div class="display-3 text-danger">
-              😳 {% translate "There are no motions for this round entered into Tabbycat." %}
+              😳 {% trans "There are no motions for this round entered into Tabbycat." %}
             </div>
           </div>
 

--- a/tabbycat/notifications/templates/email_participants.html
+++ b/tabbycat/notifications/templates/email_participants.html
@@ -9,17 +9,17 @@
 
 {% if pref.reply_to_address == "" %}
   {% tournamenturl 'options-tournament-section' section='email' as notifications_options_url %}
-  {% blocktranslate trimmed asvar p1 %}
+  {% blocktrans trimmed asvar p1 %}
     You have not specified a reply-to address. This means that participants may not reply to the message if they have questions. Please set one in the <a href="{{ notifications_options_url }}">Notifications section of the preferences</a>.
-  {% endblocktranslate %}
+  {% endblocktrans %}
   {% include "components/explainer-card.html" with type="warning" %}
 {% endif %}
 
 {% if pref.email_hook_key != "" and not sg_webhook %}
   {% tournament_absurl 'notifications-webhook' key=pref.email_hook_key as notifications_webhook_url %}
-  {% blocktranslate trimmed asvar p1 %}
+  {% blocktrans trimmed asvar p1 %}
     The webhook URL for use in SendGrid is <a href="{{ notifications_webhook_url }}">{{ notifications_webhook_url }}</a>. Please point the HTTP POST URL in <a href="https://app.sendgrid.com/settings/mail_settings">SendGrid</a> to that.
-  {% endblocktranslate %}
+  {% endblocktrans %}
   {% include "components/explainer-card.html" with type="info" %}
 {% endif %}
 
@@ -47,7 +47,7 @@
       {% include "components/form-field.html" %}
     {% endfor %}
     <button type="submit" class="btn btn-block btn-success">
-      {% translate "Send Message(s)" %}
+      {% trans "Send Message(s)" %}
     </button>
   </form>
 

--- a/tabbycat/notifications/templates/email_statuses.html
+++ b/tabbycat/notifications/templates/email_statuses.html
@@ -7,12 +7,12 @@
 
 {% block page-alerts %}
 
-  {% blocktranslate trimmed asvar text %}
+  {% blocktrans trimmed asvar text %}
     Emails can be sent by Tabbycat for a variety of purposes. Emails are sent when specific
     preferences are enabled (i.e. enabling Ballot Receipts) or through actions available on specific
     pages (i.e. the Draw Display page for matchups; or the Participants page for team registration).
     This page shows the status of previously-sent emails.
-  {% endblocktranslate %}
+  {% endblocktrans %}
   {% include "components/item-info.html" with type="info" %}
 
 {% endblock %}

--- a/tabbycat/notifications/templates/notifications_nav.html
+++ b/tabbycat/notifications/templates/notifications_nav.html
@@ -2,15 +2,15 @@
 
 <div class="btn-group flex-wrap">
   <a class="btn btn-outline-primary" href="{% tournamenturl 'notifications-status' %}">
-    {% translate "Email Statuses" %}
+    {% trans "Email Statuses" %}
   </a>
 </div>
 
 <div class="btn-group flex-wrap">
   <a class="btn btn-outline-primary" href="{% url 'notifications-test-email' %}">
-    {% translate "Send Test Email" %}
+    {% trans "Send Test Email" %}
   </a>
   <a class="btn btn-outline-primary" href="{% tournamenturl 'notifications-email' %}">
-    {% translate "Send Custom Email" %}
+    {% trans "Send Custom Email" %}
   </a>
 </div>

--- a/tabbycat/notifications/templates/test_email.html
+++ b/tabbycat/notifications/templates/test_email.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 
 {% block head-title %}{% endblock %}
-{% block page-title %}{% translate "Send Test Email" context "page title" %}{% endblock %}
+{% block page-title %}{% trans "Send Test Email" context "page title" %}{% endblock %}
 {% block nav %}{% endblock %}
 
 {% block content %}
@@ -15,19 +15,19 @@
       <form action="." method="POST">
       {% csrf_token %}
 
-      {% translate "Send Test Email" context "page title" as title %}
-      {% translate "You can use this form to send a test email, to check that your email backend settings are working, before you try to send email notifications to participants." as text %}
-      {% blocktranslate trimmed asvar p1 %}
+      {% trans "Send Test Email" context "page title" as title %}
+      {% trans "You can use this form to send a test email, to check that your email backend settings are working, before you try to send email notifications to participants." as text %}
+      {% blocktrans trimmed asvar p1 %}
         The email will be sent from: <strong>{{ default_from_email }}</strong>. If this doesn't look right, change the <code>DEFAULT_FROM_EMAIL</code> config var in Heroku (or environment variable).
-      {% endblocktranslate %}
+      {% endblocktrans %}
       {% include "components/form-title.html" with emoji="📧" %}
 
       {% include 'errors/legacy_sendgrid_warning.html' %}
 
       {% include "components/form-main.html" %}
 
-      {% translate "Send Test Email" as title %}
-      {% translate "Go back to the site home page" as subtitle %}
+      {% trans "Send Test Email" as title %}
+      {% trans "Go back to the site home page" as subtitle %}
       {% url 'tabbycat-index' as suburl %}
       {% include "components/form-submit.html" %}
 

--- a/tabbycat/options/templates/preferences_index.html
+++ b/tabbycat/options/templates/preferences_index.html
@@ -1,43 +1,43 @@
 {% extends "base.html" %}
 {% load debate_tags add_field_css i18n %}
 
-{% block page-title %}{% translate "Configuration" %}{% endblock %}
-{% block head-title %}<span class="emoji">🔧</span> {% translate "Configuration" %}{% endblock %}
+{% block page-title %}{% trans "Configuration" %}{% endblock %}
+{% block head-title %}<span class="emoji">🔧</span> {% trans "Configuration" %}{% endblock %}
 
 {% block page-alerts %}
   {% if pref.teams_in_debate == 'bp' %}
     {% if pref.ballots_per_debate_prelim == 'per-adj' or pref.ballots_per_debate_elim == 'per-adj' %}
       {% tournamenturl 'options-tournament-section' section='debate_rules' as options_url %}
-      {% blocktranslate trimmed asvar message %}
+      {% blocktrans trimmed asvar message %}
         Your draw rules specify four teams per-debate but your ballot setting specifies that
         adjudicators submit independent ballots. These settings <strong>are not compatible
         and will cause results entry to crash</strong>. You need to go back to the
         <a href="{{ options_url }}" class="alert-link">Debate Rules section</a> and change
         your configuration to use consensus ballots.
-      {% endblocktranslate %}
+      {% endblocktrans %}
       {% include "components/alert.html" with type="danger" icon="alert-circle" %}
     {% endif %}
   {% endif %}
   {% if pref.draw_side_allocations != 'preallocated' %}
     {% if pref.draw_odd_bracket == 'intermediate1' or pref.draw_odd_bracket == 'intermediate2' %}
       {% tournamenturl 'options-tournament-section' section='draw_rules' as options_url %}
-      {% blocktranslate trimmed asvar message %}
+      {% blocktrans trimmed asvar message %}
         You do not use preallocated side allocation yet the odd bracket resolution method
         uses preallocated sides. This will cause draw generation to fail. You need to edit
         odd bracket resolution, avoiding <i>Intermediate 1</i> and <i>Intermediate 2</i> in
         the <a href="{{ options_url }}" class="alert-link">Draw Rules section</a>.
-      {% endblocktranslate %}
+      {% endblocktrans %}
       {% include "components/alert.html" with type="danger" icon="alert-circle" %}
     {% endif %}
   {% endif %}
   {% if pref.team_code_names != 'off' and pref.team_code_names != 'all-tooltips' and pref.show_team_institutions %}
     {% tournamenturl 'options-tournament-section' section='ui_options' as ui_url %}
-    {% blocktranslate trimmed asvar message %}
+    {% blocktrans trimmed asvar message %}
       You both have team code names enabled, and team institutions showing on public pages.
       If your objective in enabling team code names is to obscure team institutions, this
       probably defeats the purpose of code names. You can edit these settings in the
       <a href="{{ ui_url }}" class="alert-link">UI Options section</a>.
-    {% endblocktranslate %}
+    {% endblocktrans %}
     {% include "components/alert.html" with type="warning" icon="alert-circle" %}
   {% endif %}
 {% endblock %}
@@ -50,33 +50,33 @@
     <ul class="list-group">
 
       {% tournamenturl 'options-tournament-section' section='scoring' as url %}
-      {% translate "Score Rules" as title %}
-      {% translate "The range of scores that can awarded to speeches, replies, and teams" as description %}
+      {% trans "Score Rules" as title %}
+      {% trans "The range of scores that can awarded to speeches, replies, and teams" as description %}
       {% include "components/item-action.html" with type="primary" emoji="💯" text=title extra=description %}
 
       {% tournamenturl 'options-tournament-section' section='draw_rules' as url %}
-      {% translate "Draw Rules" as title %}
-      {% translate "How teams are paired in the draw and how adjudicators are auto-allocated" as description %}
+      {% trans "Draw Rules" as title %}
+      {% trans "How teams are paired in the draw and how adjudicators are auto-allocated" as description %}
       {% include "components/item-action.html" with type="primary" emoji="📏" text=title extra=description %}
 
       {% tournamenturl 'options-tournament-section' section='debate_rules' as url %}
-      {% translate "Debate Rules" as title %}
-      {% translate "How many speeches in a debate, how motions are decided, and whether reply speeches are used" as description %}
+      {% trans "Debate Rules" as title %}
+      {% trans "How many speeches in a debate, how motions are decided, and whether reply speeches are used" as description %}
       {% include "components/item-action.html" with type="primary" emoji="🛎" text=title extra=description %}
 
       {% tournamenturl 'options-tournament-section' section='standings' as url %}
-      {% translate "Standings" as title %}
-      {% translate "How teams and speakers are ranked in the released tabs" as description %}
+      {% trans "Standings" as title %}
+      {% trans "How teams and speakers are ranked in the released tabs" as description %}
       {% include "components/item-action.html" with type="primary" emoji="📊" text=title extra=description %}
 
       {% tournamenturl 'options-tournament-section' section='feedback' as url %}
-      {% translate "Feedback" as title %}
-      {% translate "How adjudicators are ranked and who can submit feedback" as description %}
+      {% trans "Feedback" as title %}
+      {% trans "How adjudicators are ranked and who can submit feedback" as description %}
       {% include "components/item-action.html" with type="primary" emoji="🙅" text=title extra=description %}
 
       {% tournamenturl 'options-tournament-section' section='motions' as url %}
-      {% translate "Motions" as title %}
-      {% translate "How and where are motions used" as description %}
+      {% trans "Motions" as title %}
+      {% trans "How and where are motions used" as description %}
       {% include "components/item-action.html" with type="primary" emoji="📰" text=title extra=description %}
 
     </ul>
@@ -86,33 +86,33 @@
     <ul class="list-group">
 
       {% tournamenturl 'options-tournament-section' section='tab_release' as url %}
-      {% translate "Tab Release" as title %}
-      {% translate "When to release a public tab is made visible and what data it shows" as description %}
+      {% trans "Tab Release" as title %}
+      {% trans "When to release a public tab is made visible and what data it shows" as description %}
       {% include "components/item-action.html" with type="primary" emoji="🚨" text=title extra=description %}
 
       {% tournamenturl 'options-tournament-section' section='data_entry' as url %}
-      {% translate "Data Entry" as title %}
-      {% translate "How ballots, feedback, and check-ins are entered, including online submission options" as description %}
+      {% trans "Data Entry" as title %}
+      {% trans "How ballots, feedback, and check-ins are entered, including online submission options" as description %}
       {% include "components/item-action.html" with type="primary" emoji="📝" text=title extra=description %}
 
       {% tournamenturl 'options-tournament-section' section='public_features' as url %}
-      {% translate "Public Features" as title %}
-      {% translate "What information the site displays on the publicly accessible pages" as description %}
+      {% trans "Public Features" as title %}
+      {% trans "What information the site displays on the publicly accessible pages" as description %}
       {% include "components/item-action.html" with type="primary" emoji="📢" text=title extra=description %}
 
       {% tournamenturl 'options-tournament-section' section='ui_options' as url %}
-      {% translate "UI Options" as title %}
-      {% translate "Small tweaks in what information is presented by the interface" as description %}
+      {% trans "UI Options" as title %}
+      {% trans "Small tweaks in what information is presented by the interface" as description %}
       {% include "components/item-action.html" with type="primary" emoji="💻" text=title extra=description %}
 
       {% tournamenturl 'options-tournament-section' section='email' as url %}
-      {% translate "Notifications" as title %}
-      {% translate "Configures sending notifications, such as emails confirming ballot submissions or team points" as description %}
+      {% trans "Notifications" as title %}
+      {% trans "Configures sending notifications, such as emails confirming ballot submissions or team points" as description %}
       {% include "components/item-action.html" with type="primary" emoji="📧" text=title extra=description %}
 
       {% tournamenturl 'options-tournament-section' section='global' as url %}
-      {% translate "Global Settings" as title %}
-      {% translate "Settings which can affect all tournaments on the site" as description %}
+      {% trans "Global Settings" as title %}
+      {% trans "Settings which can affect all tournaments on the site" as description %}
       {% include "components/item-action.html" with type="primary" emoji="🌏" text=title extra=description %}
 
     </ul>
@@ -124,34 +124,34 @@
 
     <ul class="list-group">
       {% tournamenturl 'tournament-set-current-round' as url %}
-      {% translate "Manually Set Current Round" as title %}
-      {% translate "Tabbycat will prompt you to advance the current round on each round's results page. However, if there are special circumstances that require you to override this and set the current round to something else, use this page." as description %}
+      {% trans "Manually Set Current Round" as title %}
+      {% trans "Tabbycat will prompt you to advance the current round on each round's results page. However, if there are special circumstances that require you to override this and set the current round to something else, use this page." as description %}
       {% include "components/item-action.html" with type="primary" icon="clock" text=title extra=description %}
 
       {% tournamenturl 'set-round-weights' as url %}
-      {% translate "Set Round Weights for Tapered Scoring" as text %}
-      {% translate "Rounds can be weighted so that certain rounds are worth more team points." as extra %}
+      {% trans "Set Round Weights for Tapered Scoring" as text %}
+      {% trans "Rounds can be weighted so that certain rounds are worth more team points." as extra %}
       {% include "components/item-action.html" with type="primary" icon="anchor" %}
     </ul>
 
     <div class="card mt-3">
 
       <div class="card-body text-info border-info">
-        <h4 class="card-title"><i data-feather="clipboard"></i> {% translate "Presets" %}</h4>
-        {% blocktranslate trimmed %}
+        <h4 class="card-title"><i data-feather="clipboard"></i> {% trans "Presets" %}</h4>
+        {% blocktrans trimmed %}
           These modify common settings for basic rules; double check our
           <a href="https://tabbycat.readthedocs.io/" target="_blank">documentation</a>
           to ensure they are correct for your tournament. Each links will display what
           settings it changes before applying them.
-        {% endblocktranslate %}
+        {% endblocktrans %}
       </div>
 
       <ul class="list-group list-group-flush">
         {% for preset in presets %}
           {% tournamenturl 'options-presets-confirm' preset.slugified_name as url %}
-          {% blocktranslate trimmed asvar title with preset=preset.name %}
+          {% blocktrans trimmed asvar title with preset=preset.name %}
             Apply {{ preset }}
-          {% endblocktranslate %}
+          {% endblocktrans %}
           {% include "components/item-action.html" with type="primary" icon="play" text=title extra=preset.description %}
         {% endfor %}
       </ul>

--- a/tabbycat/options/templates/preferences_presets_complete.html
+++ b/tabbycat/options/templates/preferences_presets_complete.html
@@ -1,19 +1,19 @@
 {% extends "base.html" %}
 {% load debate_tags i18n %}
 
-{% block page-title %}{% blocktranslate %}Presets Applied: {{ preset_title }}{% endblocktranslate %}{% endblock %}
-{% block head-title %}<span class="emoji">✅</span> {% blocktranslate %}Presets Applied: {{ preset_title }}{% endblocktranslate %}{% endblock %}
+{% block page-title %}{% blocktrans %}Presets Applied: {{ preset_title }}{% endblocktrans %}{% endblock %}
+{% block head-title %}<span class="emoji">✅</span> {% blocktrans %}Presets Applied: {{ preset_title }}{% endblocktrans %}{% endblock %}
 
 {% block page-subnav-sections %}
   <a class="btn btn-primary "
      href="{% tournamenturl 'options-tournament-index' %}">
-    <i data-feather="chevron-left"></i> {% translate "Back to Configuration" %}
+    <i data-feather="chevron-left"></i> {% trans "Back to Configuration" %}
   </a>
 {% endblock %}
 
 {% block content %}
 
-  {% translate "Preferences that were changed" as title %}
+  {% trans "Preferences that were changed" as title %}
   {% include "preferences_state.html" with preferences=changed_preferences %}
 
 {% endblock content %}

--- a/tabbycat/options/templates/preferences_presets_confirm.html
+++ b/tabbycat/options/templates/preferences_presets_confirm.html
@@ -1,13 +1,13 @@
 {% extends "base.html" %}
 {% load debate_tags i18n %}
 
-{% block head-title %}<span class="emoji">❔</span>{% blocktranslate %}Confirm Presets: {{ preset_title }}{% endblocktranslate %}{% endblock %}
-{% block page-title %}{% blocktranslate %}Confirm Presets: {{ preset_title }}{% endblocktranslate %}{% endblock %}
+{% block head-title %}<span class="emoji">❔</span>{% blocktrans %}Confirm Presets: {{ preset_title }}{% endblocktrans %}{% endblock %}
+{% block page-title %}{% blocktrans %}Confirm Presets: {{ preset_title }}{% endblocktrans %}{% endblock %}
 
 {% block page-subnav-sections %}
   <a class="btn btn-outline-primary "
      href="{% tournamenturl 'options-tournament-index' %}">
-    <i data-feather="chevron-left"></i> {% translate "Back to Configuration" %}
+    <i data-feather="chevron-left"></i> {% trans "Back to Configuration" %}
   </a>
 {% endblock %}
 
@@ -15,19 +15,19 @@
 
   {% if unchanged_preferences|length > 0 %}
 
-    {% translate "Preferences that will not change" as title %}
+    {% trans "Preferences that will not change" as title %}
     {% include "preferences_state.html" with preferences=unchanged_preferences no_change=True %}
 
   {% endif %}
 
-  {% translate "Preferences that will change" as title %}
+  {% trans "Preferences that will change" as title %}
   {% include "preferences_state.html" with preferences=changed_preferences %}
 
   <div class="card mt-3">
     <ul class="list-group list-group-flush">
       <li class="list-group-item">
         <button id="applyPresets" class="btn btn-success btn-block">
-          {% blocktranslate %}Apply Presets: {{ preset_title }}{% endblocktranslate %}
+          {% blocktrans %}Apply Presets: {{ preset_title }}{% endblocktrans %}
         </button>
         <form id="applyPresetsForm" method="POST">
           {% csrf_token %}

--- a/tabbycat/options/templates/preferences_section_set.html
+++ b/tabbycat/options/templates/preferences_section_set.html
@@ -3,20 +3,20 @@
 
 {% load add_field_css %}
 
-{% block page-title %}{% blocktranslate trimmed with section=section.verbose_name %}
+{% block page-title %}{% blocktrans trimmed with section=section.verbose_name %}
   Configuration: {{ section }}
-{% endblocktranslate %}{% endblock %}
+{% endblocktrans %}{% endblock %}
 {% block head-title %}<span class="emoji">🔧</span>
-  {% blocktranslate trimmed with section=section.verbose_name %}
+  {% blocktrans trimmed with section=section.verbose_name %}
     Edit Configuration: {{ section }}
-  {% endblocktranslate %}
+  {% endblocktrans %}
 {% endblock %}
 
 {% block page-subnav-sections %}
 
   <a class="btn btn-outline-primary"
      href="{% tournamenturl 'options-tournament-index' %}">
-    <i data-feather="chevron-left"></i> {% translate "Back to Configuration" %}
+    <i data-feather="chevron-left"></i> {% trans "Back to Configuration" %}
   </a>
 
 {% endblock %}

--- a/tabbycat/participants/templates/adjudicator_record.html
+++ b/tabbycat/participants/templates/adjudicator_record.html
@@ -14,9 +14,9 @@
     {% if pref.public_participants or admin_page %}
 
       {# Just call it 'name' since this string is also used with teams #}
-      {% blocktranslate trimmed with name=adjudicator.name asvar card_title %}
+      {% blocktrans trimmed with name=adjudicator.name asvar card_title %}
         About {{ name }}
-      {% endblocktranslate %}
+      {% endblocktrans %}
 
       {% include "adjudicator_registration_card.html" %}
 

--- a/tabbycat/participants/templates/adjudicator_registration_card.html
+++ b/tabbycat/participants/templates/adjudicator_registration_card.html
@@ -12,10 +12,10 @@
       <div class="list-group-item">
         <ul>
           {% if adjudicator.independent %}
-            <li><em>{% translate "Independent adjudicator" %}</em></li>
+            <li><em>{% trans "Independent adjudicator" %}</em></li>
           {% endif %}
           {% if adjudicator.adj_core %}
-            <li><em>{% translate "Member of the adjudication core" %}</em></li>
+            <li><em>{% trans "Member of the adjudication core" %}</em></li>
           {% endif %}
         </ul>
       </div>
@@ -24,64 +24,64 @@
     {% if pref.show_adjudicator_institutions or admin_page or private_url %}
       <div class="list-group-item {% if not pref.show_adjudicator_institutions %}list-group-item-secondary{% endif %}">
         <div>
-          <strong>{% translate "Institution:" %}</strong>
+          <strong>{% trans "Institution:" %}</strong>
           {% if adjudicator.institution %}
             {{ adjudicator.institution.name }}
           {% else %}
-            <span class="text-muted">{% translate "Unaffiliated" %}</span>
+            <span class="text-muted">{% trans "Unaffiliated" %}</span>
           {% endif %}
         </div>
         {% if adjudicator.institution.region %}
           <div>
-            <strong>{% translate "Region:" %}</strong>
+            <strong>{% trans "Region:" %}</strong>
             {{ adjudicator.institution.region.name }}
           </div>
         {% endif %}
       </div>
     {% else %}
       <div class="list-group-item">
-        <em>{% translate "The institutional affiliations of adjudicators are not public at this tournament." %}</em>
+        <em>{% trans "The institutional affiliations of adjudicators are not public at this tournament." %}</em>
       </div>
     {% endif %}
 
     {% if admin_page %}
       <div class="list-group-item list-group-item-secondary">
         <div>
-          <strong>{% translate "Institutional Conflicts:" %}</strong>
+          <strong>{% trans "Institutional Conflicts:" %}</strong>
           {% for ic in adjudicator.adjudicatorinstitutionconflict_set.all %}
-            {{ ic.institution.name }}{% if not forloop.last %}{% translate "; " %}{% endif %}
+            {{ ic.institution.name }}{% if not forloop.last %}{% trans "; " %}{% endif %}
           {% empty %}
-            {% translate "None" %}
+            {% trans "None" %}
           {% endfor %}
         </div>
         <div>
-          <strong>{% translate "Team Conflicts:" %}</strong>
+          <strong>{% trans "Team Conflicts:" %}</strong>
           {% for tc in adjudicator.adjudicatorteamconflict_set.all %}
-            {% team_record_link tc.team admin_page tournament False %}{% if not forloop.last %}{% translate ", " %}{% endif %}
+            {% team_record_link tc.team admin_page tournament False %}{% if not forloop.last %}{% trans ", " %}{% endif %}
           {% empty %}
-            {% translate "None" %}
+            {% trans "None" %}
           {% endfor %}
         </div>
         <div>
-          <strong>{% translate "Adjudicator Conflicts:" %}</strong>
+          <strong>{% trans "Adjudicator Conflicts:" %}</strong>
           {% for adj in adjadj_conflicts %}
             {% if pref.public_record %}
-              <a href="{% adj_record_link adj admin_page tournament %}">{{ adj.name }}</a>{% if not forloop.last %}{% translate ", " %}{% endif %}
+              <a href="{% adj_record_link adj admin_page tournament %}">{{ adj.name }}</a>{% if not forloop.last %}{% trans ", " %}{% endif %}
             {% else %}
-              {{ adj.name }}{% if not forloop.last %}{% translate ", " %}{% endif %}
+              {{ adj.name }}{% if not forloop.last %}{% trans ", " %}{% endif %}
             {% endif %}
           {% empty %}
-            {% translate "None" %}
+            {% trans "None" %}
           {% endfor %}
         </div>
       </div>
 
       <div class="list-group-item list-group-item-secondary">
-        <strong>{% translate "Room Constraints:" %}</strong>
+        <strong>{% trans "Room Constraints:" %}</strong>
         {% for vc in adjudicator.venue_constraints.all %}
-          {{ vc.category }}{% if not forloop.last %}{% translate ", " %}{% endif %}
+          {{ vc.category }}{% if not forloop.last %}{% trans ", " %}{% endif %}
         {% empty %}
-          {% translate "None" %}
+          {% trans "None" %}
         {% endfor %}
       </div>
 

--- a/tabbycat/participants/templates/admin/participants/adjudicator/change_form.html
+++ b/tabbycat/participants/templates/admin/participants/adjudicator/change_form.html
@@ -5,9 +5,9 @@
   {% if not change %}
     <div style="background-color: #f0dada; padding: 15px 15px 5px; margin-bottom: 20px; border-radius: 4px;">
       <p>
-        {% blocktranslate trimmed %}
+        {% blocktrans trimmed %}
           <strong>Don't forget:</strong> If this adjudicator should be conflicted against their own institution, you should add this conflict <strong>now</strong> in the <strong>Adjudicator-institution conflicts</strong> tab above, because the own-institution conflict is <strong>not</strong> automatically created when using this form.
-        {% endblocktranslate %}
+        {% endblocktrans %}
       </p>
     </div>
   {% endif %}

--- a/tabbycat/participants/templates/admin/participants/delete_debateteam_warning.html
+++ b/tabbycat/participants/templates/admin/participants/delete_debateteam_warning.html
@@ -4,21 +4,21 @@
   <div style="background-color: #f0dada; padding: 15px 15px 5px; margin-bottom: 20px; border-radius: 4px;">
     <p>
       {% if object_name %}
-        {% blocktranslate trimmed %}
+        {% blocktrans trimmed %}
           <strong>Warning:</strong> If there are “debate team” objects in the
           above list, <strong>you probably shouldn't delete this
           {{ object_name }}</strong>.
-        {% endblocktranslate %}
+        {% endblocktrans %}
       {% else %}
         {# objects_name can be either singular or plural (because that's how Django works) #}
-        {% blocktranslate trimmed %}
+        {% blocktrans trimmed %}
           <strong>Warning:</strong> If there are “debate team” objects in the
           above list, <strong>you probably shouldn't delete the selected
           {{ objects_name }}</strong>.
-        {% endblocktranslate %}
+        {% endblocktrans %}
       {% endif %}
       {# Translators: This follows the above sentence in the same paragraph. #}
-      {% blocktranslate trimmed %}
+      {% blocktrans trimmed %}
         This is especially the case if any team that would be deleted has
         already participated in a debate. If a team already has a result entered
         for it, deleting the team also deletes those results, <strong>which
@@ -26,29 +26,29 @@
         results anymore. If a team has debated and is withdrawing from the
         tournament, you should <strong>not</strong> delete it. Just mark the
         team inactive under the “Availability” section of the Tabbycat admin area.
-      {% endblocktranslate %}
+      {% endblocktrans %}
     </p>
     {% if opts.model_name == 'institution' %}
       <p>
-      {% blocktranslate trimmed %}
+      {% blocktrans trimmed %}
         Note that deleting an institution also deletes all teams from that
         institution.
-      {% endblocktranslate %}
+      {% endblocktrans %}
       </p>
     {% endif %}
     <p>
       {% if object_name %}
-        {% blocktranslate trimmed %}
+        {% blocktrans trimmed %}
           If you're very sure about deleting this {{ object_name }}, please
           delete the above objects first, and be sure to heed the warning that
           you will see on the “debate team” objects page before proceeding.
-        {% endblocktranslate %}
+        {% endblocktrans %}
       {% else %}
-        {% blocktranslate trimmed %}
+        {% blocktrans trimmed %}
           If you're very sure about deleting these {{ objects_name }}, please
           delete the above objects first, and be sure to heed the warning that
           you will see on the “debate team” objects page before proceeding.
-        {% endblocktranslate %}
+        {% endblocktrans %}
       {% endif %}
     </p>
   </div>

--- a/tabbycat/participants/templates/admin/participants/team/change_form.html
+++ b/tabbycat/participants/templates/admin/participants/team/change_form.html
@@ -5,9 +5,9 @@
   {% if not change %}
     <div style="background-color: #f0dada; padding: 15px 15px 5px; margin-bottom: 20px; border-radius: 4px;">
       <p>
-        {% blocktranslate trimmed %}
+        {% blocktrans trimmed %}
           <strong>Don't forget:</strong> If this team should be conflicted against its own institution, you should add this conflict <strong>now</strong> in the <strong>Team-institution conflicts</strong> tab above, because the own-institution conflict is <strong>not</strong> automatically created when using this form.
-        {% endblocktranslate %}
+        {% endblocktrans %}
       </p>
     </div>
   {% endif %}

--- a/tabbycat/participants/templates/current_round/common.html
+++ b/tabbycat/participants/templates/current_round/common.html
@@ -3,16 +3,16 @@
 {# Round start time #}
 {% if current_round.starts_at %}
   <div class="list-group-item">
-    {% blocktranslate trimmed with start_time=current_round.starts_at %}
+    {% blocktrans trimmed with start_time=current_round.starts_at %}
       The round begins at {{ start_time }}
-    {% endblocktranslate %}
+    {% endblocktrans %}
   </div>
 {% endif %} {# current_round.starts_at #}
 
 {# Teams (only in BP -- in two-team, it's displayed above) #}
 {% if pref.teams_in_debate == 'bp' %}
   <div class="list-group-item">
-    <strong>{% translate "Teams:" %}</strong>
+    <strong>{% trans "Teams:" %}</strong>
     {% for dt in debate.debateteams_ordered %}
       {% team_record_link dt.team admin_page tournament %}{% if debate.sides_confirmed %} ({% debate_team_side_name dt tournament %}){% endif %}{% if not forloop.last %},{% endif %}
     {% endfor %}
@@ -25,23 +25,23 @@
     {% if debate.adjudicators|length > 1 %}
       {% with adjudicators=debate.adjudicators %}
         <strong>
-          {% blocktranslate trimmed count counter=adjudicators|length %}
+          {% blocktrans trimmed count counter=adjudicators|length %}
             Adjudicator:
           {% plural %}
             Adjudicators:
-          {% endblocktranslate %}
+          {% endblocktrans %}
         </strong>
         {% for adj, adjtype in adjudicators.with_positions %}
           {% if adj != debateadjudicator.adjudicator %}
             <a href="{% adj_record_link adj admin_page tournament %}">
-              {{ adj.name }}</a>{% if adjtype == adjudicators.POSITION_CHAIR %}&nbsp;{% translate "Ⓒ" context "chair icon" %}{% elif adjtype == adjudicators.POSITION_TRAINEE %}&nbsp;{% translate "Ⓣ" context "trainee icon" %}{% endif %}{% if not forloop.last %},{% endif %}
+              {{ adj.name }}</a>{% if adjtype == adjudicators.POSITION_CHAIR %}&nbsp;{% trans "Ⓒ" context "chair icon" %}{% elif adjtype == adjudicators.POSITION_TRAINEE %}&nbsp;{% trans "Ⓣ" context "trainee icon" %}{% endif %}{% if not forloop.last %},{% endif %}
           {% else %}
-            {{ adj.name }}{% if adjtype == adjudicators.POSITION_CHAIR %}&nbsp;{% translate "Ⓒ" context "chair icon" %}{% elif adjtype == adjudicators.POSITION_TRAINEE %}&nbsp;{% translate "Ⓣ" context "trainee icon" %}{% endif %}{% if not forloop.last %},{% endif %}
+            {{ adj.name }}{% if adjtype == adjudicators.POSITION_CHAIR %}&nbsp;{% trans "Ⓒ" context "chair icon" %}{% elif adjtype == adjudicators.POSITION_TRAINEE %}&nbsp;{% trans "Ⓣ" context "trainee icon" %}{% endif %}{% if not forloop.last %},{% endif %}
           {% endif %}
         {% endfor %}
       {% endwith %}
     {% else %}
-      <em>{% translate "There are no panellists or trainees assigned to this debate." %}</em>
+      <em>{% trans "There are no panellists or trainees assigned to this debate." %}</em>
     {% endif %} {# debate.adjudicators|length > 1 #}
   </div>
 {% endif %} {# not pref.no_panellist_position or not pref.no_trainee_position #}
@@ -51,22 +51,22 @@
   <div class="list-group-item {% if not pref.public_motions or not current_round.motions_released %}list-group-item-dark{% endif %}">
     {% if current_round.motions_released or admin_page %}
       {% if not current_round.motions_released %}
-        <em>{% translate "Motions are not released to public." %}</em><br />
+        <em>{% trans "Motions are not released to public." %}</em><br />
       {% endif %}
       {% if debate.round.motion_set.all|length == 1 %}
-        <strong>{% translate "Motion:" %}</strong> {{ debate.round.motion_set.first.text }}
+        <strong>{% trans "Motion:" %}</strong> {{ debate.round.motion_set.first.text }}
       {% else %}
         {% for rm in debate.round.roundmotion_set.all %}
           <strong>
-            {% blocktranslate trimmed with seq=rm.seq %}
+            {% blocktrans trimmed with seq=rm.seq %}
               Motion {{ seq }}:
-            {% endblocktranslate %}
+            {% endblocktrans %}
           </strong>
           {{ rm.motion.text }}<br />
         {% endfor %}
       {% endif %}
     {% else %} {# elif not (current_round.motions_released or admin_page) #}
-      <em>{% translate "The motion(s) for this round haven't yet been released." %}</em>
+      <em>{% trans "The motion(s) for this round haven't yet been released." %}</em>
     {% endif %} {# current_round.motions_released or admin_page #}
   </div>
 {% endif %} {# pref.public_motions or admin_page #}

--- a/tabbycat/participants/templates/current_round/round_adj.html
+++ b/tabbycat/participants/templates/current_round/round_adj.html
@@ -11,67 +11,67 @@
     {% if debate.adjudicators|length > 1 and debateadjudicator.type == debateadjudicator.TYPE_CHAIR %}
       {% if grammatical_person == "3" %}
         {% if debate.venue.url %}
-          {% blocktranslate trimmed with adjudicator=adjudicator.name room=debate.venue.display_name|default:venue_tba url=debate.venue.url %}
+          {% blocktrans trimmed with adjudicator=adjudicator.name room=debate.venue.display_name|default:venue_tba url=debate.venue.url %}
             {{ adjudicator }} is the <strong>chair</strong> adjudicating {{ aff }} vs {{ neg }} in <a href="{{ url }}"><strong>{{ room }}</strong></a>.
-          {% endblocktranslate %}
+          {% endblocktrans %}
         {% else %}
-          {% blocktranslate trimmed with adjudicator=adjudicator.name room=debate.venue.display_name|default:venue_tba %}
+          {% blocktrans trimmed with adjudicator=adjudicator.name room=debate.venue.display_name|default:venue_tba %}
             {{ adjudicator }} is the <strong>chair</strong> adjudicating {{ aff }} vs {{ neg }} in <strong>{{ room }}</strong>.
-          {% endblocktranslate %}
+          {% endblocktrans %}
         {% endif %}
       {% else %}
         {% if debate.venue.url %}
-          {% blocktranslate trimmed with room=debate.venue.display_name|default:venue_tba url=debate.venue.url %}
+          {% blocktrans trimmed with room=debate.venue.display_name|default:venue_tba url=debate.venue.url %}
             You are the <strong>chair</strong> adjudicating {{ aff }} vs {{ neg }} in <a href="{{ url }}"><strong>{{ room }}</strong></a>.
-          {% endblocktranslate %}
+          {% endblocktrans %}
         {% else %}
-          {% blocktranslate trimmed with room=debate.venue.display_name|default:venue_tba %}
+          {% blocktrans trimmed with room=debate.venue.display_name|default:venue_tba %}
             You are the <strong>chair</strong> adjudicating {{ aff }} vs {{ neg }} in <strong>{{ room }}</strong>.
-          {% endblocktranslate %}
+          {% endblocktrans %}
         {% endif %}
       {% endif %}
     {% elif debate.adjudicators|length > 1 %}
       {% if grammatical_person == "3" %}
         {% if debate.venue.url %}
-          {% blocktranslate trimmed with adjudicator=adjudicator.name type=debateadjudicator.get_type_display room=debate.venue.display_name|default:venue_tba url=debate.venue.url %}
+          {% blocktrans trimmed with adjudicator=adjudicator.name type=debateadjudicator.get_type_display room=debate.venue.display_name|default:venue_tba url=debate.venue.url %}
             {{ adjudicator }} is a <strong>{{ type }}</strong> adjudicating {{ aff }} vs {{ neg }} in <a href="{{ url }}"><strong>{{ room }}</strong></a>.
-          {% endblocktranslate %}
+          {% endblocktrans %}
         {% else %}
-          {% blocktranslate trimmed with adjudicator=adjudicator.name type=debateadjudicator.get_type_display room=debate.venue.display_name|default:venue_tba %}
+          {% blocktrans trimmed with adjudicator=adjudicator.name type=debateadjudicator.get_type_display room=debate.venue.display_name|default:venue_tba %}
             {{ adjudicator }} is a <strong>{{ type }}</strong> adjudicating {{ aff }} vs {{ neg }} in <strong>{{ room }}</strong>.
-          {% endblocktranslate %}
+          {% endblocktrans %}
         {% endif %}
       {% else %}
         {% if debate.venue.url %}
-          {% blocktranslate trimmed with type=debateadjudicator.get_type_display room=debate.venue.display_name|default:venue_tba url=debate.venue.url %}
+          {% blocktrans trimmed with type=debateadjudicator.get_type_display room=debate.venue.display_name|default:venue_tba url=debate.venue.url %}
             You are a <strong>{{ type }}</strong> adjudicating {{ aff }} vs {{ neg }} in <a href="{{ url }}"><strong>{{ room }}</strong></a>.
-          {% endblocktranslate %}
+          {% endblocktrans %}
         {% else %}
-          {% blocktranslate trimmed with type=debateadjudicator.get_type_display room=debate.venue.display_name|default:venue_tba %}
+          {% blocktrans trimmed with type=debateadjudicator.get_type_display room=debate.venue.display_name|default:venue_tba %}
             You are a <strong>{{ type }}</strong> adjudicating {{ aff }} vs {{ neg }} in <strong>{{ room }}</strong>.
-          {% endblocktranslate %}
+          {% endblocktrans %}
         {% endif %}
       {% endif %}
     {% else %}
       {% if grammatical_person == "3" %}
         {% if debate.venue.url %}
-          {% blocktranslate trimmed with adjudicator=adjudicator.name room=debate.venue.display_name|default:venue_tba url=debate.venue.url %}
+          {% blocktrans trimmed with adjudicator=adjudicator.name room=debate.venue.display_name|default:venue_tba url=debate.venue.url %}
             {{ adjudicator }} is adjudicating {{ aff }} vs {{ neg }} in <a href="{{ url }}"><strong>{{ room }}</strong></a>.
-          {% endblocktranslate %}
+          {% endblocktrans %}
         {% else %}
-          {% blocktranslate trimmed with adjudicator=adjudicator.name room=debate.venue.display_name|default:venue_tba %}
+          {% blocktrans trimmed with adjudicator=adjudicator.name room=debate.venue.display_name|default:venue_tba %}
             {{ adjudicator }} is adjudicating {{ aff }} vs {{ neg }} in <strong>{{ room }}</strong>.
-          {% endblocktranslate %}
+          {% endblocktrans %}
         {% endif %}
       {% else %}
         {% if debate.venue.url %}
-          {% blocktranslate trimmed with room=debate.venue.display_name|default:venue_tba url=debate.venue.url %}
+          {% blocktrans trimmed with room=debate.venue.display_name|default:venue_tba url=debate.venue.url %}
             You are adjudicating {{ aff }} vs {{ neg }} in <a href="{{ url }}"><strong>{{ room }}</strong></a>.
-          {% endblocktranslate %}
+          {% endblocktrans %}
         {% else %}
-          {% blocktranslate trimmed with room=debate.venue.display_name|default:venue_tba %}
+          {% blocktrans trimmed with room=debate.venue.display_name|default:venue_tba %}
             You are adjudicating {{ aff }} vs {{ neg }} in <strong>{{ room }}</strong>.
-          {% endblocktranslate %}
+          {% endblocktrans %}
         {% endif %}
       {% endif %}
     {% endif %}
@@ -82,67 +82,67 @@
     {% if debate.adjudicators|length > 1 and debateadjudicator.type == debateadjudicator.TYPE_CHAIR %}
       {% if grammatical_person == "3" %}
         {% if debate.venue.url %}
-          {% blocktranslate trimmed with adjudicator=adjudicator.name room=debate.venue.display_name|default:venue_tba url=debate.venue.url %}
+          {% blocktrans trimmed with adjudicator=adjudicator.name room=debate.venue.display_name|default:venue_tba url=debate.venue.url %}
             {{ adjudicator }} is the <strong>chair</strong> adjudicating in <a href="{{ url }}"><strong>{{ room }}</strong></a>.
-          {% endblocktranslate %}
+          {% endblocktrans %}
         {% else %}
-          {% blocktranslate trimmed with adjudicator=adjudicator.name room=debate.venue.display_name|default:venue_tba %}
+          {% blocktrans trimmed with adjudicator=adjudicator.name room=debate.venue.display_name|default:venue_tba %}
             {{ adjudicator }} is the <strong>chair</strong> adjudicating in <strong>{{ room }}</strong>.
-          {% endblocktranslate %}
+          {% endblocktrans %}
         {% endif %}
       {% else %}
         {% if debate.venue.url %}
-          {% blocktranslate trimmed with room=debate.venue.display_name|default:venue_tba url=debate.venue.url %}
+          {% blocktrans trimmed with room=debate.venue.display_name|default:venue_tba url=debate.venue.url %}
             You are the <strong>chair</strong> adjudicating in <a href="{{ url }}"><strong>{{ room }}</strong></a>.
-          {% endblocktranslate %}
+          {% endblocktrans %}
         {% else %}
-          {% blocktranslate trimmed with room=debate.venue.display_name|default:venue_tba %}
+          {% blocktrans trimmed with room=debate.venue.display_name|default:venue_tba %}
             You are the <strong>chair</strong> adjudicating in <strong>{{ room }}</strong>.
-          {% endblocktranslate %}
+          {% endblocktrans %}
         {% endif %}
       {% endif %}
     {% elif debate.adjudicators|length > 1 %}
       {% if grammatical_person == "3" %}
         {% if debate.venue.url %}
-          {% blocktranslate trimmed with adjudicator=adjudicator.name type=debateadjudicator.get_type_display room=debate.venue.display_name|default:venue_tba url=debate.venue.url %}
+          {% blocktrans trimmed with adjudicator=adjudicator.name type=debateadjudicator.get_type_display room=debate.venue.display_name|default:venue_tba url=debate.venue.url %}
             {{ adjudicator }} is a <strong>{{ type }}</strong> adjudicating in <a href="{{ url }}"><strong>{{ room }}</strong></a>.
-          {% endblocktranslate %}
+          {% endblocktrans %}
         {% else %}
-          {% blocktranslate trimmed with adjudicator=adjudicator.name type=debateadjudicator.get_type_display room=debate.venue.display_name|default:venue_tba %}
+          {% blocktrans trimmed with adjudicator=adjudicator.name type=debateadjudicator.get_type_display room=debate.venue.display_name|default:venue_tba %}
             {{ adjudicator }} is a <strong>{{ type }}</strong> adjudicating in <strong>{{ room }}</strong>.
-          {% endblocktranslate %}
+          {% endblocktrans %}
         {% endif %}
       {% else %}
         {% if debate.venue.url %}
-          {% blocktranslate trimmed with type=debateadjudicator.get_type_display room=debate.venue.display_name|default:venue_tba url=debate.venue.url %}
+          {% blocktrans trimmed with type=debateadjudicator.get_type_display room=debate.venue.display_name|default:venue_tba url=debate.venue.url %}
             You are a <strong>{{ type }}</strong> adjudicating in <a href="{{ url }}"><strong>{{ room }}</strong></a>.
-          {% endblocktranslate %}
+          {% endblocktrans %}
         {% else %}
-          {% blocktranslate trimmed with type=debateadjudicator.get_type_display room=debate.venue.display_name|default:venue_tba %}
+          {% blocktrans trimmed with type=debateadjudicator.get_type_display room=debate.venue.display_name|default:venue_tba %}
             You are a <strong>{{ type }}</strong> adjudicating in <strong>{{ room }}</strong>.
-          {% endblocktranslate %}
+          {% endblocktrans %}
         {% endif %}
       {% endif %}
     {% else %}
       {% if grammatical_person == "3" %}
         {% if debate.venue.url %}
-          {% blocktranslate trimmed with adjudicator=adjudicator.name room=debate.venue.display_name|default:venue_tba url=debate.venue.url %}
+          {% blocktrans trimmed with adjudicator=adjudicator.name room=debate.venue.display_name|default:venue_tba url=debate.venue.url %}
             {{ adjudicator }} is adjudicating in <a href="{{ url }}"><strong>{{ room }}</strong></a>.
-          {% endblocktranslate %}
+          {% endblocktrans %}
         {% else %}
-          {% blocktranslate trimmed with adjudicator=adjudicator.name room=debate.venue.display_name|default:venue_tba %}
+          {% blocktrans trimmed with adjudicator=adjudicator.name room=debate.venue.display_name|default:venue_tba %}
             {{ adjudicator }} is adjudicating in <strong>{{ room }}</strong>.
-          {% endblocktranslate %}
+          {% endblocktrans %}
         {% endif %}
       {% else %}
         {% if debate.venue.url %}
-          {% blocktranslate trimmed with room=debate.venue.display_name|default:venue_tba url=debate.venue.url %}
+          {% blocktrans trimmed with room=debate.venue.display_name|default:venue_tba url=debate.venue.url %}
             You are adjudicating in <a href="{{ url }}"><strong>{{ room }}</strong></a>.
-          {% endblocktranslate %}
+          {% endblocktrans %}
         {% else %}
-          {% blocktranslate trimmed with room=debate.venue.display_name|default:venue_tba %}
+          {% blocktrans trimmed with room=debate.venue.display_name|default:venue_tba %}
             You are adjudicating in <strong>{{ room }}</strong>.
-          {% endblocktranslate %}
+          {% endblocktrans %}
         {% endif %}
       {% endif %}
     {% endif %}

--- a/tabbycat/participants/templates/current_round/round_team.html
+++ b/tabbycat/participants/templates/current_round/round_team.html
@@ -9,23 +9,23 @@
 
   {% if debate.sides_confirmed %}
     {% if grammatical_person == "3" %}
-      {% blocktranslate trimmed with team=team_short_name side=debateteam.get_side_name room=debate.venue.display_name|default:venue_tba %}
+      {% blocktrans trimmed with team=team_short_name side=debateteam.get_side_name room=debate.venue.display_name|default:venue_tba %}
         {{ team }} is debating as the <strong>{{ side }}</strong> team against <strong>{{ opponent }}</strong>.
-      {% endblocktranslate %}
+      {% endblocktrans %}
     {% else %}
-      {% blocktranslate trimmed with side=debateteam.get_side_name room=debate.venue.display_name|default:venue_tba %}
+      {% blocktrans trimmed with side=debateteam.get_side_name room=debate.venue.display_name|default:venue_tba %}
         You are debating as the <strong>{{ side }}</strong> team against <strong>{{ opponent }}</strong>.
-      {% endblocktranslate %}
+      {% endblocktrans %}
     {% endif %}
   {% else %}
     {% if grammatical_person == "3" %}
-      {% blocktranslate trimmed with team=team_short_name room=debate.venue.display_name|default:venue_tba %}
+      {% blocktrans trimmed with team=team_short_name room=debate.venue.display_name|default:venue_tba %}
         {{ team }} is debating against <strong>{{ opponent }}</strong>.
-      {% endblocktranslate %}
+      {% endblocktrans %}
     {% else %}
-      {% blocktranslate trimmed with room=debate.venue.display_name|default:venue_tba %}
+      {% blocktrans trimmed with room=debate.venue.display_name|default:venue_tba %}
         You are debating against <strong>{{ opponent }}</strong>.
-      {% endblocktranslate %}
+      {% endblocktrans %}
     {% endif %}
   {% endif %}
   </div>
@@ -36,13 +36,13 @@
   {% if debate.sides_confirmed %}
     <div class="list-group-item {% if draw_released %}lead active{% else %}list-group-item-dark{% endif %}">
     {% if grammatical_person == "3" %}
-      {% blocktranslate trimmed with team=team_short_name side=debateteam.get_side_name room=debate.venue.display_name|default:venue_tba %}
+      {% blocktrans trimmed with team=team_short_name side=debateteam.get_side_name room=debate.venue.display_name|default:venue_tba %}
         {{ team }} is debating as the <strong>{{ side }}</strong> team.
-      {% endblocktranslate %}
+      {% endblocktrans %}
     {% else %}
-      {% blocktranslate trimmed with side=debateteam.get_side_name room=debate.venue.display_name|default:venue_tba %}
+      {% blocktrans trimmed with side=debateteam.get_side_name room=debate.venue.display_name|default:venue_tba %}
         You are debating as the <strong>{{ side }}</strong> team.
-      {% endblocktranslate %}
+      {% endblocktrans %}
     {% endif %}
     </div>
   {% endif %}
@@ -53,23 +53,23 @@
 <div class="list-group-item lead {% if draw_released %}active{% else %}list-group-item-dark{% endif %}">
   {% if grammatical_person == "3" %}
     {% if debate.venue.url %}
-      {% blocktranslate trimmed with team=team_short_name room=debate.venue.display_name|default:venue_tba url=debate.venue.url %}
+      {% blocktrans trimmed with team=team_short_name room=debate.venue.display_name|default:venue_tba url=debate.venue.url %}
         {{ team }}'s debate is in <a href="{{ url }}"><strong>{{ room }}</strong></a>.
-      {% endblocktranslate %}
+      {% endblocktrans %}
     {% else %}
-      {% blocktranslate trimmed with team=team_short_name room=debate.venue.display_name|default:venue_tba %}
+      {% blocktrans trimmed with team=team_short_name room=debate.venue.display_name|default:venue_tba %}
         {{ team }}'s debate is in <strong>{{ room }}</strong>.
-      {% endblocktranslate %}
+      {% endblocktrans %}
     {% endif %}
   {% else %}
     {% if debate.venue.url %}
-      {% blocktranslate trimmed with room=debate.venue.display_name|default:venue_tba url=debate.venue.url %}
+      {% blocktrans trimmed with room=debate.venue.display_name|default:venue_tba url=debate.venue.url %}
         Your debate is in <a href="{{ url }}"><strong>{{ room }}</strong></a>.
-      {% endblocktranslate %}
+      {% endblocktrans %}
     {% else %}
-      {% blocktranslate trimmed with room=debate.venue.display_name|default:venue_tba %}
+      {% blocktrans trimmed with room=debate.venue.display_name|default:venue_tba %}
         Your debate is in <strong>{{ room }}</strong>.
-      {% endblocktranslate %}
+      {% endblocktrans %}
     {% endif %}
   {% endif %}
 </div>

--- a/tabbycat/participants/templates/edit_speaker_eligibility.html
+++ b/tabbycat/participants/templates/edit_speaker_eligibility.html
@@ -4,9 +4,9 @@
 {% block page-alerts %}
   {% if speaker_categories_length == 0 %}
     {% tournamenturl 'participants-speaker-categories-edit' as categories_url %}
-    {% blocktranslate trimmed asvar message %}
+    {% blocktrans trimmed asvar message %}
       It looks like there aren't any speaker categories are defined. If you'd like to produce category-specific speaker tabs, such as a novice or ESL tab, use the <a href="{{ categories_url }}" class="alert-link">Speaker Categories</a> page to define them, then return to this page to set speaker eligibility.
-    {% endblocktranslate %}
+    {% endblocktrans %}
     {% include 'components/alert.html' with type='warning' %}
   {% endif %}
 {% endblock %}

--- a/tabbycat/participants/templates/feedback_progress_panel.html
+++ b/tabbycat/participants/templates/feedback_progress_panel.html
@@ -7,35 +7,35 @@
   <div class="list-group list-group-flush">
 
     <div class="list-group-item {% if not pref.feedback_progress %}list-group-item-secondary{% endif %}">
-      <h4 class="card-title mb-0">{% translate "Feedback Returns" %}</h4>
+      <h4 class="card-title mb-0">{% trans "Feedback Returns" %}</h4>
     </div>
 
     {% for tracker in feedback_progress.trackers %}
       {% if tracker.fulfilled %}
         <div class="list-group-item {% if not pref.feedback_progress %}list-group-item-secondary{% endif %} text-success">
           <span class="badge badge-secondary">{{ tracker.round.name }}</span>
-          {% blocktranslate trimmed with adjudicator=tracker.submission.adjudicator.name %}
+          {% blocktrans trimmed with adjudicator=tracker.submission.adjudicator.name %}
             Has submitted feedback for <strong>{{ adjudicator }}</strong>
-          {% endblocktranslate %}
+          {% endblocktrans %}
         </div>
       {% elif tracker.expected and tracker.count == 0 %}
         <div class="list-group-item {% if not pref.feedback_progress %}list-group-item-secondary{% endif %} text-danger">
           <span class="badge badge-secondary">{{ tracker.round.name }}</span>
           {% if tracker.acceptable_targets|length > 1 %}
-            {% blocktranslate trimmed with adjudicators=tracker.acceptable_target_names|join:", " %}
+            {% blocktrans trimmed with adjudicators=tracker.acceptable_target_names|join:", " %}
               Has not submitted feedback for one of: <strong>{{ adjudicators }}</strong>
               (whoever gave the oral adjudication)
-            {% endblocktranslate %}
+            {% endblocktrans %}
           {% else %}
-            {% blocktranslate trimmed with adjudicator=tracker.acceptable_target_names.0 %}
+            {% blocktrans trimmed with adjudicator=tracker.acceptable_target_names.0 %}
               Has not submitted feedback for <strong>{{ adjudicator }}</strong>
-            {% endblocktranslate %}
+            {% endblocktrans %}
           {% endif %}
         </div>
       {% elif tracker.expected %}
         <div class="list-group-item {% if not pref.feedback_progress %}list-group-item-secondary{% endif %} text-warning">
           <span class="badge badge-secondary">{{ tracker.round.name }}</span>
-          {% translate "More feedback submissions than expected for this debate:" %}
+          {% trans "More feedback submissions than expected for this debate:" %}
           {% for submission in tracker.acceptable_submissions %}
             <strong>{{ submission.adjudicator.name }}</strong>{% if not forloop.last %},{% endif %}
           {% endfor %}
@@ -43,16 +43,16 @@
       {% else %} {# if not tracker.fulfilled and not tracker.expected #}
         <div class="list-group-item {% if not pref.feedback_progress %}list-group-item-secondary{% endif %} text-warning">
           <span class="badge badge-secondary">{{ tracker.round.name }}</span>
-          {% blocktranslate trimmed with adjudicator=tracker.submission.adjudicator.name %}
+          {% blocktrans trimmed with adjudicator=tracker.submission.adjudicator.name %}
             Unexpected feedback submission for <strong>{{ adjudicator }}</strong>
-          {% endblocktranslate %}
+          {% endblocktrans %}
         </div>
       {% endif %}
     {% empty %}
       <div class="list-group-item {% if not pref.feedback_progress %}list-group-item-secondary{% endif %}">
-        <em>{% blocktranslate trimmed with name=participant_name %}
+        <em>{% blocktrans trimmed with name=participant_name %}
           {{ name }} doesn't have any feedback to submit.
-        {% endblocktranslate %}</em>
+        {% endblocktrans %}</em>
       </div>
     {% endfor %}
   </div>

--- a/tabbycat/participants/templates/in_this_round.html
+++ b/tabbycat/participants/templates/in_this_round.html
@@ -6,21 +6,21 @@
     <div class="list-group-item">
       <h4 class="card-title mb-0">
         {% if tournament.current_rounds|length == 1 %}
-          {% blocktranslate trimmed with round=current_round.name %}
+          {% blocktrans trimmed with round=current_round.name %}
             In This Round ({{ round }})
-          {% endblocktranslate %}
+          {% endblocktrans %}
         {% else %}
-          {% translate "In This Round" %}
+          {% trans "In This Round" %}
         {% endif %}
         {% if admin_page and not draw_released %}
-          <em>{% translate "(Not Released to Public)" %}</em>
+          <em>{% trans "(Not Released to Public)" %}</em>
         {% endif %}
       </h4>
     </div>
 
     {% if draw_released or admin_page %}
 
-      {% translate "Room TBA" as venue_tba %}
+      {% trans "Room TBA" as venue_tba %}
 
       {% if debateadjudications != None %}
         {% for debateadjudicator in debateadjudications %}
@@ -32,13 +32,13 @@
         <div class="list-group-item">
           <em>
             {% if grammatical_person == "3" %}
-              {% blocktranslate trimmed with adjudicator=adjudicator.name %}
+              {% blocktrans trimmed with adjudicator=adjudicator.name %}
                 {{ adjudicator }} is not adjudicating this round.
-              {% endblocktranslate %}
+              {% endblocktrans %}
             {% else %}
-              {% blocktranslate trimmed %}
+              {% blocktrans trimmed %}
                 You are not adjudicating this round.
-              {% endblocktranslate %}
+              {% endblocktrans %}
             {% endif %}
           </em>
         </div>
@@ -51,13 +51,13 @@
           <div class="list-group-item">
             <em>
               {# This is never in the singular, it's just needed to make pluralization work with i18n. #}
-              {% blocktranslate trimmed with team=team_short_name count ndebates=debateteams|length %}
+              {% blocktrans trimmed with team=team_short_name count ndebates=debateteams|length %}
                 It looks like {{ team }} is competing in {{ ndebates }} debate this round.
               {% plural %}
                 It looks like {{ team }} is competing in {{ ndebates }} debates this round.
-              {% endblocktranslate %}
+              {% endblocktrans %}
               {% if not admin_page %}
-                {% translate "If this is an error, please contact a tab director immediately." %}
+                {% trans "If this is an error, please contact a tab director immediately." %}
               {% endif %}
             </em>
           </div>
@@ -72,13 +72,13 @@
         <div class="list-group-item">
           <em>
             {% if grammatical_person == "3" %}
-              {% blocktranslate trimmed with team=team_short_name %}
+              {% blocktrans trimmed with team=team_short_name %}
                 {{ team }} does not have a debate this round.
-              {% endblocktranslate %}
+              {% endblocktrans %}
             {% else %}
-              {% blocktranslate trimmed %}
+              {% blocktrans trimmed %}
                 You do not have a debate this round.
-              {% endblocktranslate %}
+              {% endblocktrans %}
             {% endif %}
           </em>
         </div>
@@ -88,7 +88,7 @@
     {% else %} {# elif not (draw_released or admin_page) #}
 
       <div class="list-group-item">
-        <em>{% translate "The draw for this round hasn't yet been released." %}</em>
+        <em>{% trans "The draw for this round hasn't yet been released." %}</em>
       </div>
 
     {% endif %} {# draw_released or admin_page #}

--- a/tabbycat/participants/templates/participants_subnav.html
+++ b/tabbycat/participants/templates/participants_subnav.html
@@ -3,35 +3,35 @@
 <div class="btn-group btn-group">
   <a class="btn btn-outline-primary {% if participants_nav %}active{% endif %}"
      href="{% tournamenturl 'participants-list' %}">
-    {% translate "Participants List" %}
+    {% trans "Participants List" %}
   </a>
   <a class="btn btn-outline-primary {% if institutions_nav %}active{% endif %}"
      href="{% tournamenturl 'participants-institutions-list' %}">
-    {% translate "Institutions List" %}
+    {% trans "Institutions List" %}
   </a>
 </div>
 <div class="btn-group btn-group">
   {% if email_sent %}
-    <a href="{% tournamenturl 'participants-email' %}" class="btn btn-outline-secondary" data-toggle="tooltip" title="{% translate "Emails have already been sent." %}">
+    <a href="{% tournamenturl 'participants-email' %}" class="btn btn-outline-secondary" data-toggle="tooltip" title="{% trans "Emails have already been sent." %}">
   {% else %}
     <a href="{% tournamenturl 'participants-email' %}" class="btn btn-outline-primary">
   {% endif %}
-    {% translate "Email Team Registrations" %}
+    {% trans "Email Team Registrations" %}
   </a>
 </div>
 <div class="btn-group btn-group">
   {% if pref.team_code_names != 'off' %}
     <a class="btn btn-outline-primary {% if code_names_nav %}active{% endif %}"
        href="{% tournamenturl 'participants-code-names-list' %}">
-      {% translate "Code Names" %}
+      {% trans "Code Names" %}
     </a>
   {% endif %}
   <a class="btn btn-outline-primary {% if speaker_cats_nav %}active{% endif %}"
      href="{% tournamenturl 'participants-speaker-categories-edit' %}">
-    {% translate "Speaker Categories" %}
+    {% trans "Speaker Categories" %}
   </a>
   <a class="btn btn-outline-primary {% if speaker_eligibility_nav %}active{% endif %}"
      href="{% tournamenturl 'participants-speaker-eligibility' %}">
-    {% translate "Speaker Eligibility" %}
+    {% trans "Speaker Eligibility" %}
   </a>
 </div>

--- a/tabbycat/participants/templates/speaker_categories_edit.html
+++ b/tabbycat/participants/templates/speaker_categories_edit.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 {% load add_field_css debate_tags i18n %}
 
-{% block head-title %}<span class="emoji">🗂</span>{% translate "Speaker Categories" %}{% endblock %}
-{% block page-title %}{% translate "Speaker Categories" %}{% endblock %}
+{% block head-title %}<span class="emoji">🗂</span>{% trans "Speaker Categories" %}{% endblock %}
+{% block page-title %}{% trans "Speaker Categories" %}{% endblock %}
 
 {% block page-subnav-sections %}
   {% include "participants_subnav.html" %}
@@ -13,20 +13,20 @@
   <div class="card text-info border-info">
     {# Translators: Translate "ESL" to the acronym "<target language> as a second/foreign language", not the translation of "English as a second language". #}
     <div class="card-body">
-      {% blocktranslate trimmed %}
+      {% blocktrans trimmed %}
         Speaker categories allow category-specific speaker tabs to be produced,
         <i>e.g.</i>, for novice or ESL categories. On this page, you can define
         what speaker categories exist. After you've defined the categories, you
         can set speaker eligibility on the Speaker Eligibility page.
-      {% endblocktranslate %}
+      {% endblocktrans %}
       {% url 'admin:participants_speakercategory_changelist' as edit_db_url %}
-      {% blocktranslate trimmed %}
+      {% blocktrans trimmed %}
         If you want to delete speaker categories, use the <a href="{{ edit_db_url }}" class="alert-link">Edit Database</a> area.
-      {% endblocktranslate %}
+      {% endblocktrans %}
     </div>
   </div>
 
-  {% translate "Save Speaker Categories" as save_text %}
+  {% trans "Save Speaker Categories" as save_text %}
   {% include "components/formset.html" with double=True %}
 
 {% endblock content %}

--- a/tabbycat/participants/templates/team_record.html
+++ b/tabbycat/participants/templates/team_record.html
@@ -16,9 +16,9 @@ names are relevant, or to the team's real name if it is not. #}
 
     {% if pref.public_participants or admin_page %}
       {# Just call it 'name' since this string is also used with adjudicators #}
-      {% blocktranslate trimmed with name=team_short_name asvar card_title %}
+      {% blocktrans trimmed with name=team_short_name asvar card_title %}
         About {{ name }}
-      {% endblocktranslate %}
+      {% endblocktrans %}
       {% include "team_registration_card.html" %}
     {% endif %} {# pref.public_participants or admin_page #}
 

--- a/tabbycat/participants/templates/team_registration_card.html
+++ b/tabbycat/participants/templates/team_registration_card.html
@@ -13,37 +13,37 @@
         {% if not use_code_names or private_url or admin_page %}
           {% if team.short_name == team.long_name %}
             <div>
-              <strong>{% translate "Team name:" %}</strong>
+              <strong>{% trans "Team name:" %}</strong>
               {{ team.long_name }}
             </div>
           {% else %}
             <div>
-              <strong>{% translate "Full team name:" %}</strong>
+              <strong>{% trans "Full team name:" %}</strong>
               {{ team.long_name }}
             </div>
             <div>
-              <strong>{% translate "Short team name:" %}</strong>
+              <strong>{% trans "Short team name:" %}</strong>
               {{ team.short_name }}
             </div>
           {% endif %}
         {% endif %}
         {% if pref.team_code_names != 'off' %}
           <div>
-            <strong>{% translate "Code name:" %}</strong>
+            <strong>{% trans "Code name:" %}</strong>
             {% if team.code_name %}
               {{ team.code_name }}
             {% else %}
-              <span class="text-muted">{% translate "No code name assigned" %}</span>
+              <span class="text-muted">{% trans "No code name assigned" %}</span>
             {% endif %}
           </div>
         {% endif %}
         {% if pref.show_emoji %}
           <div>
-            <strong>{% translate "Emoji:" %}</strong>
+            <strong>{% trans "Emoji:" %}</strong>
             {% if team.emoji %}
               {{ team.emoji }}
             {% else %}
-              <span class="text-muted">{% translate "No emoji assigned" %}</span>
+              <span class="text-muted">{% trans "No emoji assigned" %}</span>
             {% endif %}
           </div>
         {% endif %}
@@ -51,11 +51,11 @@
 
     {% if pref.show_speakers_in_draw %}
       <div class="list-group-item">
-        <strong>{% translate "Speakers:" %}</strong>
+        <strong>{% trans "Speakers:" %}</strong>
         {% for speaker in team.speakers %}
-          {{ speaker.name }}{% if not forloop.last %}{% translate ", " %}{% endif %}
+          {{ speaker.name }}{% if not forloop.last %}{% trans ", " %}{% endif %}
         {% empty %}
-          {% translate "None" %}
+          {% trans "None" %}
         {% endfor %}
       </div>
     {% endif %}
@@ -63,20 +63,20 @@
     {% if pref.public_break_categories or admin_page or private_url %}
       <div class="list-group-item {% if not pref.public_break_categories %} list-group-item-secondary{% endif %}">
         <div>
-          <strong>{% translate "Eligible for break categories:" %}</strong>
+          <strong>{% trans "Eligible for break categories:" %}</strong>
           {% for category in team.break_categories.all %}
-            {{ category.name }}{% if not forloop.last %}{% translate ", " %}{% endif %}
+            {{ category.name }}{% if not forloop.last %}{% trans ", " %}{% endif %}
           {% empty %}
-            {% translate "None" %}
+            {% trans "None" %}
           {% endfor %}
         </div>
         {% if participant %}
           <div>
-            <strong>{% translate "Speaker categories:" %}</strong>
+            <strong>{% trans "Speaker categories:" %}</strong>
             {% for category in participant.categories.all %}
-              {{ category.name }}{% if not forloop.last %}{% translate ", " %}{% endif %}
+              {{ category.name }}{% if not forloop.last %}{% trans ", " %}{% endif %}
             {% empty %}
-              {% translate "None" %}
+              {% trans "None" %}
             {% endfor %}
           </div>
         {% endif %}
@@ -86,16 +86,16 @@
     {% if pref.show_team_institutions or admin_page or private_url %}
       <div class="list-group-item {% if not pref.show_team_institutions %} list-group-item-secondary{% endif %}">
         <div>
-          <strong>{% translate "Institution:" %}</strong>
+          <strong>{% trans "Institution:" %}</strong>
           {% if team.institution %}
             {{ team.institution.name }}
           {% else %}
-            <span class="text-muted">{% translate "Unaffiliated" %}</span>
+            <span class="text-muted">{% trans "Unaffiliated" %}</span>
           {% endif %}
         </div>
         {% if team.institution.region %}
           <div>
-            <strong>{% translate "Region:" %}</strong>
+            <strong>{% trans "Region:" %}</strong>
             {{ team.institution.region.name }}
           </div>
         {% endif %}
@@ -106,31 +106,31 @@
       <div class="list-group-item list-group-item-secondary">
 
         <div>
-          <strong>{% translate "Institutional Conflicts:" %}</strong>
+          <strong>{% trans "Institutional Conflicts:" %}</strong>
           {% for ic in team.teaminstitutionconflict_set.all %}
-            {{ ic.institution.name }}{% if not forloop.last %}{% translate "; " %}{% endif %}
+            {{ ic.institution.name }}{% if not forloop.last %}{% trans "; " %}{% endif %}
           {% empty %}
-            {% translate "None" %}
+            {% trans "None" %}
           {% endfor %}
         </div>
 
         <div>
-          <strong>{% translate "Adjudicator Conflicts:" %}</strong>
+          <strong>{% trans "Adjudicator Conflicts:" %}</strong>
           {% for ac in team.adjudicatorteamconflict_set.all %}
-            {{ ac.adjudicator.name }}{% if not forloop.last %}{% translate ", " %}{% endif %}
+            {{ ac.adjudicator.name }}{% if not forloop.last %}{% trans ", " %}{% endif %}
           {% empty %}
-            {% translate "None" %}
+            {% trans "None" %}
           {% endfor %}
         </div>
 
       </div>
 
       <div class="list-group-item list-group-item-secondary">
-        <strong>{% translate "Room Constraints:" %}</strong>
+        <strong>{% trans "Room Constraints:" %}</strong>
         {% for vc in team.venue_constraints.all %}
-          {{ vc.category }}{% if not forloop.last %}{% translate ", " %}{% endif %}
+          {{ vc.category }}{% if not forloop.last %}{% trans ", " %}{% endif %}
         {% empty %}
-          {% translate "None" %}
+          {% trans "None" %}
         {% endfor %}
       </div>
 

--- a/tabbycat/printing/templates/feedback_list.html
+++ b/tabbycat/printing/templates/feedback_list.html
@@ -2,25 +2,25 @@
 {% load i18n %}
 
 {% block head-title %}
-  {% translate "Feedback Forms" %}
+  {% trans "Feedback Forms" %}
 {% endblock %}
-{% block page-title %}{% blocktranslate trimmed with round=round.name %}
+{% block page-title %}{% blocktrans trimmed with round=round.name %}
 Printable Feedback Forms for {{ round }}
-{% endblocktranslate %}{% endblock %}
+{% endblocktrans %}{% endblock %}
 
 {% block page-alerts %}
   {% if not team_questions_exist or not adj_questions_exist %}
     {% if not team_questions_exist and not adj_questions_exist %}
-      {% translate "No feedback questions have been added for either teams or adjudicators to answer." as first_sentence %}
+      {% trans "No feedback questions have been added for either teams or adjudicators to answer." as first_sentence %}
     {% elif not team_questions_exist %}
-      {% translate "No feedback questions have been added for teams to answer." as first_sentence %}
+      {% trans "No feedback questions have been added for teams to answer." as first_sentence %}
     {% elif not adj_questions_exist %}
-      {% translate "No feedback questions have been added for adjudicators to answer." as first_sentence %}
+      {% trans "No feedback questions have been added for adjudicators to answer." as first_sentence %}
     {% endif %}
-    {% blocktranslate trimmed asvar message %}
+    {% blocktrans trimmed asvar message %}
       {{ first_sentence }}
       Check the <a href="http://tabbycat.readthedocs.io/en/stable/features/adjudicator-feedback.html" target="_blank">documentation</a> for information on how to add these (otherwise these forms will be quite bare).
-    {% endblocktranslate %}
+    {% endblocktrans %}
     {% include "components/alert.html" with type="warning" %}
   {% endif %}
   {{ block.super }}
@@ -38,7 +38,7 @@ Printable Feedback Forms for {{ round }}
       </div>
     </template>
     <div v-if="ballots.length === 0" class="alert alert-warning">
-      {% translate "There are no feedback sheets available — perhaps adjudicators have not been allocated?" %}
+      {% trans "There are no feedback sheets available — perhaps adjudicators have not been allocated?" %}
     </div>
   </div>
 

--- a/tabbycat/printing/templates/printables_list.html
+++ b/tabbycat/printing/templates/printables_list.html
@@ -6,9 +6,9 @@
 {% block body-class %}override-sidebar-offset{% endblock %}
 
 {% block page-alerts %}
-  {% blocktranslate trimmed asvar p1 %}
+  {% blocktrans trimmed asvar p1 %}
     Use Ctrl+P for printing or saving to PDF. Be sure to set the appropriate <strong>page orientation</strong>, to turn off <strong>headers/footers</strong> and turn on <strong>background graphics</strong>. Works best in Chrome.
-  {% endblocktranslate %}
+  {% endblocktrans %}
   {% include "components/explainer-card.html" with type="info" %}
 {% endblock %}
 

--- a/tabbycat/printing/templates/randomised_url_sheets.html
+++ b/tabbycat/printing/templates/randomised_url_sheets.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load debate_tags i18n %}
 
-{% block page-title %}{% blocktranslate trimmed with sheet=sheet_type|title %}Printable {{ sheet }} URLs{% endblocktranslate %}{% endblock %}
+{% block page-title %}{% blocktrans trimmed with sheet=sheet_type|title %}Printable {{ sheet }} URLs{% endblocktrans %}{% endblock %}
 
 {% block header %}{% endblock %}
 {% block nav %}{% endblock %}
@@ -10,11 +10,11 @@
 
 {% block page-alerts %}
   <div class="alert alert-info d-print-none">
-    {% blocktranslate trimmed %}
+    {% blocktrans trimmed %}
     This page is designed to be printed as double sided A4 sheets, with the
     outside facing side showing the participant name and the inside facing side
     showing the URL. Use CTRL-P to print; for best results use Chrome.
-    {% endblocktranslate %}
+    {% endblocktrans %}
   </div>
 {% endblock %}
 
@@ -24,20 +24,20 @@
     <div class="h1 text-center printable-page-break">
       <br>
       {% if p.institution__code %}
-        {% blocktranslate trimmed with name=p.name group=p.institution__code %}
+        {% blocktrans trimmed with name=p.name group=p.institution__code %}
           Private URL for {{ name }} ({{ group }})
-        {% endblocktranslate %}
+        {% endblocktrans %}
       {% else %}
-        {% blocktranslate trimmed with name=p.name group=p.team__short_name %}
+        {% blocktrans trimmed with name=p.name group=p.team__short_name %}
           Private URL for {{ name }} ({{ group }})
-        {% endblocktranslate %}
+        {% endblocktrans %}
       {% endif %}
     </div>
     <div class="h4 text-center printable-page-break">
       <p>
-        {% blocktranslate trimmed %}
+        {% blocktrans trimmed %}
           Please bookmark the following URL, you will use it to submit forms throughout the tournament:
-        {% endblocktranslate %}
+        {% endblocktrans %}
       </p>
       <p>{{ p.url }}</p>
       <svg version="1.1" viewBox="0 0 41 41" width="200px" xmlns="http://www.w3.org/2000/svg">

--- a/tabbycat/printing/templates/scoresheet_list.html
+++ b/tabbycat/printing/templates/scoresheet_list.html
@@ -4,14 +4,14 @@
 {% block header %}
   <div class="row d-print-none p-3 d-flex justify-content-between">
     <div class="h3 pt-1">
-      {% translate "Printable Scoresheets" %}
-      {% blocktranslate trimmed with round=round.name asvar subtitle %}
+      {% trans "Printable Scoresheets" %}
+      {% blocktrans trimmed with round=round.name asvar subtitle %}
         for {{ round }}
-      {% endblocktranslate %}
+      {% endblocktrans %}
       <small class="text-muted d-md-inline d-none">{{ subtitle }}</small>
     </div>
     <button class="btn btn-outline-primary" data-toggle="modal" data-target="#editMotionsModal">
-      {% translate "Edit Motion(s)" %}
+      {% trans "Edit Motion(s)" %}
     </button>
   </div>
 
@@ -30,33 +30,33 @@
       </div>
     </template>
     <div v-if="ballots.length === 0" class="alert alert-warning">
-      {% translate "There are no scoresheets available — perhaps the round has not been drawn?" %}
+      {% trans "There are no scoresheets available — perhaps the round has not been drawn?" %}
     </div>
 
     <div class="modal fade" id="editMotionsModal" tabindex="-1" role="dialog" aria-hidden="true">
       <div class="modal-dialog modal-lg">
         <div class="modal-content">
           <div class="modal-header">
-            <h3 class="modal-title">{% translate "Edit Ballot Motions" %}</h3>
+            <h3 class="modal-title">{% trans "Edit Ballot Motions" %}</h3>
             <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-              <span aria-hidden="true">{% translate "&times;" %}</span>
+              <span aria-hidden="true">{% trans "&times;" %}</span>
             </button>
           </div>
           <div class="modal-body">
             <p class="lead">
-              {% blocktranslate trimmed %}
+              {% blocktrans trimmed %}
                 Editing motions here will not save them permanently — it will only
                 update the text used in the printed ballots below. This can be useful if using
                 placeholder motions (to ensure confidentiality) in Tabbycat, but you still want to print
                 ballots with correct motions.
-              {% endblocktranslate %}
+              {% endblocktrans %}
             </p>
             <div v-for="motion in roundInfo.motions">
-              <h5 class="mt-3">{% translate "Motion" %}<span v-if="roundInfo.motions.length > 1"></span></h5>
+              <h5 class="mt-3">{% trans "Motion" %}<span v-if="roundInfo.motions.length > 1"></span></h5>
               <textarea v-model="motion.text" class="form-control"></textarea>
             </div>
             <div class="text-info text-center mt-3">
-              {% translate "Changes to motions will update in the displayed ballots automatically" %}
+              {% trans "Changes to motions will update in the displayed ballots automatically" %}
             </div>
           </div>
         </div>
@@ -93,7 +93,7 @@
         showDigits: {% if pref.ballots_confirm_digits %}true{% else %}false{% endif %},
         hideMotions: {% if pref.ballots_hide_motions %}true{% else %}false{% endif %},
         // Rules
-        infoText: '{% translate "Speeches are x minutes, the speaker score range is from x to x. You have x minutes to form an adjudication." %}',
+        infoText: '{% trans "Speeches are x minutes, the speaker score range is from x to x. You have x minutes to form an adjudication." %}',
         hasMotions: {% if pref.enable_motions %}true{% else %}false{% endif %},
         hasVetoes: {% if pref.motion_vetoes_enabled %}true{% else %}false{% endif %},
         // Formatting

--- a/tabbycat/privateurls/templates/private_urls.html
+++ b/tabbycat/privateurls/templates/private_urls.html
@@ -1,8 +1,8 @@
 {% extends "tables/base_vue_table.html" %}
 {% load debate_tags i18n %}
 
-{% block head-title %}<span class="emoji">🎲</span> {% translate "Private URLs" %}{% endblock %}
-{% block page-title %}{% translate "Private URLs" %}{% endblock %}
+{% block head-title %}<span class="emoji">🎲</span> {% trans "Private URLs" %}{% endblock %}
+{% block page-title %}{% trans "Private URLs" %}{% endblock %}
 
 {% block page-subnav-sections %}
   {% include 'private_urls_nav.html' %}
@@ -14,27 +14,27 @@
     <div class="card-body pb-0">
       <p>
         {% if exists %}
-          {% translate "The private URLs for ballot and/or feedback submission from participants are given below." %}
+          {% trans "The private URLs for ballot and/or feedback submission from participants are given below." %}
         {% else %}
-          {% blocktranslate trimmed %}
+          {% blocktrans trimmed %}
             Private URLs are used to allow participants to submit ballots and/or
             feedback online. You should use them if you have a means of
             distributing crazy-looking URLs to participants, and are too worried
             about fraud to use a publicly accessible page where <em>anyone</em>
             can enter <em>any</em> submission. The URLs will look something like
             this:
-          {% endblocktranslate %}
+          {% endblocktrans %}
         </p><p align="center">
           <strong><small>{% tournament_absurl 'adjfeedback-public-add-from-team-randomised' '9dnflp3z' %}</small></strong>
         </p><p>
         {% endif %}
-        {% blocktranslate trimmed %}
+        {% blocktrans trimmed %}
           Anyone with the URL can access the relevant data entry page. The idea is
           that it's hard to guess another key (the random-looking string), so you should
           make each URL accessible only to the participant in question.
           <a href="http://tabbycat.readthedocs.io/en/latest/features/data-entry.html#private-urls">
           Read more about private URLs.</a>
-        {% endblocktranslate %}
+        {% endblocktrans %}
       </p>
     </div>
 
@@ -44,13 +44,13 @@
     <div class="card border-warning text-warning mb-3">
       <div class="card-body">
         {% tournamenturl 'options-tournament-section' section='data_entry' as data_entry_options_url %}
-        {% blocktranslate trimmed %}
+        {% blocktrans trimmed %}
           Neither <strong>participant ballot submissions</strong>,
           <strong>participant feedback submissions</strong>, nor <strong>participant self-checkins</strong>
           are configured to be from private URLs. Any generated URLs will not be useful unless you
           configure those settings accordingly on the
           <a href="{{ data_entry_options_url }}">tournament configuration page</a>.
-        {% endblocktranslate %}
+        {% endblocktrans %}
       </div>
     </div>
   {% endif %}
@@ -64,13 +64,13 @@
     <div class="card">
       <div class="card-body">
         <div class="card-title">
-          <h5>{% translate "There are no private URLs assigned." %}</h5>
+          <h5>{% trans "There are no private URLs assigned." %}</h5>
         </div>
         <hr>
         <form action="{% tournamenturl 'privateurls-generate' %}" method="POST">
         {% csrf_token %}
         <button class="btn btn-success btn-block" id="generateRandomisedUrls" type="submit">
-          {% translate "Generate Private URLs" %}
+          {% trans "Generate Private URLs" %}
         </button>
         </form>
       </div>

--- a/tabbycat/privateurls/templates/private_urls_nav.html
+++ b/tabbycat/privateurls/templates/private_urls_nav.html
@@ -3,40 +3,40 @@
 {% if exists %}
   <a class="btn btn-outline-primary {% if private_urls_nav %}active{% endif %}"
      href="{% tournamenturl 'privateurls-list' %}">
-    {% translate "View URLs" %}
+    {% trans "View URLs" %}
   </a>
   <div class="btn-group">
     <a class="btn btn-outline-primary"
        href="{% tournamenturl 'printing-urls-teams' %}" target="_blank">
-      {% translate "Print Teams' URLs" %}
+      {% trans "Print Teams' URLs" %}
     </a>
     <a class="btn btn-outline-primary"
        href="{% tournamenturl 'printing-urls-adjudicators' %}" target="_blank">
-      {% translate "Print Adjudicators' URLs" %}
+      {% trans "Print Adjudicators' URLs" %}
     </a>
   </div>
   <div class="btn-group">
     {% if to_email_exists %}
       <a href="{% tournamenturl 'privateurls-email' %}" class="btn btn-outline-primary">
     {% else %}
-      <a href="{% tournamenturl 'privateurls-email' %}" class="btn btn-outline-secondary" data-toggle="tooltip" title="{% translate "All reachable participants have already been sent their private URLs." %}">
+      <a href="{% tournamenturl 'privateurls-email' %}" class="btn btn-outline-secondary" data-toggle="tooltip" title="{% trans "All reachable participants have already been sent their private URLs." %}">
     {% endif %}
-      {% translate "Email URLs" %}
+      {% trans "Email URLs" %}
     </a>
   </div>
   {% if blank_exists %}
     <div class="btn-group">
       <form action="{% tournamenturl 'privateurls-generate' %}" method="POST">
       {% csrf_token %}
-      <button class="btn btn-outline-success" id="generateRandomisedUrls" type="submit" data-toggle="tooltip" title="{% translate "This button only generates private URLs for participants who do not already have one." %}">
-        {% translate "Generate URLs" %}
+      <button class="btn btn-outline-success" id="generateRandomisedUrls" type="submit" data-toggle="tooltip" title="{% trans "This button only generates private URLs for participants who do not already have one." %}">
+        {% trans "Generate URLs" %}
       </button>
       </form>
     </div>
   {% else %}
     <div class="btn-group">
-      <button class="btn btn-outline-secondary" id="generateRandomisedUrls" data-toggle="tooltip" title="{% translate "All participants already have private URLs." %}">
-        {% translate "Generate URLs" %}
+      <button class="btn btn-outline-secondary" id="generateRandomisedUrls" data-toggle="tooltip" title="{% trans "All participants already have private URLs." %}">
+        {% trans "Generate URLs" %}
       </button>
     </div>
   {% endif %}

--- a/tabbycat/privateurls/templates/public_url_landing.html
+++ b/tabbycat/privateurls/templates/public_url_landing.html
@@ -1,26 +1,26 @@
 {% extends "tables/base_vue_table.html" %}
 {% load i18n debate_tags %}
 
-{% block page-title %}{% translate "Private URL" %}{% endblock %}
-{% block head-title %}{% translate "Private URL" %}{% endblock %}
+{% block page-title %}{% trans "Private URL" %}{% endblock %}
+{% block head-title %}{% trans "Private URL" %}{% endblock %}
 
 {% block extra-head %}<meta name="robots" content="noindex" />{% endblock %}
 
 {% block sub-title %}
-  {% blocktranslate trimmed with name=object.name %}for {{ name }}{% endblocktranslate %}
+  {% blocktrans trimmed with name=object.name %}for {{ name }}{% endblocktrans %}
   {% if object.speaker %}
-    {% blocktranslate trimmed with team=object.speaker.team.short_name %}({{ team }}){% endblocktranslate %}
+    {% blocktrans trimmed with team=object.speaker.team.short_name %}({{ team }}){% endblocktrans %}
   {% endif %}
 {% endblock %}
 
 {% block page-alerts %}
 
-  {% blocktranslate trimmed with name=object.name asvar p1 %}
+  {% blocktrans trimmed with name=object.name asvar p1 %}
     The URL of this page is personalised to you, {{ name }}. <strong>Do not
     share it with anyone;</strong> anyone who knows this URL can submit results and/or
     feedback for your debates. You may bookmark this page and return here after each
     debate for the available actions.
-  {% endblocktranslate %}
+  {% endblocktrans %}
   {% include "components/explainer-card.html" with type="warning" %}
 
 {% endblock %}
@@ -34,24 +34,24 @@
         {% csrf_token %}
         {% if event %}
           <input type="hidden" name="action" value="revoke" />
-          {% blocktranslate trimmed with check_time=event.time asvar text %}
+          {% blocktrans trimmed with check_time=event.time asvar text %}
             Revoke check-in from {{ check_time }}
-          {% endblocktranslate %}
+          {% endblocktrans %}
         {% else %}
           <input type="hidden" name="action" value="checkin" />
-          {% translate "Check in" as text %}
+          {% trans "Check in" as text %}
         {% endif %}
         {% include "components/item-action.html" with id="triggerCheckInForm" url="" child=True %}
       </form>
     {% elif checkins_used %}
       {% if event %}
         {# Translators: Include the full-stop; English doesn't because "a.m." already has a full stop. #}
-        {% blocktranslate trimmed with check_time=event.time asvar text %}
+        {% blocktrans trimmed with check_time=event.time asvar text %}
           You have been checked in at {{ check_time }}
-        {% endblocktranslate %}
+        {% endblocktrans %}
         {% include "components/item-info.html" with type='success' %}
       {% else %}
-        {% translate "You are not currently checked in." as text %}
+        {% trans "You are not currently checked in." as text %}
         {% include "components/item-info.html" with type='warning' %}
       {% endif %}
     {% endif %}
@@ -59,16 +59,16 @@
     {% if object.adjudicator and pref.participant_ballots == 'private-urls' %}
       {% for round in tournament.current_rounds %}
         {% roundurl 'results-public-ballotset-new-randomised' round url_key as url %}
-        {% blocktranslate trimmed with round=round.name asvar text %}Submit Ballot for {{ round }}{% endblocktranslate %}
+        {% blocktrans trimmed with round=round.name asvar text %}Submit Ballot for {{ round }}{% endblocktrans %}
         {% include "components/item-action.html" %}
       {% empty %}
-        {% translate "There are no current rounds" as text %}
+        {% trans "There are no current rounds" as text %}
         {% include "components/item-info.html" with type='info' %}
       {% endfor %}
     {% endif %}
 
     {% if pref.participant_feedback == 'private-urls' %}
-      {% translate "Submit Feedback" as text %}
+      {% trans "Submit Feedback" as text %}
       {% if object.adjudicator %}
         {% tournamenturl 'adjfeedback-public-add-from-adjudicator-randomised' url_key as url %}
       {% else %}
@@ -81,9 +81,9 @@
   <div class="card-deck">
     {% include "in_this_round.html" with grammatical_person="2" %}
 
-    {% blocktranslate trimmed with name=object.name asvar card_title %}
+    {% blocktrans trimmed with name=object.name asvar card_title %}
       Registration ({{ name }})
-    {% endblocktranslate %}
+    {% endblocktrans %}
     {% if object.adjudicator %}
       {% include "adjudicator_registration_card.html" with adjudicator=object.adjudicator %}
     {% else %}

--- a/tabbycat/results/templates/admin_results.html
+++ b/tabbycat/results/templates/admin_results.html
@@ -3,13 +3,13 @@
 
 {% block page-subnav-sections %}
   <a href="{% roundurl 'draw-display' %}" class="btn btn-outline-primary">
-    <i data-feather="chevron-left"></i> {% translate "Display Draw" %}
+    <i data-feather="chevron-left"></i> {% trans "Display Draw" %}
   </a>
   <a class="btn btn-outline-primary" href="{% tournamenturl 'admin-checkin-prescan' %}">
-    {% translate "Check-In Ballots" %}
+    {% trans "Check-In Ballots" %}
   </a>
   <a class="btn btn-outline-primary" href="" data-toggle="modal" data-target="#ironSpeeches">
-    {% translate "Recent 'Iron-Persons'" %}
+    {% trans "Recent 'Iron-Persons'" %}
   </a>
 
   <div class="modal fade" id="ironSpeeches" tabindex="-1" role="dialog"
@@ -17,7 +17,7 @@
     <div class="modal-dialog modal-dialog-centered modal-lg" role="document">
       <div class="modal-content">
         <div class="modal-header">
-          <h4 class="modal-title">{% translate "Teams who have recently missed a speaker" %}</h4>
+          <h4 class="modal-title">{% trans "Teams who have recently missed a speaker" %}</h4>
           <button type="button" class="close" data-dismiss="modal" aria-label="Close">
             <span aria-hidden="true">&times;</span>
           </button>
@@ -33,23 +33,23 @@
               </h5>
               {% if iron.previous_round %}
                 <p class="text-warning mt-3 mb-0">
-                  {% blocktranslate trimmed with team=iron.team %}
+                  {% blocktrans trimmed with team=iron.team %}
                     A speaker from {{ team }} gave multiple speeches in the previous round
-                  {% endblocktranslate %}
+                  {% endblocktrans %}
                 </p>
               {% endif %}
               {% if iron.current_round %}
                 <p class="text-info mt-3 mb-0">
-                  {% blocktranslate trimmed with team=iron.team %}
+                  {% blocktrans trimmed with team=iron.team %}
                     A speaker from {{ team }} gave multiple speeches in the current round
-                  {% endblocktranslate %}
+                  {% endblocktrans %}
                 </p>
               {% endif %}
             </div>
           {% empty %}
            <div class="list-group-item">
               <p class="lead text-success mb-0">
-                {% translate "No known cases in the current or previous round" %}
+                {% trans "No known cases in the current or previous round" %}
               </p>
             </div>
           {% endfor %}
@@ -63,7 +63,7 @@
 {% block page-subnav-actions %}
   {% if round.is_current %}
     <a class="btn {% if incomplete_ballots %}btn-danger disabled{% else %}btn-outline-success{% endif %} " href="{% roundurl 'tournament-complete-round-check' %}">
-      {% translate "Complete Round" %} <i data-feather="chevron-right"></i>
+      {% trans "Complete Round" %} <i data-feather="chevron-right"></i>
     </a>
   {% else %}
     <div class="hidden"></div><!-- Just keeps the spacing consistent -->
@@ -73,7 +73,7 @@
 {% block page-alerts-role-specific %}
   {# Overrides the assistant version of the same alert. #}
 
-  {% translate "This page automatically updates with the new ballot entries and checkins as they occur. You will, however, need to reload it once all ballots are completed in order to advance the round." as p1 %}
+  {% trans "This page automatically updates with the new ballot entries and checkins as they occur. You will, however, need to reload it once all ballots are completed in order to advance the round." as p1 %}
   {% include "components/explainer-card.html" with type="info" %}
 
   {% comment %}
@@ -84,20 +84,20 @@
     implemented.
   {% endcomment %}
   {% if debates_with_trainee_scoresheets %}
-    {% blocktranslate trimmed with debates_list=debates_with_trainee_scoresheets|join:", " count ndebates=debates_with_trainee_scoresheets|length asvar message %}
+    {% blocktrans trimmed with debates_list=debates_with_trainee_scoresheets|join:", " count ndebates=debates_with_trainee_scoresheets|length asvar message %}
       The following debate appears to have scoresheets from trainees: {{ debates_list }}.
     {% plural %}
       The following {{ ndebates }} debates appear to have scoresheets from trainees: {{ debates_list }}.
-    {% endblocktranslate %}
+    {% endblocktrans %}
     {% url 'admin:results_speakerscorebyadj_changelist' as editdb_speakerscorebyadj_url %}
-    {% blocktranslate trimmed asvar trainee_extra %}
+    {% blocktrans trimmed asvar trainee_extra %}
       This can happen if you demote a panellist to trainee after a result has been
       submitted for that debate. This may indicate that there is an inconsistency
       in results data, which may cause unexpected results (or crashes). Please
       consider going to the Edit Database area and deleting the offending
       <a href="{{ editdb_speakerscorebyadj_url }}?debate_adjudicator__type__exact=T" class="alert-link">"speaker
       scores by adj" objects</a>, and then opening and resaving the result here.
-    {% endblocktranslate %}
+    {% endblocktrans %}
     {% include "components/alert.html" with type="danger" icon="alert-octagon" extra=trainee_extra %}
   {% endif %}
 
@@ -108,7 +108,7 @@
     is just an extra courtesy for users who try to hack too much.
   {% endcomment %}
   {% if debates_with_multiple_confirmed_ballots_found %}
-    {% blocktranslate trimmed asvar message %}
+    {% blocktrans trimmed asvar message %}
       One or more debates in this round appear to have more than one confirmed
       ballot submission. This can cause unexpected results (or crashes), because
       Tabbycat assumes that each debate has at most one confirmed ballot
@@ -116,39 +116,39 @@
       the database with SQL queries directly. You'll need to find the offending
       debate(s) and ballot submissions yourself in the Edit Database area, or if
       that doesn't work, you might need to find them using SQL queries directly.
-    {% endblocktranslate %}
+    {% endblocktrans %}
     {% include "components/alert.html" with type="danger" icon="alert-octagon" %}
   {% endif %}
 
   {% if pref.teams_in_debate == "bp" and round.ballots_per_debate == "per-adj" %}
     {% tournamenturl 'options-tournament-section' section='debate_rules' as debate_rules_url %}
-    {% blocktranslate trimmed asvar message %}
+    {% blocktrans trimmed asvar message %}
       This tournament's configuration is set to <strong>British Parliamentary</strong> with <strong>one ballot per voting adjudicator</strong>. This combination isn't allowed: BP tournaments must use consensus ballots. Results can't be entered while this configuration is in place. Please <a href="{{ debate_rules_url }}">revise this tournament's configuration</a> before you try to enter results.
-    {% endblocktranslate %}
+    {% endblocktrans %}
     {% include "components/alert.html" with type="danger" %}
   {% endif %}
 
   {% if pref.enable_motions and round.motion_set.count == 0 %}
     {% roundurl 'motions-edit' as motions_url %}
-    {% blocktranslate trimmed asvar message %}
+    {% blocktrans trimmed asvar message %}
       Currently there are no motions entered for this round, so debate results
       cannot be entered. <a href="{{ motions_url }}" class="alert-link">Add Motions.</a>
-    {% endblocktranslate %}
+    {% endblocktrans %}
     {% include "components/alert.html" with type="danger" %}
   {% endif %}
 
   {% roundurl 'draw-display' as display_url %}
   {% if round.draw_status != round.STATUS_RELEASED and pref.participant_ballots != 'off' %}
-    {% blocktranslate trimmed asvar message %}
+    {% blocktrans trimmed asvar message %}
         Your tournament configuration allows ballots to be submitted online by adjudicators. The draw <a href="{{ display_url }}" class="alert-link">must be released</a> before they can do so for this round.
-      {% endblocktranslate %}
+      {% endblocktrans %}
     {% include "components/alert.html" with type="danger" %}
   {% endif %}
 
   {% if round.draw_status != round.STATUS_RELEASED and pref.participant_feedback != 'off' %}
-    {% blocktranslate trimmed asvar message %}
+    {% blocktrans trimmed asvar message %}
         Your tournament configuration allows feedback to be submitted online by participants. The draw <a href="{{ display_url }}" class="alert-link">must be released</a> before they can do so for this round.
-      {% endblocktranslate %}
+      {% endblocktrans %}
     {% include "components/alert.html" with type="danger" %}
   {% endif %}
 

--- a/tabbycat/results/templates/assistant_enter_results.html
+++ b/tabbycat/results/templates/assistant_enter_results.html
@@ -4,11 +4,11 @@
 {% block page-subnav-sections %}
   <a class="btn btn-outline-primary" href="{% tournamenturl 'results-assistant-round-list' %}">
     <i data-feather="chevron-left"></i>
-    {% translate "Back to All Results" %}
+    {% trans "Back to All Results" %}
   </a>
   {% if not new %}
     <a class="btn btn-primary" href="{% tournamenturl 'results-assistant-ballotset-new' debate.id %}">
-      {% translate "Create a new ballot set for this debate" %}
+      {% trans "Create a new ballot set for this debate" %}
     </a>
   {% endif %}
 {% endblock %}
@@ -30,12 +30,12 @@
           {# If confirming, always go into CONFIRMED. If incorrect, go into DRAFT or NONE depending on whether there are still ballots left. #}
           {% if not new and request.user == ballotsub.submitter %}
             <div class="alert alert-danger">
-              {% translate "You can't confirm this ballot set because you entered it." %}
+              {% trans "You can't confirm this ballot set because you entered it." %}
             </div>
           {% endif %}
           {% if ballotsub.single_adj %}
             <div class="alert alert-danger">
-              {% translate "You can't confirm this ballot set because it is for a single adjudicator. Use the merge function." %}
+              {% trans "You can't confirm this ballot set because it is for a single adjudicator. Use the merge function." %}
             </div>
           {% endif %}
           <input id="id_debate_result_status" type="hidden" name="debate_result_status" value="{{ debate.STATUS_CONFIRMED }}" />
@@ -43,15 +43,15 @@
           <input id="id_confirmed" type="hidden" name="confirmed" value="True" />
           <div class="row">
             <div class="col">
-              <input id="correct" {% if not new and request.user == ballotsub.submitter or form.confirmed.field.disabled %}disabled="disabled"{% endif %} class="btn btn-success btn-block" type="submit" value="{% translate "Confirm results" %}" tabindex="{{ form.nexttabindex }}" />
+              <input id="correct" {% if not new and request.user == ballotsub.submitter or form.confirmed.field.disabled %}disabled="disabled"{% endif %} class="btn btn-success btn-block" type="submit" value="{% trans "Confirm results" %}" tabindex="{{ form.nexttabindex }}" />
             </div>
             <div class="col">
-              <input id="incorrect" class="btn btn-danger btn-block" type="button" value="{% translate "Results are incorrect" %}" tabindex="{{ form.nexttabindex|add:1 }}" />
+              <input id="incorrect" class="btn btn-danger btn-block" type="button" value="{% trans "Results are incorrect" %}" tabindex="{{ form.nexttabindex|add:1 }}" />
             </div>
           </div>
           <div class="text-center pt-3 small text-muted">
             {% if pref.enable_ballot_receipts and not request.user == ballotsub.submitter %}
-              {% translate "Emails will be sent to adjudicators when the ballot is confirmed." %}
+              {% trans "Emails will be sent to adjudicators when the ballot is confirmed." %}
             {% endif %}
           </div>
         {% endif %}

--- a/tabbycat/results/templates/assistant_results.html
+++ b/tabbycat/results/templates/assistant_results.html
@@ -1,51 +1,51 @@
 {% extends "tables/base_vue_table.html" %}
 {% load humanize debate_tags i18n %}
 
-{% block page-title %}{% translate "Enter Results" %}{% endblock %}
-{% block head-title %}<span class="emoji">📩</span> {% translate "Enter Results" %}{% endblock %}
+{% block page-title %}{% trans "Enter Results" %}{% endblock %}
+{% block head-title %}<span class="emoji">📩</span> {% trans "Enter Results" %}{% endblock %}
 
 {% block page-alerts %}
 
   {% block page-alerts-role-specific %}
     {# Administrators have different alert that have links, see admin_results.html. #}
 
-    {% translate "This page automatically updates with the new ballot entries and checkins as they occur." as message %}
+    {% trans "This page automatically updates with the new ballot entries and checkins as they occur." as message %}
     {% include "components/alert.html" with type="info" %}
 
     {% if pref.teams_in_debate == "bp" and round.ballots_per_debate == "per-adj" %}
-      {% blocktranslate trimmed asvar message %}
+      {% blocktrans trimmed asvar message %}
         This tournament's configuration is set to <strong>British Parliamentary</strong> with <strong>one ballot per voting adjudicator</strong>. This combination isn't allowed: BP tournaments must use consensus ballots. Results can't be entered while this configuration is in place. Please ask an administrator to change this configuration.
-      {% endblocktranslate %}
+      {% endblocktrans %}
       {% include "components/alert.html" with type="danger" %}
     {% endif %}
 
     {% if pref.enable_motions and round.motion_set.count == 0 %}
-      {% blocktranslate trimmed asvar message %}
+      {% blocktrans trimmed asvar message %}
         Currently there are no motions entered for this round, so debate results
         cannot be entered. Please ask an administrator to add motions.
-      {% endblocktranslate %}
+      {% endblocktrans %}
       {% include "components/alert.html" with type="danger" %}
     {% endif %}
   {% endblock %}
 
   {% with sides_unconfirmed=round.num_debates_with_sides_unconfirmed %}
     {% if sides_unconfirmed > 0 and pref.draw_side_allocations != 'manual-ballot' %}
-      {% blocktranslate trimmed asvar message count ndebates=sides_unconfirmed %}
+      {% blocktrans trimmed asvar message count ndebates=sides_unconfirmed %}
         One debate does not have its sides confirmed. Results for this debate cannot be entered until its side allocations are marked as confirmed.
       {% plural %}
         {{ ndebates }} debate do not have their sides confirmed. Results for these debates cannot be entered until their side allocations are marked as confirmed.
-      {% endblocktranslate %}
+      {% endblocktrans %}
       {% include "components/alert.html" with type="danger" %}
     {% endif %}
   {% endwith %}
 
   {% with num_even_panel=round.num_debates_with_even_panel %}
     {% if round.ballots_per_debate == 'per-adj' and num_even_panel > 0 %}
-      {% blocktranslate trimmed asvar message count num_even_panel=num_even_panel %}
+      {% blocktrans trimmed asvar message count num_even_panel=num_even_panel %}
         One debate has a panel with an even number of voting adjudicators. If the adjudicators split evenly, the debate will be awarded to the team for which the chair voted.
       {% plural %}
         {{ num_even_panel }} debates have panels with an even number of voting adjudicators. If the adjudicators split evenly, the debate will be awarded to the team for which the chair voted.
-      {% endblocktranslate %}
+      {% endblocktrans %}
       {% include "components/alert.html" with type="warning" %}
     {% endif %}
   {% endwith %}

--- a/tabbycat/results/templates/ballot/ballot_debate_info.html
+++ b/tabbycat/results/templates/ballot/ballot_debate_info.html
@@ -3,7 +3,7 @@
 <div class="card mt-3">
   <div class="list-group list-group-flush">
 
-    {% translate "Debate Information" as title %}
+    {% trans "Debate Information" as title %}
     {% include "components/form-title.html" %}
 
     {% if form.choose_sides %}
@@ -39,10 +39,10 @@
           <select class="required custom-select form-control" id="hasIron" name="iron"
                   tabindex="{{ form.irontabindex }}" required="" aria-required="true">
             <option value="0">
-              {% translate "No speakers spoke twice (no 'iron-person' speeches)" %}
+              {% trans "No speakers spoke twice (no 'iron-person' speeches)" %}
             </option>
             <option value="1">
-              {% translate "A speaker spoke twice (an 'iron-person' speech)" %}
+              {% trans "A speaker spoke twice (an 'iron-person' speech)" %}
             </option>
           </select>
         </div>

--- a/tabbycat/results/templates/ballot/ballot_scoresheet.html
+++ b/tabbycat/results/templates/ballot/ballot_scoresheet.html
@@ -25,13 +25,13 @@
         <div class="col-6 mr-0 col-mr-auto pl-md-2 pl-1 btn-group">
 
           <button class="btn btn-outline-secondary btn-no-hover" readonly />
-            {% if pref.teams_in_debate != 'bp' %}{% translate "Result" %}{% else %}{% translate "Rank" %}{% endif %}
+            {% if pref.teams_in_debate != 'bp' %}{% trans "Result" %}{% else %}{% trans "Rank" %}{% endif %}
           </button>
           <button name="{{ team.side_code }}_rank" type="text"
                   class="btn btn-secondary btn-no-hover {{ team.side_code }}_rank" readonly  />
             ?
           </button>
-          <button class="btn btn-outline-secondary btn-no-hover" readonly />{% translate "Margin" %}</button>
+          <button class="btn btn-outline-secondary btn-no-hover" readonly />{% trans "Margin" %}</button>
           <button name="{{ team.side_code }}_margin" type="text"
                   class="btn btn-secondary btn-no-hover {{ team.side_code }}_margin" readonly  />
             +0

--- a/tabbycat/results/templates/ballot/ballot_set.html
+++ b/tabbycat/results/templates/ballot/ballot_set.html
@@ -3,7 +3,7 @@
 <div id="ballot_set">
 
   {% if form.errors %}
-    {% translate "There are some problems with this scoresheet. Please review and correct them." as message %}
+    {% trans "There are some problems with this scoresheet. Please review and correct them." as message %}
     {% include "components/form-errors.html" with errors=form.non_field_errors %}
   {% endif %}
 
@@ -16,23 +16,23 @@
 
       {% if sheet.adjudicator %}
         {% if sheet.adjudicator.institution %}
-          {% blocktranslate trimmed with name=sheet.adjudicator.name institution=sheet.adjudicator.institution.code asvar title %}
+          {% blocktrans trimmed with name=sheet.adjudicator.name institution=sheet.adjudicator.institution.code asvar title %}
             Ballot from {{ name }} ({{ institution }})
-          {% endblocktranslate %}
+          {% endblocktrans %}
         {% else %}
-          {% blocktranslate trimmed with name=sheet.adjudicator.name asvar title %}
+          {% blocktrans trimmed with name=sheet.adjudicator.name asvar title %}
             Ballot from {{ name }}
-          {% endblocktranslate %}
+          {% endblocktrans %}
         {% endif %}
         {% include "components/form-title.html" %}
       {% else %}
         <div class="list-group-item pt-4">
           <h4 class="card-title  float-left mt-0 {% if not text %}mb-2{% endif %}">
-            {% translate "Scoresheet" %}
+            {% trans "Scoresheet" %}
           </h4>
             {% for da in debate.adjudicators.voting_with_positions reversed %}
               <div class="badge badge-secondary float-right ml-2 mt-1">
-                <p class="mb-0">{{ da.0.name }} ({% if da.1 == "o" %}{% translate "Solo Chair" %}{% elif da.1 == "c" %}{% translate "Chair" %}{% elif da.1 == "p" %}{% translate "Panellist" %}{% elif da.1 == "t" %}{% translate "Trainee" %}{% endif %})</p>
+                <p class="mb-0">{{ da.0.name }} ({% if da.1 == "o" %}{% trans "Solo Chair" %}{% elif da.1 == "c" %}{% trans "Chair" %}{% elif da.1 == "p" %}{% trans "Panellist" %}{% elif da.1 == "t" %}{% trans "Trainee" %}{% endif %})</p>
               </div>
             {% endfor %}
 
@@ -41,7 +41,7 @@
 
       {% if form.choosing_sides %}
         <div class="sides-before-scores-warning list-group-item-warning list-group-item">
-          {% translate "Assign sides before entering scores" %}
+          {% trans "Assign sides before entering scores" %}
         </div>
       {% endif %}
 

--- a/tabbycat/results/templates/ballot/ballot_speaks.html
+++ b/tabbycat/results/templates/ballot/ballot_speaks.html
@@ -16,7 +16,7 @@
 
         <div class="iron-person small pt-0 m-0 form-check form-check-inline" style="display: none;"
                data-toggle="tooltip" data-placement="bottom"
-               title="{% translate "Duplicate speeches are hidden from the speaker tab. If a speaker is 'iron-manning' you would typically mark only the lesser of their scores as a duplicate." %}">
+               title="{% trans "Duplicate speeches are hidden from the speaker tab. If a speaker is 'iron-manning' you would typically mark only the lesser of their scores as a duplicate." %}">
           {{ position.ghost|addcss:"form-check-input" }}
           <span class="mt-2"></span>
           {{ position.ghost.label_tag }}

--- a/tabbycat/results/templates/ballot/other_ballots_list.html
+++ b/tabbycat/results/templates/ballot/other_ballots_list.html
@@ -6,11 +6,11 @@
     {% if new and nballotsubs > 0 or nballotsubs > 1 %}
       <li class="list-group-item list-group-item-warning">
         <h4 class="list-group-item-heading mb-0">
-          {% blocktranslate trimmed with number=nballotsubs|apnumber count nballotsubs=nballotsubs %}
+          {% blocktrans trimmed with number=nballotsubs|apnumber count nballotsubs=nballotsubs %}
             There is {{ number }} existing ballot set for this debate.
           {% plural %}
             There are {{ number }} existing ballot sets for this debate.
-          {% endblocktranslate %}
+          {% endblocktrans %}
         </h4>
       </li>
     {% endif %}
@@ -18,12 +18,12 @@
 
   {% if ballotsub.confirmed %}
     <li class="list-group-item list-group-item-success">
-      {% translate "This ballot set is <strong>confirmed</strong>." %}
+      {% trans "This ballot set is <strong>confirmed</strong>." %}
     </li>
   {% endif %}
   {% if ballotsub.discarded %}
     <li class="list-group-item list-group-item-warning">
-      {% translate "This ballot set is <strong>discarded</strong>." %}
+      {% trans "This ballot set is <strong>discarded</strong>." %}
     </li>
   {% endif %}
 
@@ -38,56 +38,56 @@
       {% endif %}
 
         {% if other == ballotsub %}
-          <span class="badge badge-success float-right">{% translate "CURRENTLY VIEWING" %}</span>
+          <span class="badge badge-success float-right">{% trans "CURRENTLY VIEWING" %}</span>
         {% endif %}
 
         {% if other.merged %}
-          <span class="badge badge-success float-right">{% translate "MERGING" %}</span>
+          <span class="badge badge-success float-right">{% trans "MERGING" %}</span>
         {% endif %}
 
-        {% blocktranslate trimmed with version=other.version %}
+        {% blocktrans trimmed with version=other.version %}
           Version <strong>{{ version }}</strong>,
-        {% endblocktranslate %}
+        {% endblocktrans %}
 
         {% if other.submitter_type == ballotsub.SUBMITTER_TABROOM %}
-          {% blocktranslate trimmed with submitter=other.submitter %}
+          {% blocktrans trimmed with submitter=other.submitter %}
             entered by <strong>{{ submitter }}</strong>,
-          {% endblocktranslate %}
+          {% endblocktrans %}
         {% elif other.submitter_type == ballotsub.SUBMITTER_PUBLIC %}
           {% if other.participant_submitter %}
-            {% blocktranslate trimmed with adjudicator=other.participant_submitter %}
+            {% blocktrans trimmed with adjudicator=other.participant_submitter %}
               submitted from <strong>{{ adjudicator }}</strong>'s private URL,
-            {% endblocktranslate %}
+            {% endblocktrans %}
           {% else %}
-            {% blocktranslate trimmed with ip_address=other.ip_address %}
+            {% blocktrans trimmed with ip_address=other.ip_address %}
               submitted from the public form on {{ ip_address }},
-            {% endblocktranslate %}
+            {% endblocktrans %}
           {% endif %}
         {% endif %}
 
-        {% blocktranslate trimmed with timestamp=other.timestamp timeago=other.timestamp|timesince %}
+        {% blocktrans trimmed with timestamp=other.timestamp timeago=other.timestamp|timesince %}
           {{ timestamp }} ({{ timeago }} ago),
-        {% endblocktranslate %}
+        {% endblocktrans %}
 
         {% if other.confirmed %}
-          {% translate "unknown" as confirmer_unknown %}
-          {% blocktranslate trimmed with confirmer=other.confirmer|default:confirmer_unknown %}
+          {% trans "unknown" as confirmer_unknown %}
+          {% blocktrans trimmed with confirmer=other.confirmer|default:confirmer_unknown %}
             confirmed by <strong>{{ confirmer }}</strong>
-          {% endblocktranslate %}
+          {% endblocktrans %}
         {% else %}
-          {% translate "unconfirmed" %}
+          {% trans "unconfirmed" %}
         {% endif %}
 
         {% if other.discarded %}
-          {% translate "(discarded)" %}
+          {% trans "(discarded)" %}
         {% endif %}
 
         {% if other.identical_ballotsub_versions %}
-          {% blocktranslate trimmed with others=other.identical_ballotsub_versions|join:", " count n=other.identical_ballotsub_versions|length %}
+          {% blocktrans trimmed with others=other.identical_ballotsub_versions|join:", " count n=other.identical_ballotsub_versions|length %}
             <em>(identical to version {{ others }})</em>
           {% plural %}
             <em>(identical to versions {{ others }})</em>
-          {% endblocktranslate %}
+          {% endblocktrans %}
         {% endif %}
 
       {% if other != ballotsub %}

--- a/tabbycat/results/templates/ballot_entry.html
+++ b/tabbycat/results/templates/ballot_entry.html
@@ -18,10 +18,10 @@
       {% tournamenturl 'old-results-assistant-ballotset-edit' pk=ballotsub.id as old_url %}
     {% endif %}
   {% endif %}
-  {% blocktranslate trimmed asvar message %}
+  {% blocktrans trimmed asvar message %}
     This ballot entry interface is in beta, if you encounter any problems the older
     version of the interface is <a href="{{ old_url }}" class="alert-link">available here</a>.
-  {% endblocktranslate %}
+  {% endblocktrans %}
   {% include "components/alert.html" with type="info" %}
   {{ block.super }}
 

--- a/tabbycat/results/templates/ballot_entry_base.html
+++ b/tabbycat/results/templates/ballot_entry_base.html
@@ -9,16 +9,16 @@
   {% else %}
     <a class="btn btn-outline-primary" href="{% tournamenturl 'results-assistant-round-list' %}">
   {% endif %}
-      <i data-feather="chevron-left"></i>{% translate "Back to All Results" %}
+      <i data-feather="chevron-left"></i>{% trans "Back to All Results" %}
     </a>
   {% if not new %}
     {% if for_admin %}
       <a class="btn btn-primary" href="{% tournamenturl 'old-results-ballotset-new' debate.id %}">
-        {% translate "Create a new ballot set for this debate" %}
+        {% trans "Create a new ballot set for this debate" %}
       </a>
     {% else %}
       <a class="btn btn-primary" href="{% tournamenturl 'old-results-assistant-ballotset-new' debate.id %}">
-        {% translate "Create a new ballot set for this debate" %}
+        {% trans "Create a new ballot set for this debate" %}
       </a>
     {% endif %}
   {% endif %}
@@ -27,22 +27,22 @@
 {% block page-alerts %}
 
   {% if round.ballots_per_debate == 'per-adj' and debate.adjudicators.is_even %}
-    {% blocktranslate trimmed asvar message %}
+    {% blocktrans trimmed asvar message %}
       This debate has a panel with an even number of voting adjudicators.
       If the adjudicators split evenly, the debate will be awarded to the team
       for which the chair voted.
-    {% endblocktranslate %}
+    {% endblocktrans %}
     {% include "components/alert.html" with type="warning" %}
   {% endif %}
 
   {% if iron %}
     {% for i in iron %}
       {% team_name_for_data_entry i.team use_team_code_names as team %}
-      {% blocktranslate trimmed asvar message %}
+      {% blocktrans trimmed asvar message %}
         {{ team }} had speakers who spoke multiple times in the last round — i.e. an 'iron' person
         speech. Please carefully check the ballot to see if that is still the case for this round.
         If it is, ensure the speakers selected below reflect this.
-      {% endblocktranslate %}
+      {% endblocktrans %}
       {% include "components/alert.html" with type="danger" icon="user-x" %}
     {% endfor %}
   {% endif %}

--- a/tabbycat/results/templates/ballot_entry_form.html
+++ b/tabbycat/results/templates/ballot_entry_form.html
@@ -20,28 +20,28 @@
 
     {% if sheet.adjudicator %}
       {% if sheet.adjudicator.institution %}
-        {% blocktranslate trimmed with name=sheet.adjudicator.name institution=sheet.adjudicator.institution.code asvar title %}
+        {% blocktrans trimmed with name=sheet.adjudicator.name institution=sheet.adjudicator.institution.code asvar title %}
           Ballot from {{ name }} ({{ institution }})
-        {% endblocktranslate %}
+        {% endblocktrans %}
       {% else %}
-        {% blocktranslate trimmed with name=sheet.adjudicator.name asvar title %}
+        {% blocktrans trimmed with name=sheet.adjudicator.name asvar title %}
           Ballot from {{ name }}
-        {% endblocktranslate %}
+        {% endblocktrans %}
       {% endif %}
       {% if sheet.adjudicator == debate.adjudicators.chair %}
-        {% blocktranslate trimmed asvar subtitle %}Chair{% endblocktranslate %}
+        {% blocktrans trimmed asvar subtitle %}Chair{% endblocktrans %}
       {% elif sheet.adjudicator != debate.adjudicators.chair %}
-        {% blocktranslate trimmed asvar subtitle %}Panellist{% endblocktranslate %}
+        {% blocktrans trimmed asvar subtitle %}Panellist{% endblocktrans %}
       {% endif %}
     {% else %}
       {% if debate.adjudicators.has_chair %}
-        {% blocktranslate trimmed with chair=debate.adjudicators.chair asvar title %}
+        {% blocktrans trimmed with chair=debate.adjudicators.chair asvar title %}
           Scoresheet from chair {{ chair }}
-        {% endblocktranslate %}
+        {% endblocktrans %}
       {% else %}
-        {% blocktranslate trimmed asvar title %}
+        {% blocktrans trimmed asvar title %}
           Scoresheet, no chair set
-        {% endblocktranslate %}
+        {% endblocktrans %}
       {% endif %}
     {% endif %}
 
@@ -60,21 +60,21 @@
             </div>
 
             {% for error in position.speaker.errors %}
-              {% blocktranslate trimmed asvar message with pos=position.name error=error %}
+              {% blocktrans trimmed asvar message with pos=position.name error=error %}
                 Error with {{ pos }}'s speaker field: {{ error }}
-              {% endblocktranslate %}
+              {% endblocktrans %}
               {% include "components/form-errors.html" %}
             {% endfor %}
             {% for error in position.ghost.errors %}
-              {% blocktranslate trimmed asvar message with pos=position.name error=error %}
+              {% blocktrans trimmed asvar message with pos=position.name error=error %}
                 Error with {{ pos }}'s duplicate speaker field: {{ error }}
-              {% endblocktranslate %}
+              {% endblocktrans %}
               {% include "components/form-errors.html" %}
             {% endfor %}
             {% for error in position.score.errors %}
-              {% blocktranslate trimmed asvar message with pos=position.name error=error %}
+              {% blocktrans trimmed asvar message with pos=position.name error=error %}
                 Error with {{ pos }}'s score field: {{ error }}
-              {% endblocktranslate %}
+              {% endblocktrans %}
               {% include "components/form-errors.html" %}
             {% endfor %}
 

--- a/tabbycat/results/templates/debate_postponement_form.html
+++ b/tabbycat/results/templates/debate_postponement_form.html
@@ -1,11 +1,11 @@
 {% load debate_tags i18n %}
 {% if debate.result_status == debate.STATUS_POSTPONED %}
-  <small>{% translate "Postponed" %}</small>
+  <small>{% trans "Postponed" %}</small>
 {% else %}
   <form method="POST" action="{% roundurl 'results-postpone-debate' debate.round debate.id %}" class='text-secondary'>
     {% csrf_token %}
     <button type="submit" class="btn btn-link text-primary p-0">
-      <small>{% translate "Postpone" %}</small>
+      <small>{% trans "Postpone" %}</small>
     </button>
   </form>
 {% endif %}

--- a/tabbycat/results/templates/enter_results.html
+++ b/tabbycat/results/templates/enter_results.html
@@ -12,8 +12,8 @@
     <div class="card mt-3">
       <div class="list-group list-group-flush">
 
-        {% translate "Ballot Status" as title %}
-        {% translate "only the confirmed ballot set will affect this debate's result" as subtitle %}
+        {% trans "Ballot Status" as title %}
+        {% trans "only the confirmed ballot set will affect this debate's result" as subtitle %}
         {% include "components/form-title.html" %}
 
         <div class="list-group-item">
@@ -29,10 +29,10 @@
     <div class="card mt-3">
       <div class="list-group list-group-flush">
 
-        {% blocktranslate trimmed asvar title %}
+        {% blocktrans trimmed asvar title %}
           Debate Status
-        {% endblocktranslate %}
-        {% translate "all debates must be confirmed to complete the round" as subtitle %}
+        {% endblocktrans %}
+        {% trans "all debates must be confirmed to complete the round" as subtitle %}
         {% include "components/form-title.html" %}
 
         <div class="list-group-item pb-4">
@@ -42,15 +42,15 @@
         <div class="list-group-item pt-3 pb-1">
           <div class="row">
             <div class="col-md-6 col form-group">
-              <input id="submit" class="save btn btn-success btn-block " type="submit" value="{% translate "Save Ballot" %}" tabindex="{{ form.nexttabindex }}" />
+              <input id="submit" class="save btn btn-success btn-block " type="submit" value="{% trans "Save Ballot" %}" tabindex="{{ form.nexttabindex }}" />
             </div>
             <div class="col-md-6 col form-group">
-              <a class="btn btn-primary btn-block btn-danger" href="{% roundurl 'results-round-list' debate.round %}" tabindex="{{ form.nexttabindex|add:1 }}">{% translate "Cancel Entry" %}</a>
+              <a class="btn btn-primary btn-block btn-danger" href="{% roundurl 'results-round-list' debate.round %}" tabindex="{{ form.nexttabindex|add:1 }}">{% trans "Cancel Entry" %}</a>
             </div>
           </div>
           <div class="text-center pt-3 small text-muted">
             {% if pref.enable_ballot_receipts %}
-              {% translate "Emails will be sent to adjudicators when the ballot is confirmed." %}
+              {% trans "Emails will be sent to adjudicators when the ballot is confirmed." %}
             {% endif %}
           </div>
         </div>

--- a/tabbycat/results/templates/includes/public_enter_results_info.html
+++ b/tabbycat/results/templates/includes/public_enter_results_info.html
@@ -1,11 +1,11 @@
 {% load i18n %}
 
 {% if private_url %}
-  {% blocktranslate trimmed with name=adjudicator.name asvar p1 %}
+  {% blocktrans trimmed with name=adjudicator.name asvar p1 %}
     The URL of this page is personalised to you, {{ name }}. <strong>Do not
     share it with anyone;</strong> anyone who knows this URL can submit results and/or
     feedback for your debates. You may bookmark this page and return here after each
     debate for the available actions.
-  {% endblocktranslate %}
+  {% endblocktrans %}
   {% include "components/explainer-card.html" with type="info" %}
 {% endif %}

--- a/tabbycat/results/templates/privateurl_ballot_set.html
+++ b/tabbycat/results/templates/privateurl_ballot_set.html
@@ -4,12 +4,12 @@
 {% block extra-head %}<meta name="robots" content="noindex" />{% endblock %}
 
 {% block page-alerts %}
-  {% blocktranslate trimmed with name=adjudicator.name asvar p1 %}
+  {% blocktrans trimmed with name=adjudicator.name asvar p1 %}
     The page is provided to allow you, <strong>{{ name }}</strong>, to verify
     your own scoresheet.
     <strong>You must not share this URL with anyone.</strong>
     Sharing the URL will allow others to access <strong>all</strong> actions
     from your personal landing page.
-  {% endblocktranslate %}
+  {% endblocktrans %}
   {% include "components/explainer-card.html" with type="warning" %}
 {% endblock %}

--- a/tabbycat/results/templates/privateurl_ballot_set_error.html
+++ b/tabbycat/results/templates/privateurl_ballot_set_error.html
@@ -1,21 +1,21 @@
 {% extends "base.html" %}
 {% load debate_tags i18n %}
 
-{% block page-title %}{% translate "Ballot Not Available" %}{% endblock %}
+{% block page-title %}{% trans "Ballot Not Available" %}{% endblock %}
 {% block head-title %}
-  <h2><span class="emoji">😾</span> {% translate "Ballot Not Available" %}</h2>
+  <h2><span class="emoji">😾</span> {% trans "Ballot Not Available" %}</h2>
 {% endblock %}
 
 {% block extra-head %}<meta name="robots" content="noindex" />{% endblock %}
 
 {% block page-alerts %}
-  {% blocktranslate trimmed with name=adjudicator.name asvar p1 %}
+  {% blocktrans trimmed with name=adjudicator.name asvar p1 %}
     The page is provided to allow you, <strong>{{ name }}</strong>, to verify
     your own scoresheet.
     <strong>You must not share this URL with anyone.</strong>
     Sharing the URL will allow others to access <strong>all</strong> actions
     from your personal landing page.
-  {% endblocktranslate %}
+  {% endblocktrans %}
   {% include "components/explainer-card.html" with type="warning" %}
 {% endblock %}
 
@@ -24,9 +24,9 @@
     <div class="card-body">
       {{ message }}
       {% tournamenturl 'privateurls-person-index' adjudicator.url_key as url %}
-      {% blocktranslate trimmed %}
+      {% blocktrans trimmed %}
         <a href="{{ url }}">Back to your private landing page.</a>
-      {% endblocktranslate %}
+      {% endblocktrans %}
     </div>
   </div>
 {% endblock %}

--- a/tabbycat/results/templates/public_add_ballot.html
+++ b/tabbycat/results/templates/public_add_ballot.html
@@ -1,6 +1,6 @@
 {% extends "tables/base_vue_table.html" %}
 {% load debate_tags i18n %}
 
-{% block page-title %}{% translate "Enter Ballot" %}{% endblock %}
-{% block head-title %}{% translate "Who are you?" %}{% endblock %}
-{% block sub-title %}{% translate "(click your name on this list)" %}{% endblock %}
+{% block page-title %}{% trans "Enter Ballot" %}{% endblock %}
+{% block head-title %}{% trans "Who are you?" %}{% endblock %}
+{% block sub-title %}{% trans "(click your name on this list)" %}{% endblock %}

--- a/tabbycat/results/templates/public_add_ballot_unreleased.html
+++ b/tabbycat/results/templates/public_add_ballot_unreleased.html
@@ -1,11 +1,11 @@
 {% extends "base.html" %}
 {% load debate_tags static i18n %}
 
-{% block head-title %}{% translate "Enter Ballot" %}{% endblock %}
-{% block page-title %}{% translate "Enter Ballot" %}{% endblock %}
+{% block head-title %}{% trans "Enter Ballot" %}{% endblock %}
+{% block page-title %}{% trans "Enter Ballot" %}{% endblock %}
 
 {% block content %}
-  <p class="lead">{% blocktranslate trimmed with round=round.name %}
+  <p class="lead">{% blocktrans trimmed with round=round.name %}
     The draw and/or motions for {{ round }} have yet to be released.
-  {% endblocktranslate %}</p>
+  {% endblocktrans %}</p>
 {% endblock %}

--- a/tabbycat/results/templates/public_ballot_set.html
+++ b/tabbycat/results/templates/public_ballot_set.html
@@ -3,45 +3,45 @@
 
 {% block page-title %}
   {% if use_code_names %}
-    {% blocktranslate trimmed with matchup=debate.matchup_codes %}
+    {% blocktrans trimmed with matchup=debate.matchup_codes %}
       Ballot for {{ matchup }}
-    {% endblocktranslate %}
+    {% endblocktrans %}
   {% else %}
-    {% blocktranslate trimmed with matchup=debate.matchup %}
+    {% blocktrans trimmed with matchup=debate.matchup %}
       Ballot for {{ matchup }}
-    {% endblocktranslate %}
+    {% endblocktrans %}
   {% endif %}
 {% endblock %}
 {% block head-title %}
   {% if use_code_names %}
-    {% blocktranslate trimmed with matchup=debate.matchup_codes %}
+    {% blocktrans trimmed with matchup=debate.matchup_codes %}
       Ballot for {{ matchup }}
-    {% endblocktranslate %}
+    {% endblocktrans %}
   {% else %}
-    {% blocktranslate trimmed with matchup=debate.matchup %}
+    {% blocktrans trimmed with matchup=debate.matchup %}
       Ballot for {{ matchup }}
-    {% endblocktranslate %}
+    {% endblocktrans %}
   {% endif %}
 {% endblock %}
 
 {% block sub-title %}
-  {% blocktranslate trimmed with round=debate.round.name room=debate.venue.display_name %}
+  {% blocktrans trimmed with round=debate.round.name room=debate.venue.display_name %}
     {{ round }} @ {{ room }}
-  {% endblocktranslate %}
+  {% endblocktrans %}
 {% endblock %}
 
 {% block page-subnav-sections %}
   {% if private_url %}
     <a class="btn btn-outline-primary" href="{% tournamenturl 'privateurls-person-index' url_key %}">
       <i data-feather="chevron-left"></i>
-      {% translate "Return to landing page" %}
+      {% trans "Return to landing page" %}
     </a>
   {% else %}
     <a class="btn btn-outline-primary" href="{% roundurl 'results-public-round' debate.round %}">
       <i data-feather="chevron-left"></i>
-      {% blocktranslate trimmed with round=debate.round.name %}
+      {% blocktrans trimmed with round=debate.round.name %}
         Return to Results for {{ round }}
-      {% endblocktranslate %}
+      {% endblocktrans %}
     </a>
   {% endif %}
 {% endblock %}
@@ -51,7 +51,7 @@
   {% if motion.text  %}
     <div class="card">
       <div class="card-body">
-        <h4 class="card-title">{% translate "Motion" %}</h4>
+        <h4 class="card-title">{% trans "Motion" %}</h4>
         {{ motion.text }}
       </div>
     </div>
@@ -64,11 +64,11 @@
       <div class="card-body pb-1">
         <h4 class="card-title">
           {% if sheet.adjudicator %}
-            {% blocktranslate trimmed with name=sheet.adjudicator.name institution=sheet.adjudicator.institution.code %}
+            {% blocktrans trimmed with name=sheet.adjudicator.name institution=sheet.adjudicator.institution.code %}
               From {{ name }} ({{ institution }})
-            {% endblocktranslate %}
+            {% endblocktrans %}
           {% else %}
-            {% translate "Scoresheet" %}
+            {% trans "Scoresheet" %}
           {% endif %}
         </h4>
 
@@ -89,32 +89,32 @@
               <li class="list-group-item list-group-item-{{ team.win_style }}">
                 {% if team.total %}
                   {% if use_code_names %}
-                    {% blocktranslate trimmed with name=team.team.code_name side=team.side %}
+                    {% blocktrans trimmed with name=team.team.code_name side=team.side %}
                       <em>Total for {{ name }} ({{ side }})</em>
-                    {% endblocktranslate %}
+                    {% endblocktrans %}
                   {% else %}
-                    {% blocktranslate trimmed with name=team.team.short_name side=team.side %}
+                    {% blocktrans trimmed with name=team.team.short_name side=team.side %}
                       <em>Total for {{ name }} ({{ side }})</em>
-                    {% endblocktranslate %}
+                    {% endblocktrans %}
                   {% endif %}
                   <span class="badge badge-secondary float-right">
                     {{ team.total }}
                   </span>
                 {% else %}
                   {% if use_code_names %}
-                    {% blocktranslate trimmed with name=team.team.code_name side=team.side %}
+                    {% blocktrans trimmed with name=team.team.code_name side=team.side %}
                       <em>{{ name }} ({{ side }})</em>
-                    {% endblocktranslate %}
+                    {% endblocktrans %}
                   {% else %}
-                    {% blocktranslate trimmed with name=team.team.short_name side=team.side %}
+                    {% blocktrans trimmed with name=team.team.short_name side=team.side %}
                       <em>{{ name }} ({{ side }})</em>
-                    {% endblocktranslate %}
+                    {% endblocktrans %}
                   {% endif %}
                   <span class="badge badge-secondary float-right">
                     {% if team.rank is not None %}
                       {{ team.rank|ordinal }}
                     {% else %}
-                      {% if team.win %}{% translate "Won" %}{% else %}{% translate "Lost" %}{% endif %}
+                      {% if team.win %}{% trans "Won" %}{% else %}{% trans "Lost" %}{% endif %}
                     {% endif %}
                   </span>
                 {% endif %}

--- a/tabbycat/results/templates/public_ballot_set_error.html
+++ b/tabbycat/results/templates/public_ballot_set_error.html
@@ -1,9 +1,9 @@
 {% extends "base.html" %}
 {% load debate_tags i18n %}
 
-{% block page-title %}{% translate "Ballot Not Available" %}{% endblock %}
+{% block page-title %}{% trans "Ballot Not Available" %}{% endblock %}
 {% block head-title %}
-  <h2><span class="emoji">😾</span> {% translate "Ballot Not Available" %}</h2>
+  <h2><span class="emoji">😾</span> {% trans "Ballot Not Available" %}</h2>
 {% endblock %}
 
 {% block content %}
@@ -11,9 +11,9 @@
     <div class="card-body">
       {{ message }}
       {% tournamenturl 'tournament-public-index' as url %}
-      {% blocktranslate trimmed %}
+      {% blocktrans trimmed %}
         <a href="{{ url }}">Back to the tournament home page.</a>
-      {% endblocktranslate %}
+      {% endblocktrans %}
     </div>
   </div>
 {% endblock %}

--- a/tabbycat/results/templates/public_enter_results.html
+++ b/tabbycat/results/templates/public_enter_results.html
@@ -6,26 +6,26 @@
 {% block page-alerts %}
 
   {% if form.scoresheets|length > 1 %}
-    {% blocktranslate trimmed with adjudicator=adjudicator.name asvar message %}
+    {% blocktrans trimmed with adjudicator=adjudicator.name asvar message %}
       {{ adjudicator }}, note that you must enter <strong>all of the ballots</strong> from your panel, not just your own!
-    {% endblocktranslate %}
+    {% endblocktrans %}
     {% include "components/alert.html" with type="warning" %}
   {% endif %}
 
   {% if prefilled %}
-    {% blocktranslate trimmed asvar message %}
+    {% blocktrans trimmed asvar message %}
       Some information, such as speaker order, shown is based on a previous ballot. If anything is incorrect, please correct it and contact the tab team.
-    {% endblocktranslate %}
+    {% endblocktrans %}
     {% include "components/alert.html" with type="warning" %}
   {% endif %}
 
   {% with nballotsubs=all_ballotsubs.count %}
     {% if nballotsubs > 0 %}
-      {% blocktranslate trimmed with nsubmissions=nballotsubs|apnumber count counter=nballotsubs asvar message %}
+      {% blocktrans trimmed with nsubmissions=nballotsubs|apnumber count counter=nballotsubs asvar message %}
         This form has already been submitted <strong>once</strong>. Please contact a tab official after submitting your form.
       {% plural %}
         This form has already been submitted <strong>{{ nsubmissions }}</strong> times. Please contact a tab official after submitting your form.
-      {% endblocktranslate %}
+      {% endblocktrans %}
       {% include "components/alert.html" with type="danger" %}
     {% endif %}
   {% endwith %}
@@ -60,12 +60,12 @@
         <input id="id_debate_result_status" type="hidden" name="debate_result_status" value="{{ debate.STATUS_DRAFT }}" />
         <input id="id_discarded" type="hidden" name="discarded" />
         <input id="id_confirmed" type="hidden" name="confirmed" />
-        <input class="save btn btn-success btn-block " type="submit" value="{% translate 'Submit Ballot(s)' %}" tabindex="{{ form.nexttabindex }}"/>
+        <input class="save btn btn-success btn-block " type="submit" value="{% trans 'Submit Ballot(s)' %}" tabindex="{{ form.nexttabindex }}"/>
         <div class="text-center pt-3 small text-muted">
-          {% translate "When submitting this form your IP address will be stored for logging purposes." %}
+          {% trans "When submitting this form your IP address will be stored for logging purposes." %}
           {% if pref.enable_ballot_receipts %}
             <br />
-            {% translate "Emails will be sent to adjudicators when the ballot is confirmed." %}
+            {% trans "Emails will be sent to adjudicators when the ballot is confirmed." %}
           {% endif %}
         </div>
       </div>

--- a/tabbycat/results/templates/public_enter_results_error.html
+++ b/tabbycat/results/templates/public_enter_results_error.html
@@ -1,10 +1,10 @@
 {% extends "base.html" %}
 {% load static i18n %}
 
-{% block head-title %}{% blocktranslate trimmed with adjudicator=adjudicator.name %}
+{% block head-title %}{% blocktrans trimmed with adjudicator=adjudicator.name %}
   No Result to Enter ({{ adjudicator }})
-{% endblocktranslate %}{% endblock %}
-{% block page-title %}{% translate "No Result to Enter" %}{% endblock %}
+{% endblocktrans %}{% endblock %}
+{% block page-title %}{% trans "No Result to Enter" %}{% endblock %}
 {% block extra-head %}<meta name="robots" content="noindex" />{% endblock %}
 
 {% block content %}

--- a/tabbycat/results/templates/public_results_for_round.html
+++ b/tabbycat/results/templates/public_results_for_round.html
@@ -4,10 +4,10 @@
 {% block page-subnav-sections %}
   <div class="btn-group">
     <a class="btn btn-outline-primary {% if view_type == 'team' %}active{% endif %}" href="?view=team">
-      {% translate "View by Team" %}
+      {% trans "View by Team" %}
     </a>
     <a class="btn btn-outline-primary {% if view_type == 'debate' %}active{% endif %}" href="?view=debate">
-      {% translate "View by Debate" %}
+      {% trans "View by Debate" %}
     </a>
   </div>
   {{ block.super }}

--- a/tabbycat/results/templates/public_results_index.html
+++ b/tabbycat/results/templates/public_results_index.html
@@ -1,17 +1,17 @@
 {% extends "base.html" %}
 {% load debate_tags i18n %}
 
-{% block head-title %}<span class="emoji">💥</span> {% translate "Results" %}{% endblock %}
-{% block page-title %}💥 {% translate "Results" %}{% endblock %}
+{% block head-title %}<span class="emoji">💥</span> {% trans "Results" %}{% endblock %}
+{% block page-title %}💥 {% trans "Results" %}{% endblock %}
 
 {% block content %}
 
 <ul class="list-group">
   {% for r in tournament.rounds_with_released_results %}
     {% roundurl 'results-public-round' r as url %}
-    {% blocktranslate trimmed with round=r.name asvar text %}
+    {% blocktrans trimmed with round=r.name asvar text %}
       Results for {{ round }}
-    {% endblocktranslate %}
+    {% endblocktrans %}
     {% include "components/item-action.html" with icon="trending-up" %}
   {% endfor %}
 </ul>

--- a/tabbycat/results/templates/public_results_not_available.html
+++ b/tabbycat/results/templates/public_results_not_available.html
@@ -1,17 +1,17 @@
 {% extends "base.html" %}
 {% load i18n %}
 
-{% block page-title %}{% translate "Results Not Available" %}{% endblock %}
+{% block page-title %}{% trans "Results Not Available" %}{% endblock %}
 {% block head-title %}
-  <h2><span class="emoji">😾</span> {% translate "Results Not Available" %}</h2>
+  <h2><span class="emoji">😾</span> {% trans "Results Not Available" %}</h2>
 {% endblock %}
 
 {% block content %}
   <div class="card">
     <div class="card-body">
-      <p>{% blocktranslate trimmed with round=round.name %}
+      <p>{% blocktrans trimmed with round=round.name %}
         The results for {{ round }} aren't yet available.
-      {% endblocktranslate %} <span class="emoji">😶</span></p>
+      {% endblocktrans %} <span class="emoji">😶</span></p>
     </div>
   </div>
 {% endblock %}

--- a/tabbycat/results/templates/public_results_silent.html
+++ b/tabbycat/results/templates/public_results_silent.html
@@ -1,17 +1,17 @@
 {% extends "base.html" %}
 {% load i18n %}
 
-{% block page-title %}{% translate "Results Not Available" %}{% endblock %}
+{% block page-title %}{% trans "Results Not Available" %}{% endblock %}
 {% block head-title %}
-  <h2><span class="emoji">😾</span> {% translate "Results Not Available" %}</h2>
+  <h2><span class="emoji">😾</span> {% trans "Results Not Available" %}</h2>
 {% endblock %}
 
 {% block content %}
   <div class="card">
     <div class="card-body">
-      <p>{% blocktranslate trimmed with round=round.name %}
+      <p>{% blocktrans trimmed with round=round.name %}
         {{ round }} is a silent round.
-      {% endblocktranslate %} <span class="emoji">😶</span></p>
+      {% endblocktrans %} <span class="emoji">😶</span></p>
     </div>
   </div>
 {% endblock %}

--- a/tabbycat/standings/templates/current_standings.html
+++ b/tabbycat/standings/templates/current_standings.html
@@ -3,20 +3,20 @@
 
 {% block content %}
   {% if not pref.all_results_released %}
-    {% translate "It also excludes results from silent rounds (if any) and from the current round." as silent_round_sentence %}
+    {% trans "It also excludes results from silent rounds (if any) and from the current round." as silent_round_sentence %}
   {% endif %}
   {% if pref.teams_in_debate == 'bp' %}
-    {% blocktranslate trimmed asvar p1 %}
+    {% blocktrans trimmed asvar p1 %}
       This list is sorted by team points, then alphabetically by team name. It
       does not indicate each team's ranking within each bracket.
       {{ silent_round_sentence }}
-    {% endblocktranslate %}
+    {% endblocktrans %}
   {% else %}
-    {% blocktranslate trimmed asvar p1 %}
+    {% blocktrans trimmed asvar p1 %}
       This list is sorted by number of wins, then alphabetically by team name.
       It does not indicate each team's ranking within each bracket.
       {{ silent_round_sentence }}
-    {% endblocktranslate %}
+    {% endblocktrans %}
   {% endif %}
   {% include "components/explainer-card.html" with type="info" %}
 

--- a/tabbycat/standings/templates/current_standings_no_round.html
+++ b/tabbycat/standings/templates/current_standings_no_round.html
@@ -3,7 +3,7 @@
 
 {% block page-alerts %}
 
-  {% translate "There aren't any rounds for which results are available." as message %}
+  {% trans "There aren't any rounds for which results are available." as message %}
   {% include "components/alert.html" with type="info" icon="alert-circle" %}
 
 {% endblock %}

--- a/tabbycat/standings/templates/reply_standings.html
+++ b/tabbycat/standings/templates/reply_standings.html
@@ -3,23 +3,23 @@
 
 {% block page-alerts %}
 
-  {% translate "Reply speakers are ranked by their <strong>average reply score</strong>." as p1 %}
+  {% trans "Reply speakers are ranked by their <strong>average reply score</strong>." as p1 %}
 
   {% if pref.standings_missed_replies > 0 %}
-    {% blocktranslate trimmed with count=pref.standings_missed_replies asvar p2 %}
+    {% blocktrans trimmed with count=pref.standings_missed_replies asvar p2 %}
       Speakers can miss up to {{ count }} reply speeches before they are omitted from
       the replies tab.
-    {% endblocktranslate %}
+    {% endblocktrans %}
   {% else %}
-    {% translate "All reply speakers appear in these standings, no matter how many replies they've missed." as p2 %}
+    {% trans "All reply speakers appear in these standings, no matter how many replies they've missed." as p2 %}
   {% endif %}
 
   {% tournamenturl 'options-tournament-section' section='standings' as standings_config_url %}
-  {% blocktranslate trimmed asvar p3 %}
+  {% blocktrans trimmed asvar p3 %}
     These settings can be changed in the
     <a href="{{ standings_config_url }}" class="alert-link">Standings section
     of this tournament's configuration</a>.
-  {% endblocktranslate %}
+  {% endblocktrans %}
   {% include "components/explainer-card.html" with type="info" %}
 
 {% endblock %}

--- a/tabbycat/standings/templates/speaker_standings.html
+++ b/tabbycat/standings/templates/speaker_standings.html
@@ -8,44 +8,44 @@
   {% tournamenturl 'options-tournament-section' section='standings' as standings_config_url %}
 
   {% if pref.speaker_standings_precedence|length == 0 %}
-    {% blocktranslate trimmed asvar message %}
+    {% blocktrans trimmed asvar message %}
       The speaker standings precedence is empty. This means that speakers aren't
       ranked according to any metrics, so everyone is first equal. If this isn't
       what you intended, set the speaker standings precedence in the
       <a href="{{ standings_config_url }}" class="alert-link">Standings section
       of this tournament's configuration</a>. In most
       tournaments, the first metric should be total or average.
-    {% endblocktranslate %}
+    {% endblocktrans %}
     {% include "components/alert.html" with type="warning" icon="alert-circle" %}
   {% endif %}
 
   {% if pref.speaker_standings_precedence.0 == 'average' %}
-    {% translate "Speakers are ranked by their <strong>average score</strong>." as p1 %}
+    {% trans "Speakers are ranked by their <strong>average score</strong>." as p1 %}
   {% elif pref.speaker_standings_precedence.0 == 'total' %}
-    {% blocktranslate trimmed asvar p1 %}
+    {% blocktrans trimmed asvar p1 %}
       Speakers are ranked by their <strong>total score</strong>.
       Any speaker who misses a single debate will be severely punished in these rankings.
-    {% endblocktranslate %}
+    {% endblocktrans %}
   {% endif %}
 
   {% if pref.standings_missed_debates >= 0 %}
-    {% blocktranslate trimmed with count=pref.standings_missed_debates asvar p2 %}
+    {% blocktrans trimmed with count=pref.standings_missed_debates asvar p2 %}
       Speakers can miss up to {{ count }} debates before they are omitted from
       the speaker tab.
-    {% endblocktranslate %}
+    {% endblocktrans %}
   {% else %}
-    {% translate "All speakers appear in these standings, no matter how many debates they've missed." as p2 %}
+    {% trans "All speakers appear in these standings, no matter how many debates they've missed." as p2 %}
   {% endif %}
 
-  {% blocktranslate trimmed asvar p3 %}
+  {% blocktrans trimmed asvar p3 %}
     These settings can be changed in the
     <a href="{{ standings_config_url }}" class="alert-link">Standings section
     of this tournament's configuration</a>.
-  {% endblocktranslate %}
+  {% endblocktrans %}
   {% include "components/explainer-card.html" with type="info" %}
 
   {% if 'count' not in pref.speaker_standings_precedence and 'count' not in pref.speaker_standings_extra_metrics and pref.standings_missed_debates >= 0 %}
-    {% blocktranslate trimmed asvar message %}
+    {% blocktrans trimmed asvar message %}
       Enforcing the limit on the number of missed debates requires the "number
       of speeches given" metric to be included in the speaker standings
       calculations, so it's been automatically added. To remove this warning
@@ -53,7 +53,7 @@
       <strong>Speaker standings extra metrics</strong> in the
       <a href="{{ standings_config_url }}" class="alert-link">Standings section
       of this tournament's configuration</a>.
-    {% endblocktranslate %}
+    {% endblocktrans %}
     {% include "components/alert.html" with type="warning" icon="alert-circle" %}
   {% endif %}
 

--- a/tabbycat/standings/templates/standings_diversity.html
+++ b/tabbycat/standings/templates/standings_diversity.html
@@ -1,8 +1,8 @@
 {% extends "standings_base.html" %}
 {% load debate_tags static i18n %}
 
-{% block page-title %}🗃{% translate "Diversity Overview" %}{% endblock %}
-{% block head-title %}<span class="emoji">🗃</span>{% translate "Diversity Overview" %}{% endblock %}
+{% block page-title %}🗃{% trans "Diversity Overview" %}{% endblock %}
+{% block head-title %}<span class="emoji">🗃</span>{% trans "Diversity Overview" %}{% endblock %}
 {% block diversity_active %}active{% endblock %}
 
 {% block page-subnav-sections %}
@@ -19,12 +19,12 @@
 
 {% block page-alerts %}
 
-  {% blocktranslate trimmed asvar text %}
+  {% blocktrans trimmed asvar text %}
     The results data displayed here is presented without tests for statistical significance.
     Correlations should not be automatically considered reliable; particularly at small tournaments.
     A 'region' is a customisable category assigned to a set of institutions, and counted using the
     number of participants assigned to those institutions.
-  {% endblocktranslate %}
+  {% endblocktrans %}
   {% include "components/explainer-card.html" with type="info" %}
 
 {% endblock %}
@@ -34,13 +34,13 @@
   <div class="d-lg-flex justify-content-lg-between">
     <div class="nav nav-pills btn-group">
       <button class="btn btn-primary gender-display gender-nm h6">
-        {% translate "Non-cis male identifying" %}
+        {% trans "Non-cis male identifying" %}
       </button>
       <button class="btn btn-primary gender-display gender-male h6">
-        {% translate "Cis-male identifying" %}
+        {% trans "Cis-male identifying" %}
       </button>
       <button class="btn btn-primary gender-display gender-unknown h6">
-        {% translate "Unspecified/unrecorded" %}
+        {% trans "Unspecified/unrecorded" %}
       </button>
     </div>
     <div class="nav nav-pills btn-group mt-md-0 mt-3">

--- a/tabbycat/standings/templates/standings_index.html
+++ b/tabbycat/standings/templates/standings_index.html
@@ -2,8 +2,8 @@
 {% load static %}
 {% load debate_tags i18n %}
 
-{% block head-title %}<span class="emoji">📊</span>{% translate "Standings" %}{% endblock %}
-{% block page-title %}{% translate "Standings" %}{% endblock %}
+{% block head-title %}<span class="emoji">📊</span>{% trans "Standings" %}{% endblock %}
+{% block page-title %}{% trans "Standings" %}{% endblock %}
 
 {% block standings_active %}active{% endblock %}
 
@@ -15,17 +15,17 @@
     <!-- List group -->
     <ul class="list-group list-group-flush">
       <li class="list-group-item">
-        <h5 class="card-title mb-0">{% translate "Top Speaks" %}</h5>
+        <h5 class="card-title mb-0">{% trans "Top Speaks" %}</h5>
       </li>
       {% for top_speak in top_speaks %}
         <li class="list-group-item">
-          {% blocktranslate trimmed with speaker=top_speak.speaker round=top_speak.debate_team.debate.round.abbreviation %}
+          {% blocktrans trimmed with speaker=top_speak.speaker round=top_speak.debate_team.debate.round.abbreviation %}
           {{ speaker }} in {{ round }}
-          {% endblocktranslate %}
+          {% endblocktrans %}
           <span class="badge badge-secondary float-right">{{ top_speak.score|floatformat }}</span>
         </li>
       {% empty %}
-        <li class="list-group-item">{% translate "No data yet" %}</li>
+        <li class="list-group-item">{% trans "No data yet" %}</li>
       {% endfor %}
     </ul>
   </div>
@@ -34,17 +34,17 @@
     <!-- List group -->
     <ul class="list-group list-group-flush">
       <li class="list-group-item">
-        <h5 class="card-title mb-0">{% translate "Bottom Speaks" %}</h5>
+        <h5 class="card-title mb-0">{% trans "Bottom Speaks" %}</h5>
       </li>
       {% for bottom_speak in bottom_speaks %}
         <li class="list-group-item">
-          {% blocktranslate trimmed with speaker=bottom_speak.speaker round=bottom_speak.debate_team.debate.round.abbreviation %}
+          {% blocktrans trimmed with speaker=bottom_speak.speaker round=bottom_speak.debate_team.debate.round.abbreviation %}
           {{ speaker }} in {{ round }}
-          {% endblocktranslate %}
+          {% endblocktrans %}
           <span class="badge badge-secondary float-right">{{ bottom_speak.score|floatformat }}</span>
         </li>
       {% empty %}
-      <li class="list-group-item">{% translate "No data yet" %}</li>{% endfor %}
+      <li class="list-group-item">{% trans "No data yet" %}</li>{% endfor %}
     </ul>
   </div>
 
@@ -53,17 +53,17 @@
       <!-- List group -->
       <ul class="list-group list-group-flush">
         <li class="list-group-item">
-          <h5 class="card-title mb-0">{% translate "Largest Margins" %}</h5>
+          <h5 class="card-title mb-0">{% trans "Largest Margins" %}</h5>
         </li>
         {% for top_margin in top_margins %}
           <li class="list-group-item">
-            {% blocktranslate trimmed with team=top_margin.debate_team.team.short_name opp=top_margin.debate_team.opponent.team.short_name round=top_margin.debate_team.debate.round.abbreviation %}
+            {% blocktrans trimmed with team=top_margin.debate_team.team.short_name opp=top_margin.debate_team.opponent.team.short_name round=top_margin.debate_team.debate.round.abbreviation %}
             {{ team }} vs {{ opp }} in {{ round }}
-            {% endblocktranslate %}
+            {% endblocktrans %}
             <span class="badge badge-secondary float-right">{{ top_margin.margin|floatformat }}</span>
           </li>
         {% empty %}
-          <li class="list-group-item">{% translate "No data yet" %}</li>
+          <li class="list-group-item">{% trans "No data yet" %}</li>
         {% endfor %}
       </ul>
     </div>
@@ -74,17 +74,17 @@
       <!-- List group -->
       <ul class="list-group list-group-flush">
         <li class="list-group-item">
-          <h5 class="card-title mb-0">{% translate "Closest Margins" %}</h5>
+          <h5 class="card-title mb-0">{% trans "Closest Margins" %}</h5>
         </li>
         {% for bottom_margin in bottom_margins %}
           <li class="list-group-item">
-            {% blocktranslate trimmed with team=bottom_margin.debate_team.team.short_name opp=bottom_margin.debate_team.opponent.team.short_name round=bottom_margin.debate_team.debate.round.abbreviation %}
+            {% blocktrans trimmed with team=bottom_margin.debate_team.team.short_name opp=bottom_margin.debate_team.opponent.team.short_name round=bottom_margin.debate_team.debate.round.abbreviation %}
             {{ team }} vs {{ opp }} in {{ round }}
-            {% endblocktranslate %}
+            {% endblocktrans %}
             <span class="badge badge-secondary float-right">{{ bottom_margin.margin|floatformat }}</span>
           </li>
         {% empty %}
-          <li class="list-group-item">{% translate "No data yet" %}</li>
+          <li class="list-group-item">{% trans "No data yet" %}</li>
         {% endfor %}
       </ul>
     </div>
@@ -95,17 +95,17 @@
       <!-- List group -->
       <ul class="list-group list-group-flush">
         <li class="list-group-item">
-          <h5 class="card-title mb-0">{% translate "Top Team Scores" %}</h5>
+          <h5 class="card-title mb-0">{% trans "Top Team Scores" %}</h5>
         </li>
         {% for top_score in top_team_scores %}
           <li class="list-group-item">
-            {% blocktranslate trimmed with team=top_score.debate_team.team.short_name round=top_score.debate_team.debate.round.abbreviation %}
+            {% blocktrans trimmed with team=top_score.debate_team.team.short_name round=top_score.debate_team.debate.round.abbreviation %}
             {{ team }} in {{ round }}
-            {% endblocktranslate %}
+            {% endblocktrans %}
             <span class="badge badge-secondary float-right">{{ top_score.score }}</span>
           </li>
         {% empty %}
-          <li class="list-group-item">{% translate "No data yet" %}</li>
+          <li class="list-group-item">{% trans "No data yet" %}</li>
         {% endfor %}
       </ul>
     </div>
@@ -116,17 +116,17 @@
       <!-- List group -->
       <ul class="list-group list-group-flush">
         <li class="list-group-item">
-          <h5 class="card-title mb-0">{% translate "Bottom Team Scores" %}</h5>
+          <h5 class="card-title mb-0">{% trans "Bottom Team Scores" %}</h5>
         </li>
         {% for bottom_score in bottom_team_scores %}
           <li class="list-group-item">
-            {% blocktranslate trimmed with team=bottom_score.debate_team.team.short_name round=bottom_score.debate_team.debate.round.abbreviation %}
+            {% blocktrans trimmed with team=bottom_score.debate_team.team.short_name round=bottom_score.debate_team.debate.round.abbreviation %}
             {{ team }} in {{ round }}
-            {% endblocktranslate %}
+            {% endblocktrans %}
             <span class="badge badge-secondary float-right">{{ bottom_score.score }}</span>
           </li>
         {% empty %}
-          <li class="list-group-item">{% translate "No data yet" %}</li>
+          <li class="list-group-item">{% trans "No data yet" %}</li>
         {% endfor %}
       </ul>
     </div>
@@ -137,7 +137,7 @@
       <!-- List group -->
       <ul class="list-group list-group-flush">
         <li class="list-group-item">
-          <h5 class="card-title mb-0">{% translate "Most/Least Popular Motions" %}</h5>
+          <h5 class="card-title mb-0">{% trans "Most/Least Popular Motions" %}</h5>
         </li>
         {% for top_motion in top_motions %}
           <li class="list-group-item">
@@ -149,7 +149,7 @@
             <span class="badge badge-secondary float-right">{{ top_motion.ballotsubmission__count }}</span>
           </li>
         {% empty %}
-          <li class="list-group-item">{% translate "No data yet" %}</li>
+          <li class="list-group-item">{% trans "No data yet" %}</li>
         {% endfor %}
         <li class="list-group-item disabled">
         ...
@@ -164,7 +164,7 @@
             <span class="badge badge-secondary float-right">{{ bottom_motion.ballotsubmission__count }}</span>
           </li>
         {% empty %}
-          <li class="list-group-item">{% translate "No data yet" %}</li>
+          <li class="list-group-item">{% trans "No data yet" %}</li>
         {% endfor %}
       </ul>
     </div>
@@ -174,7 +174,7 @@
     <!-- List group -->
     <ul class="list-group list-group-flush">
       <li class="list-group-item">
-        <h5 class="card-title mb-0">{% translate "Average Speaks" %}</h5>
+        <h5 class="card-title mb-0">{% trans "Average Speaks" %}</h5>
       </li>
       {% if round_speaks %}
         {% for round_speak in round_speaks %}
@@ -183,7 +183,7 @@
             <span class="badge badge-secondary float-right">{{ round_speak.score|floatformat }}</span>
           </li>
         {% empty %}
-          <li class="list-group-item">{% translate "No data yet" %}</li>
+          <li class="list-group-item">{% trans "No data yet" %}</li>
         {% endfor %}
       {% endif %}
     </ul>

--- a/tabbycat/standings/templates/standings_menu.html
+++ b/tabbycat/standings/templates/standings_menu.html
@@ -3,20 +3,20 @@
 <div class="btn-group flex-wrap">
   <a class="btn btn-outline-primary {% if standings_overview_nav %}active{% endif %}"
      href="{% roundurl 'standings-index' current_round %}">
-    {% translate "Overview" %}
+    {% trans "Overview" %}
   </a>
 </div>
 
 <div class="btn-group flex-wrap">
   {% if tournament.break_categories_nongeneral.count > 0 %}
-    <div class="btn btn-outline-primary disabled">{% translate "Teams" %}</div>
+    <div class="btn btn-outline-primary disabled">{% trans "Teams" %}</div>
   {% endif %}
   <a class="btn btn-outline-primary {% if standings_team_nav %}active{% endif %}"
      href="{% roundurl 'standings-team' current_round %}">
     {% if tournament.break_categories_nongeneral.count > 0 %}
-      {% translate "All" context "All [Teams]" %}
+      {% trans "All" context "All [Teams]" %}
     {% else %}
-      {% translate "Teams" %}
+      {% trans "Teams" %}
     {% endif %}
   </a>
   {% for category in tournament.break_categories_nongeneral %}
@@ -29,30 +29,30 @@
 
 <div class="btn-group flex-wrap">
   {% if tournament.speakercategory_set.all.count > 0 or pref.reply_scores_enabled %}
-    <div class="btn btn-outline-primary disabled">{% translate "Speakers" %}</div>
+    <div class="btn btn-outline-primary disabled">{% trans "Speakers" %}</div>
   {% endif %}
   <a class="btn btn-outline-primary {% if standings_speaker_nav %}active{% endif %}"
      href="{% roundurl 'standings-speaker' current_round %}">
     {% if pref.reply_scores_enabled %}
-      {% translate "Substantives" context "Substantive speeches" %}
+      {% trans "Substantives" context "Substantive speeches" %}
     {% elif tournament.speakercategory_set.all.count > 0 %}
-      {% translate "All" context "All [Speakers]" %}
+      {% trans "All" context "All [Speakers]" %}
     {% else %}
-      {% translate "Speakers " %}
+      {% trans "Speakers " %}
     {% endif %}
   </a>
   {% for category in tournament.speakercategory_set.all %}
     <a class="btn btn-outline-primary"
        href="{% roundurl 'standings-speaker-category' round=current_round category=category.slug %}">
-      {% blocktranslate trimmed with category=category.name %}
+      {% blocktrans trimmed with category=category.name %}
         {{ category }}
-      {% endblocktranslate %}
+      {% endblocktrans %}
     </a>
   {% endfor %}
   {% if pref.reply_scores_enabled %}
     <a class="btn btn-outline-primary {% if standings_reply_nav %}active{% endif %}"
        href="{% roundurl 'standings-reply' current_round %}">
-      {% translate "Replies" %}
+      {% trans "Replies" %}
     </a>
   {% endif %}
 </div>
@@ -60,10 +60,10 @@
 {% if pref.enable_motion_reuse %}
   <div class="btn-group">
     <a class="btn btn-outline-primary {% if motions_statistics_nav %}active{% endif %}" href="{% tournamenturl 'motions-global-statistics' %}">
-      {% translate "Motions" %}
+      {% trans "Motions" %}
     </a>
     <a class="btn btn-outline-primary {% if motions_statistics_nav %}active{% endif %}" href="{% tournamenturl 'motions-statistics' %}">
-      {% translate "By Round" %}
+      {% trans "By Round" %}
     </a>
   </div>
 {% endif %}
@@ -73,12 +73,12 @@
   {% if not pref.enable_motion_reuse %}
     <a class="btn btn-outline-primary {% if motions_statistics_nav %}active{% endif %}"
        href="{% tournamenturl 'motions-statistics' %}">
-      {% translate "Motions" %}
+      {% trans "Motions" %}
     </a>
   {% endif %}
   <a class="btn btn-outline-primary {% if standings_diversity_nav %}active{% endif %}"
      href="{% roundurl 'standings-diversity' current_round %}">
-    {% translate "Diversity" %}
+    {% trans "Diversity" %}
   </a>
 
 </div>

--- a/tabbycat/standings/templates/team_standings.html
+++ b/tabbycat/standings/templates/team_standings.html
@@ -7,14 +7,14 @@
 
   {% if pref.team_standings_precedence|length == 0 %}
     {% tournamenturl 'options-tournament-section' section='standings' as standings_config_url %}
-    {% blocktranslate trimmed asvar message %}
+    {% blocktrans trimmed asvar message %}
       The team standings precedence is empty. This means that teams aren't
       ranked according to any metrics, so everyone is first equal. If this isn't
       what you intended, set the team standings precedence in the
       <a href="{{ standings_config_url }}" class="alert-link">Standings section
       of this tournament's configuration</a>. In most
       tournaments, the first metric should be points or wins.
-    {% endblocktranslate %}
+    {% endblocktrans %}
     {% include "components/alert.html" with type="warning" icon="alert-circle" %}
   {% endif %}
 

--- a/tabbycat/templates/admin/delete_protected_message.html
+++ b/tabbycat/templates/admin/delete_protected_message.html
@@ -1,8 +1,8 @@
 {% load i18n %}
 {% if protected %}
 <p style="margin-top: 10px">
-  {% blocktranslate trimmed %}
+  {% blocktrans trimmed %}
   You need to delete the above objects first.
-  {% endblocktranslate %}
+  {% endblocktrans %}
 </p>
 {% endif %}

--- a/tabbycat/templates/admin/style_guide.html
+++ b/tabbycat/templates/admin/style_guide.html
@@ -27,10 +27,10 @@
 
 <h6 class="mt-5">Info Cards (explain crucial information on a page)</h6>
 
-{% blocktranslate trimmed asvar p1 %}This style of info card announces critical information. <a href="">Link</a>.{% endblocktranslate %}
+{% blocktrans trimmed asvar p1 %}This style of info card announces critical information. <a href="">Link</a>.{% endblocktrans %}
 {% include "components/explainer-card.html" with type="warning" %}
 
-{% blocktranslate trimmed asvar p1 %}This style of info card announces general <a href="">information</a>.{% endblocktranslate %}
+{% blocktrans trimmed asvar p1 %}This style of info card announces general <a href="">information</a>.{% endblocktrans %}
 {% include "components/explainer-card.html" with type="info" p2="This is a second paragraph" %}
 
 <h6 class="mt-5">Action Cards (i.e. for checkins)</h6>
@@ -157,8 +157,8 @@
   <div class="list-group list-group-flush">
   <form>
 
-    {% translate "Form Title" context "page title" as title %}
-    {% translate "Sub Title Title" as text %}
+    {% trans "Form Title" context "page title" as title %}
+    {% trans "Sub Title Title" as text %}
     {% include "components/form-title.html" with icon="feather" %}
 
     <div class="list-group-item pb-4">
@@ -194,8 +194,8 @@
 
     </div>
 
-    {% translate "Log In" context "button" as title %}
-    {% translate "I forgot my password" context "button" as subtitle %}
+    {% trans "Log In" context "button" as title %}
+    {% trans "I forgot my password" context "button" as subtitle %}
     {% url 'password_reset' as suburl %}
     {% include "components/form-submit.html" %}
 

--- a/tabbycat/templates/base.html
+++ b/tabbycat/templates/base.html
@@ -7,16 +7,16 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-  <title>{% if tournament %}{{ tournament.short_name }}{% else %}{% translate "Tabbycat" %}{% endif %} | {% if page_title %}{{ page_title }}{% else %}{% block page-title %}{% endblock %}{% endif %}</title>
+  <title>{% if tournament %}{{ tournament.short_name }}{% else %}{% trans "Tabbycat" %}{% endif %} | {% if page_title %}{{ page_title }}{% else %}{% block page-title %}{% endblock %}{% endif %}</title>
 
   {% if tournament %}
-    {% blocktranslate trimmed with tournament=tournament.short_name asvar meta_description %}
+    {% blocktrans trimmed with tournament=tournament.short_name asvar meta_description %}
       The tab for {{ tournament }} runs on Tabbycat, a source-available tab system for a variety of parliamentary debating formats
-    {% endblocktranslate %}
+    {% endblocktrans %}
   {% else %}
-    {% blocktranslate trimmed asvar meta_description %}
+    {% blocktrans trimmed asvar meta_description %}
       This tab runs on Tabbycat, a source-available tab system for a variety of parliamentary debating formats
-    {% endblocktranslate %}
+    {% endblocktrans %}
   {% endif %}
   <meta name="description" content="{{ meta_description }}" />
   <meta property="og:description" content="{{ meta_description }}" />

--- a/tabbycat/templates/components/form-errors.html
+++ b/tabbycat/templates/components/form-errors.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 
 {% if message == None %}
-  {% translate "Whoops! There was an error with one or more fields." as message %}
+  {% trans "Whoops! There was an error with one or more fields." as message %}
 {% endif %}
 
 {% include "components/alert.html" with type="danger" extra=errors|cut:'__all__' %}

--- a/tabbycat/templates/components/formset.html
+++ b/tabbycat/templates/components/formset.html
@@ -20,7 +20,7 @@
           <input class="btn btn-block btn-success" type="submit" name="submit" value="{{ save_text }}" />
         </div>
         <div class="col mt-md-0 mt-3">
-          <input class="btn btn-block btn-primary" type="submit" name="add_more" value="{% translate 'Save and Add More' %}" />
+          <input class="btn btn-block btn-primary" type="submit" name="add_more" value="{% trans 'Save and Add More' %}" />
         </div>
       </div>
     </div>

--- a/tabbycat/templates/errors/assistant_403.html
+++ b/tabbycat/templates/errors/assistant_403.html
@@ -1,19 +1,19 @@
 {% extends "base.html" %}
 {% load debate_tags i18n %}
 
-{% block page-title %}{% translate "Permission Denied (403)" %}{% endblock %}
+{% block page-title %}{% trans "Permission Denied (403)" %}{% endblock %}
 {% block head-title %}
-  <h2><span class="emoji">😾</span> {% translate "Permission Denied (403)" %}</h2>
+  <h2><span class="emoji">😾</span> {% trans "Permission Denied (403)" %}</h2>
 {% endblock %}
 
 {% block content %}
   <div class="card">
     <div class="card-body">
       {% tournamenturl 'tournament-assistant-home' as url %}
-      {% blocktranslate trimmed %}
+      {% blocktrans trimmed %}
         This assistant page isn't enabled for this tournament.
         <a href="{{ url }}">Back to the assistant home page.</a>
-      {% endblocktranslate %}
+      {% endblocktrans %}
     </div>
   </div>
 {% endblock %}

--- a/tabbycat/templates/errors/database_limit_warning.html
+++ b/tabbycat/templates/errors/database_limit_warning.html
@@ -1,4 +1,4 @@
-s{% load i18n humanize %}
+{% load i18n humanize %}
 {% comment %}
   The threshold for showing this message is governed by WarnAboutDatabaseUseMixin,
   not here. The variable `database_rows_used` won't be set if we don't want this
@@ -6,7 +6,7 @@ s{% load i18n humanize %}
   will never appear, but we need to provide the pluralization for other languages.
 {% endcomment %}
 {% if database_rows_used %}
-  {% blocktranslate trimmed with nrows=database_rows_used|intcomma count dbrows=database_rows_used asvar database_use_warning_message %}
+  {% blocktrans trimmed with nrows=database_rows_used|intcomma count dbrows=database_rows_used asvar database_use_warning_message %}
     You're currently using {{ nrows }} row in your database. If you haven't
     already upgraded your Heroku database to a paid tier, it's limited to a
     maximum of 10,000 rows. As you're close to this limit, you should
@@ -20,6 +20,6 @@ s{% load i18n humanize %}
     <strong>not create new tournaments</strong> on this site unless and until you've
     <a href="https://devcenter.heroku.com/articles/upgrading-heroku-postgres-databases">upgraded
     your database</a> to a paid tier.
-  {% endblocktranslate %}
+  {% endblocktrans %}
   {% include "components/alert.html" with type="warning" icon="alert-circle" message=database_use_warning_message %}
 {% endif %}

--- a/tabbycat/templates/errors/legacy_sendgrid_warning.html
+++ b/tabbycat/templates/errors/legacy_sendgrid_warning.html
@@ -8,7 +8,7 @@ utils.mixins.WarnAboutLegacySendgridConfigVarsMixin, and references to this
 template.
 {% endcomment %}
 {% if using_legacy_sendgrid_config_vars %}
-  {% blocktranslate trimmed asvar legacy_sendgrid_warning_message %}
+  {% blocktrans trimmed asvar legacy_sendgrid_warning_message %}
     It looks like you're using the old SendGrid config vars on Heroku,
     <code>SENDGRID_USERNAME</code> and <code>SENDGRID_PASSWORD</code>.
     These are now deprecated (as of version 2.6), and will stop working in a
@@ -16,6 +16,6 @@ template.
     <code>SENDGRID_API_KEY</code> instead. For more information, please see
     <a href="https://tabbycat.readthedocs.io/en/stable/features/notifications.html#configuring-an-email-provider">
         our documentation on this topic</a>.
-  {% endblocktranslate %}
+  {% endblocktrans %}
   {% include "components/alert.html" with type="warning" icon="alert-circle" message=legacy_sendgrid_warning_message %}
 {% endif %}

--- a/tabbycat/templates/errors/public_403.html
+++ b/tabbycat/templates/errors/public_403.html
@@ -1,9 +1,9 @@
 {% extends "base.html" %}
 {% load debate_tags i18n %}
 
-{% block page-title %}{% translate "Permission Denied (403)" %}{% endblock %}
+{% block page-title %}{% trans "Permission Denied (403)" %}{% endblock %}
 {% block head-title %}
-  <h2><span class="emoji">😾</span> {% translate "Permission Denied (403)" %}</h2>
+  <h2><span class="emoji">😾</span> {% trans "Permission Denied (403)" %}</h2>
 {% endblock %}
 
 {% block content %}
@@ -11,16 +11,16 @@
     <div class="card-body">
       {% if tournament %}
         {% tournamenturl 'tournament-public-index' as url %}
-        {% blocktranslate trimmed %}
+        {% blocktrans trimmed %}
           Whoops! This page isn't enabled for this tournament.
           <a href="{{ url }}">Back to the tournament home page.</a>
-        {% endblocktranslate %}
+        {% endblocktrans %}
       {% else %}
         {% url 'tabbycat-index' as url %}
-        {% blocktranslate trimmed %}
+        {% blocktrans trimmed %}
           Whoops! This page isn't enabled for this tournament.
           <a href="{{ url }}">Back to the home page.</a>
-        {% endblocktranslate %}
+        {% endblocktrans %}
       {% endif %}
     </div>
   </div>

--- a/tabbycat/templates/footer.html
+++ b/tabbycat/templates/footer.html
@@ -11,47 +11,47 @@
       <div class="col-lg-6 col-md-5">
         <h6 class="d-inline-block">
           {% if tournament and tabbycat_codename %}
-            {% blocktranslate trimmed %}{{ tournament }} runs on Tabbycat {{ tabbycat_version }} ({{ tabbycat_codename }}) {% endblocktranslate %}
+            {% blocktrans trimmed %}{{ tournament }} runs on Tabbycat {{ tabbycat_version }} ({{ tabbycat_codename }}) {% endblocktrans %}
           {% else %}
-            {% blocktranslate trimmed %}This site runs on Tabbycat {{ tabbycat_version }} ({{ tabbycat_codename }}) {% endblocktranslate %}
+            {% blocktrans trimmed %}This site runs on Tabbycat {{ tabbycat_version }} ({{ tabbycat_codename }}) {% endblocktrans %}
           {% endif %}
         </h6>
         <p class="text-muted">
-          {% blocktranslate trimmed %}
+          {% blocktrans trimmed %}
             Tabbycat is a source-available project developed by volunteers, and is free to use for tabbing non-profit, non-fundraising tournaments.
-          {% endblocktranslate %}
+          {% endblocktrans %}
           {% if tournament and tournament.billable_teams > 0 %}
-            {% blocktranslate trimmed with amount=tournament.billable_teams %}
+            {% blocktrans trimmed with amount=tournament.billable_teams %}
               For a tournament of this size, we suggest <a href="https://opencollective.com/tabbycat/contribute/licensing-29466/checkout?amount={{ amount }}">a donation of <strong>${{ amount }}</strong></a>.
-            {% endblocktranslate %}
+            {% endblocktrans %}
             <a href="https://opencollective.com/tabbycat">
-              {% translate "Learn more about donating." %}
+              {% trans "Learn more about donating." %}
             </a>
           {% else %}
-            {% blocktranslate trimmed %}
+            {% blocktrans trimmed %}
               <a href="https://opencollective.com/tabbycat">Donations to Tabbycat from individuals or organisations</a> are much appreciated.
-            {% endblocktranslate %}
+            {% endblocktrans %}
           {% endif %}
         </p>
       </div>
 
       <div class="col-lg-4 col-md-4 mt-2 mt-md-0">
-        <h6 class="d-inline-block">{% blocktranslate trimmed %}Still timing debates with the stopwatch app?{% endblocktranslate %}</h6>
+        <h6 class="d-inline-block">{% blocktrans trimmed %}Still timing debates with the stopwatch app?{% endblocktrans %}</h6>
         <p class="text-muted">
-          {% blocktranslate trimmed %}
+          {% blocktrans trimmed %}
             Using an app designed for debate timekeeping makes speaking and adjudicating easier!
             Check out <a href="https://itunes.apple.com/app/apple-store/id1156065589?pt=814172&ct=Tabbycat%20Installs&mt=8">Timekept</a> (iPhone/iPad)
             or <a href="https://play.google.com/store/apps/details?id=net.czlee.debatekeeper&referrer=utm_source%3Dtabbycat%26utm_medium%3Dfooter">Debatekeeper</a> (Android).
-          {% endblocktranslate %}
+          {% endblocktrans %}
         </p>
       </div>
 
       <div class="col-lg-2 col-md-3 mt-2 mt-md-0">
-        <h6 class="d-inline-block">{% blocktranslate trimmed %}Our Organisation{% endblocktranslate %}</h6>
+        <h6 class="d-inline-block">{% blocktrans trimmed %}Our Organisation{% endblocktrans %}</h6>
         <p class="text-muted">
-          {% blocktranslate trimmed %}
+          {% blocktrans trimmed %}
             Tabbycat is supported by the <a href="http://tabbycat-debate.org/">Tabbycat Debate Association</a>, a non-profit for advancing open debate technology.
-          {% endblocktranslate %}
+          {% endblocktrans %}
         </p>
       </div>
 
@@ -62,38 +62,38 @@
           <li class="nav-item p-2">
             <i data-feather="globe"></i>
             <a class="nav-link p-0 d-inline-block" href="#" data-toggle="modal" data-target="#setLanguageModal">
-              {% translate "Language" as local_language_label %}
+              {% trans "Language" as local_language_label %}
               Language {% if LANGUAGE_CODE != 'en' and local_language_label != "Language" %} / {{ local_language_label }}{% endif %}
             </a>
           </li>
           <li class="nav-item p-2">
             <i data-feather="github"></i>
             <a class="nav-link p-0 d-inline-block" href="https://github.com/TabbycatDebate/tabbycat/">
-              {% translate "GitHub" %}
+              {% trans "GitHub" %}
             </a>
           </li>
           <li class="nav-item p-2">
             <i data-feather="book"></i>
             <a class="nav-link p-0 d-inline-block" href="http://tabbycat.readthedocs.io/en/stable/">
-              {% translate "Documentation" %}
+              {% trans "Documentation" %}
             </a>
           </li>
           <li class="nav-item p-2">
             <i data-feather="help-circle"></i>
             <a class="nav-link p-0 d-inline-block" href="http://tabbycat.readthedocs.io/en/stable/about/support.html">
-              {% translate "Support" %}
+              {% trans "Support" %}
             </a>
           </li>
           <li class="nav-item p-2">
             <i data-feather="facebook"></i>
             <a class="nav-link p-0 d-inline-block" href="https://www.facebook.com/TabbycatDebate/">
-              {% translate "Facebook" %}
+              {% trans "Facebook" %}
             </a>
           </li>
           <li class="nav-item p-2">
             <i data-feather="upload-cloud"></i>
             <a class="nav-link p-0 d-inline-block" href="https://github.com/TabbycatDebate/tabbycat#%EF%B8%8F-installation">
-              {% translate "Set Up A Copy" %}
+              {% trans "Set Up A Copy" %}
             </a>
           </li>
         </ul>
@@ -107,7 +107,7 @@
   <div class="modal-dialog modal-dialog-centered" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title">{% translate "Change Language" %}</h5>
+        <h5 class="modal-title">{% trans "Change Language" %}</h5>
         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">&times;</span>
         </button>
@@ -124,7 +124,7 @@
                 </option>
               {% endfor %}
           </select>
-          <input class="btn btn-primary btn-block mt-3" type="submit" value="{% translate "Use this language" %}">
+          <input class="btn btn-primary btn-block mt-3" type="submit" value="{% trans "Use this language" %}">
         </form>
       </div>
     </div>

--- a/tabbycat/templates/nav/admin_nav.html
+++ b/tabbycat/templates/nav/admin_nav.html
@@ -6,9 +6,9 @@
     <a href="#tlisth" data-toggle="collapse" data-parent="#sidebar" aria-expanded="false"
        class="tournament-title d-flex justify-content-between align-items-center">
       <div class="mx-auto mx-md-0 text-center">
-        {% blocktranslate trimmed asvar logo_alt %}
+        {% blocktrans trimmed asvar logo_alt %}
           Tabbycat Logo
-        {% endblocktranslate %}
+        {% endblocktrans %}
         {% if on_local %}
           {% include "nav/logo_local.html" with width=18 height=18 alt=logo_alt %}
         {% else %}
@@ -25,13 +25,13 @@
     </a>
     <div class="collapse" id="tlisth">
       <a href="/" class="list-group-item" data-parent="#titleh">
-        <i data-feather="home"></i>{% translate "Site Home" %}
+        <i data-feather="home"></i>{% trans "Site Home" %}
       </a>
       <a href="{% url 'tournament-create' %}" class="list-group-item" data-parent="#titleh">
-        <i data-feather="edit-2"></i>{% translate "New Tournament" %}
+        <i data-feather="edit-2"></i>{% trans "New Tournament" %}
       </a>
       <a href="{% url 'admin:index' %}" target="_blank" class="list-group-item" data-parent="#titleh">
-        <i data-feather="database"></i>{% translate "Edit Database" %}
+        <i data-feather="database"></i>{% trans "Edit Database" %}
       </a>
       {% for t in all_tournaments %}
         <div class="list-group-item tournament-areas-title" data-parent="#titleh">
@@ -39,15 +39,15 @@
         </div>
         <a href="{% url 'tournament-admin-home' tournament_slug=t.slug %}"
            class="list-group-item" data-parent="#titleh">
-          <i data-feather="settings"></i>{% translate "Admin Area" %}
+          <i data-feather="settings"></i>{% trans "Admin Area" %}
         </a>
         <a href="{% url 'tournament-assistant-home' tournament_slug=t.slug %}"
            class="list-group-item" data-parent="#titleh">
-          <i data-feather="pocket"></i>{% translate "Assistant Area" %}
+          <i data-feather="pocket"></i>{% trans "Assistant Area" %}
         </a>
         <a href="{% url 'tournament-public-index' tournament_slug=t.slug %}"
            class="list-group-item" data-parent="#titleh">
-          <i data-feather="globe"></i>{% translate "Public Area" %}
+          <i data-feather="globe"></i>{% trans "Public Area" %}
         </a>
       {% endfor %}
     </div>
@@ -57,44 +57,44 @@
     <a href="{% tournamenturl 'tournament-admin-home' %}" data-parent="#sidebar"
        class="collapsed">
       <i data-feather="monitor"></i>
-      <span class="d-none d-md-inline">{% translate "Overview" %}</span>
+      <span class="d-none d-md-inline">{% trans "Overview" %}</span>
     </a>
   </div>
 
   <div class="list-group-item d-inline-block">
     <a href="#setuph" data-toggle="collapse" data-parent="#sidebar" aria-expanded="false">
        <i data-feather="briefcase"></i>
-       <span class="d-none d-md-inline">{% translate "Setup" %}</span>
+       <span class="d-none d-md-inline">{% trans "Setup" %}</span>
        <i data-feather="chevron-down" class="sidebar-expand d-none d-md-inline"></i>
        <i data-feather="chevron-up" class="sidebar-expand d-none d-md-inline"></i>
     </a>
     <div class="collapse" id="setuph">
       <a href="{% tournamenturl 'options-tournament-index' %}"
          class="list-group-item" data-parent="#setuph">
-        <span class="circle-icon small-circle"></span><i data-feather="settings"></i>{% translate "Configuration" %}
+        <span class="circle-icon small-circle"></span><i data-feather="settings"></i>{% trans "Configuration" %}
       </a>
       <a href="{% tournamenturl 'importer-simple-index' %}" class="list-group-item" data-parent="#setuph">
-        <span class="circle-icon small-circle"></span><i data-feather="download-cloud"></i>{% translate "Import Data" %}
+        <span class="circle-icon small-circle"></span><i data-feather="download-cloud"></i>{% trans "Import Data" %}
       </a>
       <a href="{% tournamenturl 'participants-list' %}"
          class="list-group-item" data-parent="#setuph">
-        <span class="circle-icon small-circle"></span><i data-feather="book"></i>{% translate "Participants" %}
+        <span class="circle-icon small-circle"></span><i data-feather="book"></i>{% trans "Participants" %}
       </a>
       <a href="{% tournamenturl 'privateurls-list' %}"
          class="list-group-item" data-parent="#setuph}">
-        <span class="circle-icon small-circle"></span><i data-feather="link"></i>{% translate "Private URLs" %}
+        <span class="circle-icon small-circle"></span><i data-feather="link"></i>{% trans "Private URLs" %}
       </a>
       <a href="{% tournamenturl 'notifications-status' %}"
          class="list-group-item" data-parent="#setuph">
-        <span class="circle-icon small-circle"></span><i data-feather="mail"></i>{% translate "Emails" %}
+        <span class="circle-icon small-circle"></span><i data-feather="mail"></i>{% trans "Emails" %}
       </a>
       <a href="{% tournamenturl 'panel-adjudicators-index' %}"
          class="list-group-item" data-parent="#setuph">
-        <span class="circle-icon small-circle"></span><i data-feather="box"></i>{% translate "Preformed Panels" %}
+        <span class="circle-icon small-circle"></span><i data-feather="box"></i>{% trans "Preformed Panels" %}
       </a>
       <a href="{% tournamenturl 'exporter-xml-index' %}"
           class="list-group-item" data-parent="#setuph">
-        <span class="circle-icon small-circle"></span><i data-feather="archive"></i>{% translate "Export XML" %}
+        <span class="circle-icon small-circle"></span><i data-feather="archive"></i>{% trans "Export XML" %}
       </a>
     </div>
   </div>
@@ -104,7 +104,7 @@
       <a href="{% tournamenturl 'draw-side-allocations' %}" data-parent="#sidebar"
         class="collapsed">
         <i data-feather="shuffle"></i>
-        <span class="d-none d-md-inline">{% translate "Sides" %}</span>
+        <span class="d-none d-md-inline">{% trans "Sides" %}</span>
       </a>
     </div>
   {% endif %}
@@ -114,26 +114,26 @@
     <a href="#checkinh" data-toggle="collapse" data-parent="#sidebar" aria-expanded="false"
        class="{% if checkins_nav %}active{% endif %}">
        <i data-feather="compass"></i>
-       <span class="d-none d-md-inline">{% translate "Check-Ins" %}</span>
+       <span class="d-none d-md-inline">{% trans "Check-Ins" %}</span>
        <i data-feather="chevron-down" class="sidebar-expand d-none d-md-inline"></i>
        <i data-feather="chevron-up" class="sidebar-expand d-none d-md-inline"></i>
     </a>
     <div class="collapse {% if checkins_nav %}show{% endif %}" id="checkinh">
       <a href="{% tournamenturl 'admin-checkin-identifiers' %}"
          class="list-group-item {% if checkins_ids %}active{% endif %}" data-parent="#checkinh">
-        <i data-feather="menu"></i>{% translate "Make Identifiers" %}
+        <i data-feather="menu"></i>{% trans "Make Identifiers" %}
       </a>
       <a href="{% tournamenturl 'admin-checkin-prescan' %}"
          class="list-group-item {% if checkins_scans %}active{% endif %}" data-parent="#checkinh">
-        <i data-feather="instagram"></i>{% translate "Scan Identifiers" %}
+        <i data-feather="instagram"></i>{% trans "Scan Identifiers" %}
       </a>
       <a href="{% tournamenturl 'admin-people-statuses' %}"
          class="list-group-item {% if checkins_people_statuses %}active{% endif %}" data-parent="#checkinh">
-        <i data-feather="watch"></i>{% translate "People's Status" %}
+        <i data-feather="watch"></i>{% trans "People's Status" %}
       </a>
       <a href="{% tournamenturl 'admin-venues-statuses' %}"
          class="list-group-item {% if checkins_venues_statuses %}active{% endif %}" data-parent="#checkinh">
-        <i data-feather="map"></i>{% translate "Rooms' Status" %}
+        <i data-feather="map"></i>{% trans "Rooms' Status" %}
       </a>
     </div>
   </div>
@@ -141,37 +141,37 @@
   <div class="list-group-item d-inline-block">
     <a href="#feedh" data-toggle="collapse" data-parent="#sidebar" aria-expanded="false" class="collapsed">
       <i data-feather="message-circle"></i>
-      <span class="d-none d-md-inline">{% translate "Feedback" %}</span>
+      <span class="d-none d-md-inline">{% trans "Feedback" %}</span>
       <i data-feather="chevron-down" class="sidebar-expand d-none d-md-inline"></i>
       <i data-feather="chevron-up" class="sidebar-expand d-none d-md-inline"></i>
     </a>
     <div class="collapse" id="feedh">
       <a class="list-group-item" href="{% tournamenturl 'adjfeedback-overview' %}" data-parent="#feedh">
-        <i data-feather="maximize"></i>{% translate "Overview" %}
+        <i data-feather="maximize"></i>{% trans "Overview" %}
       </a>
         <a class="list-group-item" href="{% tournamenturl 'adjfeedback-view-latest' %}" data-parent="#feedh">
-        <i data-feather="clock"></i>{% translate "Latest" %}
+        <i data-feather="clock"></i>{% trans "Latest" %}
       </a>
       <a class="list-group-item" href="{% tournamenturl 'adjfeedback-view-important' %}" data-parent="#feedh">
-        <i data-feather="star"></i>{% translate "Important" %}
+        <i data-feather="star"></i>{% trans "Important" %}
       </a>
       <a class="list-group-item" href="{% tournamenturl 'adjfeedback-view-comments' %}" data-parent="#feedh">
-        <i data-feather="message-square"></i>{% translate "Comments" %}
+        <i data-feather="message-square"></i>{% trans "Comments" %}
       </a>
       <a class="list-group-item" href="{% tournamenturl 'adjfeedback-view-by-source' %}" data-parent="#feedh">
-        <i data-feather="phone-outgoing"></i>{% translate "Find by Source" %}
+        <i data-feather="phone-outgoing"></i>{% trans "Find by Source" %}
       </a>
       <a class="list-group-item" href="{% tournamenturl 'adjfeedback-view-by-target' %}" data-parent="#feedh">
-        <i data-feather="phone-incoming"></i>{% translate "Find by Target" %}
+        <i data-feather="phone-incoming"></i>{% trans "Find by Target" %}
       </a>
       <a class="list-group-item" href="{% tournamenturl 'adjfeedback-progress' %}" data-parent="#feedh">
-        <i data-feather="x-circle"></i>{% translate "Unsubmitted" %}
+        <i data-feather="x-circle"></i>{% trans "Unsubmitted" %}
       </a>
       <a class="list-group-item" href="{% tournamenturl 'adjfeedback-add-index' %}">
-        <i data-feather="plus-circle"></i>{% translate "Add Feedback" %}
+        <i data-feather="plus-circle"></i>{% trans "Add Feedback" %}
       </a>
       <a class="list-group-item" href="{% tournamenturl 'adjfeedback-update-scores-bulk' %}">
-        <i data-feather="upload"></i>{% translate "Bulk Update" %}
+        <i data-feather="upload"></i>{% trans "Bulk Update" %}
       </a>
     </div>
   </div>
@@ -180,54 +180,54 @@
     <a href="#standh" data-toggle="collapse" data-parent="#sidebar" aria-expanded="false"
        data-parent="#sidebar" class="collapsed">
       <i data-feather="bar-chart-2"></i>
-      <span class="d-none d-md-inline">{% translate "Standings" %}</span>
+      <span class="d-none d-md-inline">{% trans "Standings" %}</span>
       <i data-feather="chevron-down" class="sidebar-expand d-none d-md-inline"></i>
       <i data-feather="chevron-up" class="sidebar-expand d-none d-md-inline"></i>
     </a>
     <div class="collapse" id="standh">
       <a href="{% roundurl 'standings-index' current_round %}"
          class="list-group-item" data-parent="#setuph">
-        <i data-feather="maximize"></i>{% translate "Overview" %}
+        <i data-feather="maximize"></i>{% trans "Overview" %}
       </a>
       <a class="list-group-item" href="{% roundurl 'standings-team' current_round %}">
         {% if tournament.break_categories_nongeneral.count > 0 %}
-          <i data-feather="users"></i>{% translate "All Teams" %}
+          <i data-feather="users"></i>{% trans "All Teams" %}
         {% else %}
-          <i data-feather="users"></i>{% translate "Teams" %}
+          <i data-feather="users"></i>{% trans "Teams" %}
         {% endif %}
       </a>
       {% for category in tournament.break_categories_nongeneral %}
         <a class="list-group-item {% if standings_active %}active{% endif %}" href="{% roundurl 'standings-break-category' round=current_round category=category.slug %}">
-          <i data-feather="users"></i>{% blocktranslate trimmed with category=category.name %}
+          <i data-feather="users"></i>{% blocktrans trimmed with category=category.name %}
             {{ category }} Teams
-          {% endblocktranslate %}
+          {% endblocktrans %}
         </a>
       {% endfor %}
       <a class="list-group-item" href="{% roundurl 'standings-speaker' current_round %}">
         {% if tournament.speakercategory_set.all.count > 0 %}
-          <i data-feather="user"></i>{% translate "All Speakers" %}
+          <i data-feather="user"></i>{% trans "All Speakers" %}
         {% else %}
-          <i data-feather="user"></i>{% translate "Speakers" %}
+          <i data-feather="user"></i>{% trans "Speakers" %}
         {% endif %}
       </a>
       {% for category in tournament.speakercategory_set.all %}
         <a class="list-group-item" href="{% roundurl 'standings-speaker-category' round=current_round category=category.slug %}">
-          <i data-feather="user-plus"></i>{% blocktranslate trimmed with category=category.name %}
+          <i data-feather="user-plus"></i>{% blocktrans trimmed with category=category.name %}
             {{ category }} Speakers
-          {% endblocktranslate %}
+          {% endblocktrans %}
         </a>
       {% endfor %}
       {% if pref.reply_scores_enabled %}
         <a class="list-group-item {% if standings_reply_nav %}active{% endif %}"
            href="{% roundurl 'standings-reply' current_round %}">
-          <i data-feather="speaker"></i>{% translate "Replies" %}
+          <i data-feather="speaker"></i>{% trans "Replies" %}
         </a>
       {% endif %}
       <a class="list-group-item" href="{% tournamenturl 'motions-statistics'  %}">
-        <i data-feather="crosshair"></i>{% translate "Motions" %}
+        <i data-feather="crosshair"></i>{% trans "Motions" %}
       </a>
       <a class="list-group-item" href="{% roundurl 'standings-diversity' current_round %}">
-        <i data-feather="globe"></i>{% translate "Diversity" %}
+        <i data-feather="globe"></i>{% trans "Diversity" %}
       </a>
     </div>
   </div>
@@ -240,27 +240,27 @@
           <a href="#breakh" data-toggle="collapse" data-parent="#sidebar" aria-expanded="false"
              class="collapsed">
             <i data-feather="target"></i>
-            <span class="d-none d-md-inline">{% translate "Breaks" %}</span>
+            <span class="d-none d-md-inline">{% trans "Breaks" %}</span>
             <i data-feather="chevron-down" class="sidebar-expand d-none d-md-inline"></i>
             <i data-feather="chevron-up" class="sidebar-expand d-none d-md-inline"></i>
           </a>
           <div class="collapse" id="breakh">
             <a class="list-group-item" href="{% tournamenturl 'breakqual-index' %}">
-              <i data-feather="maximize"></i>{% translate "Overview" %}
+              <i data-feather="maximize"></i>{% trans "Overview" %}
             </a>
             {% for category in tournament.breakcategory_set.all %}
               <a class="list-group-item" href="{% tournamenturl 'breakqual-teams' category.slug %}">
-                <i data-feather="pie-chart"></i>{% blocktranslate trimmed with category=category.name %}{{ category }}{% endblocktranslate %}
+                <i data-feather="pie-chart"></i>{% blocktrans trimmed with category=category.name %}{{ category }}{% endblocktrans %}
               </a>
             {% endfor %}
             <a class="list-group-item" href="{% tournamenturl 'breakqual-adjudicators' %}">
-              <i data-feather="shield"></i>{% translate "Adjudicators'" %}
+              <i data-feather="shield"></i>{% trans "Adjudicators'" %}
             </a>
             <a class="list-group-item" href="{% tournamenturl 'break-categories-edit' %}">
-              <i data-feather="pocket"></i>{% translate "Edit Categories" %}
+              <i data-feather="pocket"></i>{% trans "Edit Categories" %}
             </a>
             <a class="list-group-item" href="{% tournamenturl 'breakqual-edit-eligibility' %}">
-              <i data-feather="trello"></i>{% translate "Edit Eligibility" %}
+              <i data-feather="trello"></i>{% trans "Edit Eligibility" %}
             </a>
           </div>
 
@@ -275,7 +275,7 @@
     <a href="{% url 'logout' %}" data-parent="#sidebar"
      class="collapsed">
       <i data-feather="log-out"></i>
-      <span class="d-none d-md-inline">{% translate "Log Out" %}</span>
+      <span class="d-none d-md-inline">{% trans "Log Out" %}</span>
     </a>
   </div>
 

--- a/tabbycat/templates/nav/assistant_nav.html
+++ b/tabbycat/templates/nav/assistant_nav.html
@@ -2,31 +2,31 @@
 
 <li class="nav-item {% if results_nav %}active{% endif %}">
   <a class="nav-link" href="{% tournamenturl 'results-assistant-round-list' %}">
-    {% translate "Enter Results" %}
+    {% trans "Enter Results" %}
   </a>
 </li>
 
 <li class="nav-item {% if feedback_nav %}active{% endif %}">
   <a class="nav-link" href="{% tournamenturl 'adjfeedback-assistant-add-index' %}">
-    {% translate "Enter Feedback" %}
+    {% trans "Enter Feedback" %}
   </a>
 </li>
 
 <li class="nav-item dropdown {% if participants_nav or institutions_nav or code_names_nav %}active{% endif %}">
   <a class="nav-link dropdown-toggle" href="#" id="checkinsDrop"
      data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-    {% translate "Participants" %}
+    {% trans "Participants" %}
   </a>
   <div class="dropdown-menu" aria-labelledby="checkinsDrop">
     <a class="dropdown-item {% if participants_nav %}active{% endif %}" href="{% tournamenturl 'participants-assistant-list' %}">
-      {% translate "Participants List" %}
+      {% trans "Participants List" %}
     </a>
     <a class="dropdown-item {% if institutions_nav %}active{% endif %}" href="{% tournamenturl 'participants-assistant-institutions-list' %}">
-      {% translate "Institutions" %}
+      {% trans "Institutions" %}
     </a>
     {% if pref.team_code_names != 'off' %}
       <a class="dropdown-item {% if code_names_nav %}active{% endif %}" href="{% tournamenturl 'participants-assistant-code-names-list' %}">
-        {% translate "Code Names" %}
+        {% trans "Code Names" %}
       </a>
     {% endif %}
   </div>
@@ -35,20 +35,20 @@
 <li class="nav-item dropdown {% if checkins_nav %}active{% endif %}">
   <a class="nav-link dropdown-toggle" href="#" id="checkinsDrop"
      data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-    {% translate "Check-Ins" %}
+    {% trans "Check-Ins" %}
   </a>
   <div class="dropdown-menu" aria-labelledby="checkinsDrop">
     <a class="dropdown-item {% if checkins_scans %}active{% endif %}" href="{% tournamenturl 'assistant-checkin-prescan' %}">
-      {% translate "Scan Identifiers" %}
+      {% trans "Scan Identifiers" %}
     </a>
     <a class="dropdown-item {% if checkins_ids %}active{% endif %}" href="{% tournamenturl 'assistant-checkin-identifiers' %}">
-      {% translate "View Identifiers" %}
+      {% trans "View Identifiers" %}
     </a>
     <a class="dropdown-item {% if checkins_people_statuses %}active{% endif %}" href="{% tournamenturl 'assistant-people-statuses' %}">
-      {% translate "People's Status" %}
+      {% trans "People's Status" %}
     </a>
     <a class="dropdown-item {% if checkins_venues_statuses %}active{% endif %}" href="{% tournamenturl 'assistant-venues-statuses' %}">
-      {% translate "Room's Status" %}
+      {% trans "Room's Status" %}
     </a>
   </div>
 </li>
@@ -56,7 +56,7 @@
 {% if pref.assistant_access != "results_only" %}
   <li class="nav-item {% if draw_nav %}active{% endif %}">
     <a class="nav-link" href="{% tournamenturl 'draw-assistant-display' %}">
-      {% translate "Display/Print Draw" %}
+      {% trans "Display/Print Draw" %}
     </a>
   </li>
 {% endif %}

--- a/tabbycat/templates/nav/public_nav.html
+++ b/tabbycat/templates/nav/public_nav.html
@@ -3,23 +3,23 @@
 <!-- TAB RELEASES -->
 {% if pref.team_tab_released %}
   <li class="nav-item {% if tab_team_nav %}active{% endif %}">
-    <a class="nav-link" href="{% tournamenturl 'standings-public-tab-team' %}">{% translate "Team Tab" %}</a>
+    <a class="nav-link" href="{% tournamenturl 'standings-public-tab-team' %}">{% trans "Team Tab" %}</a>
   </li>
 {% endif %}
 {% if pref.break_category_tabs_released %}
   {% for category in tournament.break_categories_nongeneral %}
     <li>
       <a class="nav-link" href="{% tournamenturl 'standings-public-tab-break-category' category=category.slug %}">
-        {% blocktranslate trimmed with category=category.name %}
+        {% blocktrans trimmed with category=category.name %}
           {{ category }} Teams
-        {% endblocktranslate %}
+        {% endblocktrans %}
       </a>
     </li>
   {% endfor %}
 {% endif %}
 {% if pref.speaker_tab_released %}
   <li class="nav-item {% if tab_speaker_nav %}active{% endif %}">
-    <a class="nav-link" href="{% tournamenturl 'standings-public-tab-speaker' %}">{% translate "Speaker Tab" %}</a>
+    <a class="nav-link" href="{% tournamenturl 'standings-public-tab-speaker' %}">{% trans "Speaker Tab" %}</a>
   </li>
 {% endif %}
 {% if pref.speaker_category_tabs_released %}
@@ -27,9 +27,9 @@
     {% if category.public %}
       <li>
         <a class="nav-link" href="{% tournamenturl 'standings-public-tab-speaker-category' category=category.slug %}">
-          {% blocktranslate trimmed with category=category.name %}
+          {% blocktrans trimmed with category=category.name %}
             {{ category }} Speakers
-          {% endblocktranslate %}
+          {% endblocktrans %}
         </a>
       </li>
     {% endif %}
@@ -37,12 +37,12 @@
 {% endif %}
 {% if pref.replies_tab_released %}
   <li class="nav-item {% if tab_replies_nav %}active{% endif %}">
-    <a class="nav-link" href="{% tournamenturl 'standings-public-tab-replies' %}">{% translate "Replies Tab" %}</a>
+    <a class="nav-link" href="{% tournamenturl 'standings-public-tab-replies' %}">{% trans "Replies Tab" %}</a>
   </li>
 {% endif %}
 {% if pref.adjudicators_tab_released %}
   <li class="nav-item {% if adjudicators_nav %}active{% endif %}">
-    <a class="nav-link" href="{% tournamenturl 'standings-public-adjudicators-tab' %}">{% translate "Adjudicator Tab" %}</a>
+    <a class="nav-link" href="{% tournamenturl 'standings-public-adjudicators-tab' %}">{% trans "Adjudicator Tab" %}</a>
   </li>
 {% endif %}
 {% if pref.motion_tab_released %}
@@ -50,16 +50,16 @@
     <li class="nav-item dropdown {% if motions_nav %}active{% endif %}">
       <a class="nav-link dropdown-toggle" href="#" id="motionsDrop"
          data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-        {% translate "Motions Tab" %}
+        {% trans "Motions Tab" %}
       </a>
       <div class="dropdown-menu" aria-labelledby="motionsDrop">
-        <a class="dropdown-item" href="{% tournamenturl 'motions-public-statistics' %}">{% translate "By round" %}</a>
-        <a class="dropdown-item" href="{% tournamenturl 'motions-global-public-statistics' %}">{% translate "Globally" %}</a>
+        <a class="dropdown-item" href="{% tournamenturl 'motions-public-statistics' %}">{% trans "By round" %}</a>
+        <a class="dropdown-item" href="{% tournamenturl 'motions-global-public-statistics' %}">{% trans "Globally" %}</a>
       </div>
     </li>
   {% else %}
     <li class="nav-item {% if motions_nav %}active{% endif %}">
-      <a class="nav-link" href="{% tournamenturl 'motions-public-statistics' %}">{% translate "Motions Tab" %}</a>
+      <a class="nav-link" href="{% tournamenturl 'motions-public-statistics' %}">{% trans "Motions Tab" %}</a>
     </li>
   {% endif %}
 {% endif%}
@@ -69,7 +69,7 @@
   <li class="nav-item dropdown {% if draw_nav %}active{% endif %}">
     <a class="nav-link dropdown-toggle" href="#" id="drawsDrop"
        data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-      {% translate "Draws" %}
+      {% trans "Draws" %}
     </a>
     <div class="dropdown-menu draw-dropdown-menu" aria-labelledby="drawsDrop">
       {% for r in tournament.round_set.all %}
@@ -80,7 +80,7 @@
         {% endif %}
       {% endfor %}
       <div class="dropdown-item">
-        {% translate "No Draws Available" %}
+        {% trans "No Draws Available" %}
       </div>
     </div>
   </li>
@@ -88,11 +88,11 @@
   <li class="nav-item {% if draw_nav %}active{% endif %}">
     <a class="nav-link" href="{% tournamenturl 'draw-public-current-rounds' %}">
       {% if tournament.current_rounds|length == 1 %}
-        {% blocktranslate trimmed with round=current_round.name %}
+        {% blocktrans trimmed with round=current_round.name %}
           Draw for {{ round }}
-        {% endblocktranslate %}
+        {% endblocktrans %}
       {% else %}
-        {% translate "Current Draws" %}
+        {% trans "Current Draws" %}
       {% endif %}
     </a>
   </li>
@@ -102,7 +102,7 @@
 {% if pref.public_checkins  %}
   <li class="nav-item {% if checkins_status %}active{% endif %}">
     <a class="nav-link" href="{% tournamenturl 'checkins-public-status' %}">
-      {% translate "Check-Ins" %}
+      {% trans "Check-Ins" %}
     </a>
   </li>
 {% endif %}
@@ -112,7 +112,7 @@
   <li class="nav-item dropdown {% if results_nav %}active{% endif %}">
     <a class="nav-link dropdown-toggle" href="#" id="roundsDrop"
        data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-       {% translate "Results" %}
+       {% trans "Results" %}
     </a>
     <div class="dropdown-menu" aria-labelledby="roundsDrop">
       {% for r in tournament.rounds_with_released_results %}
@@ -130,7 +130,7 @@
   <li class="nav-item dropdown {% if break_nav %}active{% endif %}">
     <a class="nav-link dropdown-toggle" href="#" id="breakdrop"
        data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-      {% translate "Break" %}
+      {% trans "Break" %}
     </a>
     <div class="dropdown-menu" aria-labelledby="breakdrop">
       {% if pref.public_breaking_teams %}
@@ -142,7 +142,7 @@
       {% endif %}
       {% if pref.public_breaking_adjs %}
         <a class="dropdown-item" href="{% tournamenturl 'breakqual-public-adjs' %}">
-          {% translate "Adjudicators" %}
+          {% trans "Adjudicators" %}
         </a>
       {% endif %}
     </div>
@@ -152,49 +152,49 @@
 <!-- MISC -->
 {% if pref.public_motions and pref.motion_tab_released == False %}
   <li class="nav-item {% if motions_nav %}active{% endif %}">
-    <a class="nav-link" href="{% tournamenturl 'motions-public' %}">{% translate "Motions" %}</a>
+    <a class="nav-link" href="{% tournamenturl 'motions-public' %}">{% trans "Motions" %}</a>
   </li>
 {% endif %}
 {% if pref.public_side_allocations %}
   <li class="nav-item {% if sides_nav %}active{% endif %}">
-    <a class="nav-link" href="{% tournamenturl 'draw-public-side-allocations' %}">{% translate "Sides" %}</a>
+    <a class="nav-link" href="{% tournamenturl 'draw-public-side-allocations' %}">{% trans "Sides" %}</a>
   </li>
 {% endif %}
 {% if pref.public_team_standings and current_round.prev and not pref.team_tab_released %}
   <li>
-    <a class="nav-link" href="{% tournamenturl 'standings-public-teams-current' %}">{% translate "Standings" %}</a>
+    <a class="nav-link" href="{% tournamenturl 'standings-public-teams-current' %}">{% trans "Standings" %}</a>
   </li>
 {% endif %}
 {% if pref.public_diversity %}
   <li class="nav-item {% if diversity_nav %}active{% endif %}">
-    <a class="nav-link" href="{% tournamenturl 'standings-public-diversity' %}">{% translate "Diversity" %}</a>
+    <a class="nav-link" href="{% tournamenturl 'standings-public-diversity' %}">{% trans "Diversity" %}</a>
   </li>
 {% endif %}
 {% if pref.public_participants %}
   <li class="nav-item {% if participants_nav %}active{% endif %}">
-    <a class="nav-link" href="{% tournamenturl 'participants-public-list' %}">{% translate "Participants" %}</a>
+    <a class="nav-link" href="{% tournamenturl 'participants-public-list' %}">{% trans "Participants" %}</a>
   </li>
 {% endif %}
 {% if pref.public_institutions_list %}
   <li class="nav-item {% if institutions_nav %}active{% endif %}">
-    <a class="nav-link" href="{% tournamenturl 'participants-public-institutions-list' %}">{% translate "Institutions" %}</a>
+    <a class="nav-link" href="{% tournamenturl 'participants-public-institutions-list' %}">{% trans "Institutions" %}</a>
   </li>
 {% endif %}
 {% if pref.feedback_progress %}
   <li class="nav-item {% if feedback_progress_nav %}active{% endif %}">
-    <a class="nav-link" href="{% tournamenturl 'public_feedback_progress' %}">{% translate "Feedback Progress" %}</a>
+    <a class="nav-link" href="{% tournamenturl 'public_feedback_progress' %}">{% trans "Feedback Progress" %}</a>
   </li>
 {% endif %}
 {% if pref.participant_ballots == 'public' %}
   {% if tournament.current_rounds|length == 1 %}
     <li class="nav-item {% if enter_ballots_nav %}active{% endif %}">
-      <a class="nav-link" href="{% roundurl 'results-public-ballot-submission-index' tournament.current_rounds.0 %}">{% translate "Enter Ballot" %}</a>
+      <a class="nav-link" href="{% roundurl 'results-public-ballot-submission-index' tournament.current_rounds.0 %}">{% trans "Enter Ballot" %}</a>
     </li>
   {% elif tournament.current_rounds|length > 1 %}
     <li class="nav-item dropdown {% if enter_ballots_nav %}active{% endif %}">
       <a class="nav-link dropdown-toggle" href="#" id="roundsDrop"
          data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-         {% translate "Enter Ballot" %}
+         {% trans "Enter Ballot" %}
       </a>
       <div class="dropdown-menu" aria-labelledby="roundsDrop">
         {% for r in tournament.current_rounds %}
@@ -208,6 +208,6 @@
 {% endif %}
 {% if pref.participant_feedback == 'public' %}
   <li class="nav-item {% if enter_feedback_nav %}active{% endif %}">
-    <a class="nav-link" href="{% tournamenturl 'adjfeedback-public-add-index' %}">{% translate "Enter Feedback" %}</a>
+    <a class="nav-link" href="{% tournamenturl 'adjfeedback-public-add-index' %}">{% trans "Enter Feedback" %}</a>
   </li>
 {% endif %}

--- a/tabbycat/templates/nav/round_panel.html
+++ b/tabbycat/templates/nav/round_panel.html
@@ -24,7 +24,7 @@
         {% elif r.draw_status == r.STATUS_DRAFT %} circle-done
         {% elif r.draw_status == r.STATUS_CONFIRMED %} circle-done
         {% elif r.draw_status == r.STATUS_RELEASED %} circle-done
-        {% else %} circle-later{% endif %}"></i>{% translate "Availability" %}
+        {% else %} circle-later{% endif %}"></i>{% trans "Availability" %}
     </a>
 
     <a href="{% roundurl 'draw' r %}" data-parent="#rh{{ r.id }}"
@@ -34,7 +34,7 @@
         {% elif r.draw_status == r.STATUS_NONE %} circle-later
         {% elif r.draw_status == r.STATUS_CONFIRMED %} circle-done
         {% elif r.draw_status == r.STATUS_RELEASED %} circle-done
-        {% else %} circle-todo{% endif %}"></i>{% translate "Draw" %}
+        {% else %} circle-todo{% endif %}"></i>{% trans "Draw" %}
     </a>
 
     <a href="{% roundurl 'draw-display' r %}" data-parent="#rh{{ r.id }}"
@@ -45,7 +45,7 @@
         {% elif r.draw_status == r.STATUS_DRAFT %} circle-later
         {% elif r.draw_status == r.STATUS_CONFIRMED %} circle-todo
         {% elif r.draw_status == r.STATUS_RELEASED %} circle-done
-        {% else %} circle-todo{% endif %}"></i>{% translate "Display" %}
+        {% else %} circle-todo{% endif %}"></i>{% trans "Display" %}
     </a>
 
     <a href="{% roundurl 'results-round-list' r %}" data-parent="#rh{{ r.id }}"
@@ -54,7 +54,7 @@
         {% if r.completed %} circle-done
         {% elif r.draw_status == r.STATUS_CONFIRMED %}circle-todo
         {% elif r.draw_status == r.STATUS_RELEASED %}circle-todo
-        {% else %} circle-later{% endif %}"></i>{% translate "Results" %}
+        {% else %} circle-later{% endif %}"></i>{% trans "Results" %}
     </a>
 
   </div>

--- a/tabbycat/templates/nav/top_nav_base.html
+++ b/tabbycat/templates/nav/top_nav_base.html
@@ -3,9 +3,9 @@
 <nav class="navbar navbar-expand-lg navbar-light">
 
   {# Decisions about whether to show items in the menu are based on the role of the user (not the view). #}
-  {% blocktranslate trimmed asvar logo_alt %}
+  {% blocktrans trimmed asvar logo_alt %}
     Tabbycat Logo
-  {% endblocktranslate %}
+  {% endblocktrans %}
   {% if all_tournaments.count > 1 or user.is_authenticated %}
     <div class="nav-item dropdown">
 
@@ -26,27 +26,27 @@
           {% if user.is_superuser %}
             <a class="dropdown-item px-2" href="{% url 'tournament-admin-home' tournament_slug=tournament.slug %}">
               <i data-feather="settings"></i>
-              {% blocktranslate trimmed %}
+              {% blocktrans trimmed %}
                 Administrator area for <strong>{{ tournament }}</strong>
-              {% endblocktranslate %}
+              {% endblocktrans %}
             </a>
           {% endif %}
 
           {% if user.is_authenticated %}
             <a class="dropdown-item px-2" href="{% url 'tournament-assistant-home' tournament_slug=tournament.slug %}">
               <i data-feather="pocket"></i>
-              {% blocktranslate trimmed %}
+              {% blocktrans trimmed %}
                 Assistant area for <strong>{{ tournament }}</strong>
-              {% endblocktranslate %}
+              {% endblocktrans %}
             </a>
           {% endif %}
 
           <a class="dropdown-item px-2" href="{% url 'tournament-public-index' tournament_slug=tournament.slug %}">
             {% if user.is_authenticated %}
               <i data-feather="globe"></i>
-              {% blocktranslate trimmed %}
+              {% blocktrans trimmed %}
                 Public area for <strong>{{ tournament }}</strong>
-              {% endblocktranslate %}
+              {% endblocktrans %}
             {% else %}
               <i data-feather="award"></i>
               {{ tournament }}
@@ -63,7 +63,7 @@
           <div class="dropdown-divider"></div>
         {% endif %}
 
-        <a class="dropdown-item px-2" href="/"><i data-feather="home"></i>{% translate "Site Home" %}</a>
+        <a class="dropdown-item px-2" href="/"><i data-feather="home"></i>{% trans "Site Home" %}</a>
       </div>
 
     </div>
@@ -105,11 +105,11 @@
       <li class="nav-item">
         {% if user.is_authenticated %}
           <a class="nav-link" href="{% url 'logout' %}">
-            {% translate "Log Out" %} ({{ user }})
+            {% trans "Log Out" %} ({{ user }})
           </a>
         {% else %}
           <a class="nav-link" href="{% url 'login' %}">
-            {% translate "Login" %}
+            {% trans "Login" %}
           </a>
         {% endif %}
       </li>

--- a/tabbycat/templates/registration/logged_out.html
+++ b/tabbycat/templates/registration/logged_out.html
@@ -2,16 +2,16 @@
 {% load i18n %}
 
 {% block head-title %}
-  👋 {% translate "Goodbye" %}
+  👋 {% trans "Goodbye" %}
 {% endblock %}
 {% block page-title %}You have been logged out{% endblock %}
 
 {% block page-alerts %}
 
   {% url 'login' as login_url %}
-  {% blocktranslate trimmed asvar message %}
+  {% blocktrans trimmed asvar message %}
     You have been logged out. <a href="{{ login_url }}">Log in again?</a>
-  {% endblocktranslate %}
+  {% endblocktrans %}
   {% include "components/alert.html" with type="info" %}
 
 {% endblock %}

--- a/tabbycat/templates/registration/login.html
+++ b/tabbycat/templates/registration/login.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load add_field_css i18n %}
 
-{% block page-title %}🔓{% translate "Login" context "page title" %}{% endblock %}
+{% block page-title %}🔓{% trans "Login" context "page title" %}{% endblock %}
 {% block head-title %}{% endblock %}
 
 {% block nav %}{% endblock %}
@@ -26,7 +26,7 @@
         <div class="list-group list-group-flush">
         <form id="login" action="." method="POST">
 
-          {% translate "Log in to Tabbycat" context "page title" as title %}
+          {% trans "Log in to Tabbycat" context "page title" as title %}
           {% include "components/form-title.html" with icon="lock" %}
 
           <div class="list-group-item pt-4 pb-4">
@@ -34,7 +34,7 @@
             {% csrf_token %}
 
             {% if form.errors %}
-              {% translate "Your username and password didn't match." as message %}
+              {% trans "Your username and password didn't match." as message %}
               {% for error in form.errors %}
                 {% include "components/form-errors.html" with errors=form.errors %}
               {% endfor %}
@@ -43,10 +43,10 @@
             {% if next %}
 
               {% if user.is_authenticated %}
-                {% translate "Your account doesn't have access to this page. To proceed, please log in with an account that has access." as message %}
+                {% trans "Your account doesn't have access to this page. To proceed, please log in with an account that has access." as message %}
                 {% include "components/alert.html" with type="warning" %}
               {% else %}
-                {% translate "Please log in to see this page." as message %}
+                {% trans "Please log in to see this page." as message %}
                 {% include "components/alert.html" with type="danger" %}
               {% endif %}
             {% endif %}
@@ -58,8 +58,8 @@
           </div>
 
           <input type="hidden" name="next" value="{{ next }}" />
-          {% translate "Log In" context "button" as title %}
-          {% translate "I forgot my password" context "button" as subtitle %}
+          {% trans "Log In" context "button" as title %}
+          {% trans "I forgot my password" context "button" as subtitle %}
           {% url 'password_reset' as suburl %}
           {% include "components/form-submit.html" %}
 

--- a/tabbycat/templates/registration/password_change_done.html
+++ b/tabbycat/templates/registration/password_change_done.html
@@ -1,17 +1,17 @@
 {% extends "base.html" %}
 {% load add_field_css i18n %}
 
-{% block page-title %}🔓{% translate "Password changed" context "page title" %}{% endblock %}
-{% block head-title %}<span class="emoji">🔓</span>{% translate "Password changed" context "page title" %}{% endblock %}
+{% block page-title %}🔓{% trans "Password changed" context "page title" %}{% endblock %}
+{% block head-title %}<span class="emoji">🔓</span>{% trans "Password changed" context "page title" %}{% endblock %}
 
 {% block nav %}{% endblock %}
 
 {% block content %}
 
-  {% translate "Your password has been changed." as message %}
+  {% trans "Your password has been changed." as message %}
   {% include "components/alert.html" with type="success" %}
 
-  {% translate "Go to the home page" as text %}
+  {% trans "Go to the home page" as text %}
   {% url 'tabbycat-index' as index %}
   {% include "components/item-action.html" with icon="home" url=index %}
 

--- a/tabbycat/templates/registration/password_change_form.html
+++ b/tabbycat/templates/registration/password_change_form.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load add_field_css i18n %}
 
-{% block page-title %}🔐{% translate "Password Change" context "page title" %}{% endblock %}
+{% block page-title %}🔐{% trans "Password Change" context "page title" %}{% endblock %}
 {% block head-title %}{% endblock %}
 
 {% block nav %}{% endblock %}
@@ -13,10 +13,10 @@
   <div class="col-lg-8 ml-lg-auto mr-md-auto">
 
     {% if user and user.is_staff %}
-      {% blocktranslate trimmed asvar p1 with api_token=user.auth_token.key %}
+      {% blocktrans trimmed asvar p1 with api_token=user.auth_token.key %}
         API Token: <samp>{{ api_token }}</samp>
-      {% endblocktranslate %}
-      {% translate "The API token will allow you to authorize external applications to access the site as staff." as p2 %}
+      {% endblocktrans %}
+      {% trans "The API token will allow you to authorize external applications to access the site as staff." as p2 %}
       {% include "components/explainer-card.html" with type="info" %}
     {% endif %}
 
@@ -24,14 +24,14 @@
       <form id="reset-confirm" action="." method="POST">
       {% csrf_token %}
 
-        {% translate "Password Change" context "page title" as title %}
-        {% translate "Please enter your old password, then enter a new one." as text %}
+        {% trans "Password Change" context "page title" as title %}
+        {% trans "Please enter your old password, then enter a new one." as text %}
         {% include "components/form-title.html" with emoji="🔐" p1="" p2="" %}
 
         {% include "components/form-main.html" %}
 
-        {% translate "Change my password" context "button" as title %}
-        {% translate "Cancel and go back to the site home page" as subtitle %}
+        {% trans "Change my password" context "button" as title %}
+        {% trans "Cancel and go back to the site home page" as subtitle %}
         {% url 'tabbycat-index' as suburl %}
         {% include "components/form-submit.html" %}
 

--- a/tabbycat/templates/registration/password_reset_complete.html
+++ b/tabbycat/templates/registration/password_reset_complete.html
@@ -1,17 +1,17 @@
 {% extends "base.html" %}
 {% load add_field_css i18n %}
 
-{% block page-title %}🔓{% translate "Password reset complete" context "page title" %}{% endblock %}
-{% block head-title %}<span class="emoji">🔓</span>{% translate "Password reset complete" context "page title" %}{% endblock %}
+{% block page-title %}🔓{% trans "Password reset complete" context "page title" %}{% endblock %}
+{% block head-title %}<span class="emoji">🔓</span>{% trans "Password reset complete" context "page title" %}{% endblock %}
 
 {% block nav %}{% endblock %}
 
 {% block content %}
 
-  {% translate "Your password has been reset." as message %}
+  {% trans "Your password has been reset." as message %}
   {% include "components/alert.html" with type="success" icon="info" %}
 
-  {% translate "Go to the login page" as text %}
+  {% trans "Go to the login page" as text %}
   {% url 'login' as login_url %}
   {% include "components/item-action.html" with icon="log-in" url=login_url %}
 

--- a/tabbycat/templates/registration/password_reset_confirm.html
+++ b/tabbycat/templates/registration/password_reset_confirm.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load add_field_css i18n %}
 
-{% block page-title %}🔐{% translate "Password Reset Confirmation" context "page title" %}{% endblock %}
+{% block page-title %}🔐{% trans "Password Reset Confirmation" context "page title" %}{% endblock %}
 {% block head-title %}{% endblock %}
 
 {% block nav %}{% endblock %}
@@ -13,24 +13,24 @@
 
     {% if validlink %}
       <div class="card">
-        {% translate "Password Reset" context "page title" as title %}
+        {% trans "Password Reset" context "page title" as title %}
         {% include "components/form-title.html" with emoji="🔐" p1="" p2="" %}
-        {% translate "Please enter a new password (twice):" as text %}
+        {% trans "Please enter a new password (twice):" as text %}
 
         <form id="reset-confirm" action="." method="POST">
           {% csrf_token %}
 
           {% include "components/form-main.html" %}
 
-          {% translate "Change my password" context "button" as title %}
-          {% translate "Cancel and go back to the site home page" as subtitle %}
+          {% trans "Change my password" context "button" as title %}
+          {% trans "Cancel and go back to the site home page" as subtitle %}
           {% url 'tabbycat-index' as suburl %}
           {% include "components/form-submit.html" %}
         </form>
       </div>
 
     {% else %}
-      {% translate "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset." as text %}
+      {% trans "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset." as text %}
       {% include "components/explainer-card.html" with type="danger" %}
     {% endif %}
 

--- a/tabbycat/templates/registration/password_reset_done.html
+++ b/tabbycat/templates/registration/password_reset_done.html
@@ -1,18 +1,18 @@
 {% extends "base.html" %}
 {% load add_field_css i18n %}
 
-{% block page-title %}🔐{% translate "Password reset email sent" context "page title" %}{% endblock %}
-{% block head-title %}<span class="emoji">🔐</span>{% translate "Password reset email sent" context "page title" %}{% endblock %}
+{% block page-title %}🔐{% trans "Password reset email sent" context "page title" %}{% endblock %}
+{% block head-title %}<span class="emoji">🔐</span>{% trans "Password reset email sent" context "page title" %}{% endblock %}
 
 {% block nav %}{% endblock %}
 
 {% block content %}
 
-  {% translate "We've emailed you instructions for setting your password, if an account exists with the email address you entered. You should receive them shortly." as reset_message %}
-  {% translate "If you don't receive an email, please make sure you've entered the address you registered with, and check your spam folder." as reset_extra %}
+  {% trans "We've emailed you instructions for setting your password, if an account exists with the email address you entered. You should receive them shortly." as reset_message %}
+  {% trans "If you don't receive an email, please make sure you've entered the address you registered with, and check your spam folder." as reset_extra %}
   {% include "components/alert.html" with type="success" icon="info" message=reset_message extra=reset_extra %}
 
-  {% translate "Go to the login page" as text %}
+  {% trans "Go to the login page" as text %}
   {% url 'login' as login_url %}
   {% include "components/item-action.html" with icon="log-in" url=login_url %}
 

--- a/tabbycat/templates/registration/password_reset_email.html
+++ b/tabbycat/templates/registration/password_reset_email.html
@@ -1,15 +1,15 @@
 {% load i18n %}
-{% blocktranslate trimmed with user=user.get_username %}
+{% blocktrans trimmed with user=user.get_username %}
 Hi, {{ user }}!
-{% endblocktranslate %}
+{% endblocktrans %}
 
-{% blocktranslate trimmed %}
+{% blocktrans trimmed %}
 Someone asked for a password reset for the email address {{ email }} on the Tabbycat site at {{ protocol }}://{{ domain }}.
-{% endblocktranslate %}
+{% endblocktrans %}
 
-{% translate 'If this was you, follow the link below to reset your password:' %}
+{% trans 'If this was you, follow the link below to reset your password:' %}
 {{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}
 
-{% blocktranslate trimmed %}
+{% blocktrans trimmed %}
 If this wasn't you, that probably means someone else typed your email address into the password reset form on the Tabbycat site at {{ protocol }}://{{ domain }}.
-{% endblocktranslate %}
+{% endblocktrans %}

--- a/tabbycat/templates/registration/password_reset_form.html
+++ b/tabbycat/templates/registration/password_reset_form.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load add_field_css i18n %}
 
-{% block page-title %}🔐{% translate "Password Reset" context "page title" %}{% endblock %}
+{% block page-title %}🔐{% trans "Password Reset" context "page title" %}{% endblock %}
 {% block head-title %}{% endblock %}
 
 {% block nav %}{% endblock %}
@@ -21,22 +21,22 @@
 
           <div class="list-group-item pb-0">
             <h4 class="card-title mb-4">
-              <span class="emoji">🔐</span>{% translate "Password Reset" context "page title" %}
+              <span class="emoji">🔐</span>{% trans "Password Reset" context "page title" %}
             </h4>
             <p class="text-info">
-              {% translate "Enter your email address below, and we'll email you a password reset link." %}
+              {% trans "Enter your email address below, and we'll email you a password reset link." %}
             </p>
           </div>
 
           <div class="list-group-item pt-4 pb-4">
 
             {% if form.errors %}
-              {% translate "Please enter a valid email address." as message %}
+              {% trans "Please enter a valid email address." as message %}
               {% include "components/form-errors.html" with errors=form.errors %}
             {% endif %}
             {% with field=form.email %}
               <div class="mb-3">
-                <label for="{{ field.id_for_label }}">{% translate "Email address" %}</label>
+                <label for="{{ field.id_for_label }}">{% trans "Email address" %}</label>
                 {{ field|addcss:"form-control" }}
                 {{ field.errors }}
               </div>
@@ -47,10 +47,10 @@
           <div class="list-group-item pt-4 pb-3">
 
             <button type="submit" class="btn btn-block btn-success mb-3">
-              {% translate "Reset my password" context "button" %}
+              {% trans "Reset my password" context "button" %}
             </button>
             <div class="text-center">
-              <a href="{% url 'login' %}">{% translate "Back to the login page" %}</a>
+              <a href="{% url 'login' %}">{% trans "Back to the login page" %}</a>
             </div>
 
           </div>

--- a/tabbycat/templates/registration/password_reset_subject.txt
+++ b/tabbycat/templates/registration/password_reset_subject.txt
@@ -1,3 +1,3 @@
 {% load i18n %}{% autoescape off %}
-{% blocktranslate %}Password reset on Tabbycat site at {{ domain }}{% endblocktranslate %}
+{% blocktrans %}Password reset on Tabbycat site at {{ domain }}{% endblocktrans %}
 {% endautoescape %}

--- a/tabbycat/tournaments/templates/assistant_tournament_index.html
+++ b/tabbycat/tournaments/templates/assistant_tournament_index.html
@@ -1,13 +1,13 @@
 {% extends "base.html" %}
 {% load i18n debate_tags static %}
 
-{% block page-title %}{% translate "Dashboard" %}{% endblock %}
-{% block head-title %}<span class="emoji">⏰</span> {% translate "Overview" %}{% endblock %}
+{% block page-title %}{% trans "Dashboard" %}{% endblock %}
+{% block head-title %}<span class="emoji">⏰</span> {% trans "Overview" %}{% endblock %}
 
 {% block sub-title %}
-  {% blocktranslate trimmed with round=round.name status=round.get_draw_status_display.lower %}
+  {% blocktrans trimmed with round=round.name status=round.get_draw_status_display.lower %}
     current round: {{ round }}, status: {{ status }}
-  {% endblocktranslate %}
+  {% endblocktrans %}
 {% endblock %}
 
 {% block page-alerts %}

--- a/tabbycat/tournaments/templates/blank_site_start.html
+++ b/tabbycat/tournaments/templates/blank_site_start.html
@@ -4,7 +4,7 @@
 {% block nav %}{% endblock %}
 
 {% block head-title %}{% endblock %}
-{% block page-title %}{% translate "Welcome to Tabbycat!" %}{% endblock %}
+{% block page-title %}{% trans "Welcome to Tabbycat!" %}{% endblock %}
 
 {% block content %}
 
@@ -17,27 +17,27 @@
       <form action="." method="POST">
       {% csrf_token %}
 
-        {% translate "Welcome to Tabbycat!" as title %}
+        {% trans "Welcome to Tabbycat!" as title %}
         {% include "components/form-title.html" with emoji="👋" %}
 
-        {% blocktranslate trimmed asvar p1 %}
+        {% blocktrans trimmed asvar p1 %}
           To get started, you'll need to create the first user account. This account
           is a "superuser" account: it will be able to edit anything on the site.
           Therefore, you should use a strong password.
-        {% endblocktranslate %}
-         {% blocktranslate trimmed asvar p2 %}
+        {% endblocktrans %}
+         {% blocktrans trimmed asvar p2 %}
           You can only create this account once, but if you like, you can change the
           username and password after it's created, or add new superusers afterwards.
-        {% endblocktranslate %}
-        {% blocktranslate trimmed asvar p3 %}
+        {% endblocktrans %}
+        {% blocktrans trimmed asvar p3 %}
           The email address is used for password resets. You don't have to
           provide one, but if you don't, you won't be able to reset your password
           if you forget it.
-        {% endblocktranslate %}
+        {% endblocktrans %}
         {% include "components/form-title.html" with title=None %}
 
         {% include "components/form-main.html" %}
-        {% translate "Create Account" as title %}
+        {% trans "Create Account" as title %}
         {% include "components/form-submit.html" %}
 
       </form>

--- a/tabbycat/tournaments/templates/configure_tournament.html
+++ b/tabbycat/tournaments/templates/configure_tournament.html
@@ -2,11 +2,11 @@
 {% load add_field_css i18n %}
 
 {% block head-title %}<span class="emoji">🏆</span>
-  {% blocktranslate trimmed with tournament=tournament.short_name %}
+  {% blocktrans trimmed with tournament=tournament.short_name %}
     Configure Tournament {{ tournament }}
-  {% endblocktranslate %}
+  {% endblocktrans %}
 {% endblock %}
-{% block page-title %}{% translate "Tabbycat" %}{% endblock %}
+{% block page-title %}{% trans "Tabbycat" %}{% endblock %}
 {% block body-class %}override-sidebar-offset{% endblock %}
 
 {% block nav %}{% endblock %}
@@ -17,12 +17,12 @@
     <div class="list-group list-group-flush">
       <form action="." method="POST">
 
-        {% translate "To finish creating your tournament select a basic configuration options. Note that these can always be changed later (and with more precise control) if needed." as text %}
+        {% trans "To finish creating your tournament select a basic configuration options. Note that these can always be changed later (and with more precise control) if needed." as text %}
         {% include "components/form-title.html" %}
 
         {% include "components/form-main.html" %}
 
-        {% translate "Configure Tournament" as title %}
+        {% trans "Configure Tournament" as title %}
         {% include "components/form-submit.html" %}
 
       </form>

--- a/tabbycat/tournaments/templates/create_tournament.html
+++ b/tabbycat/tournaments/templates/create_tournament.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 {% load add_field_css i18n %}
 
-{% block head-title %}<span class="emoji">🏆</span>{% translate "Create New Tournament"%}{% endblock %}
-{% block page-title %}{% translate "Tabbycat" %}{% endblock %}
+{% block head-title %}<span class="emoji">🏆</span>{% trans "Create New Tournament"%}{% endblock %}
+{% block page-title %}{% trans "Tabbycat" %}{% endblock %}
 {% block sidebar %}{% endblock %} {# Need to override sidebar manually it will crash when no tournaments are present. Ideally this would be handled with the Mixins but this is a relatively unique view as it is part of Tournaments but is admin-only and thus shown with the sidebar #}
 
 {% block page-alerts %}
@@ -12,26 +12,26 @@
 {% block content %}
 
   {% url 'donations' as donations_url %}
-  {% blocktranslate trimmed asvar donation %}
+  {% blocktrans trimmed asvar donation %}
     Tabbycat is free to use for non-profit and non-fundraising tournaments
     (although donations are encouraged). If your tournament is run for profit
     or for fundraising, please note that there is a
     <a href="{{ donations_url }}">required payment</a>. For more details, see the <a href="http://tabbycat.readthedocs.io/en/stable/about/licence.html">
     Tabbycat licence agreement</a>.
-  {% endblocktranslate %}
+  {% endblocktrans %}
   {% include "components/explainer-card.html" with type="primary" p1=donation %}
 
   <div class="card border-info text-info mt-3">
     <div class="card-body">
 
-      <strong>{% translate "Just trying out Tabbycat?" %}</strong>
-      {% blocktranslate trimmed %}
+      <strong>{% trans "Just trying out Tabbycat?" %}</strong>
+      {% blocktrans trimmed %}
         If you're learning or playing around with Tabbycat, it's easiest to
         create a demo tournament that is prepopulated with a fake (but typical)
         set of teams, adjudicators, rooms, and the like. You can then delete
         this demo tournament later on, or deploy a new instance for your real
         tournament.
-      {% endblocktranslate %}
+      {% endblocktrans %}
 
       <div class="row mt-3">
         {% for slug, demo in demo_datasets %}
@@ -39,17 +39,17 @@
             <form action="{% url 'load-demo' %}" method="POST">
               <input type="hidden" name="source" value="{{ slug }}">
               <button type="submit" class="btn btn-info btn-block">
-                {% blocktranslate trimmed %}
+                {% blocktrans trimmed %}
                   Load {{ demo }}
-                {% endblocktranslate %}
+                {% endblocktrans %}
               </button>
             </form>
             {% if slug in preexisting %}
               <div class="alert alert-warning mt-3 mb-0 small">
-                {% blocktranslate trimmed %}
+                {% blocktrans trimmed %}
                   You already have a tournament set up using this data set. Reloading
                   the data will delete <strong>all data</strong> from that tournament.
-                {% endblocktranslate %}
+                {% endblocktrans %}
               </div>
             {% endif %}
           </div>
@@ -66,8 +66,8 @@
 
       {% include "components/form-main.html" %}
 
-      {% translate "Create Tournament" as title %}
-      {% translate "Cancel and go back to the site home page" as subtitle %}
+      {% trans "Create Tournament" as title %}
+      {% trans "Cancel and go back to the site home page" as subtitle %}
       {% url 'tabbycat-index' as suburl %}
       {% include "components/form-submit.html" %}
 

--- a/tabbycat/tournaments/templates/fix_debate_teams.html
+++ b/tabbycat/tournaments/templates/fix_debate_teams.html
@@ -3,7 +3,7 @@
 
 {% block page-title %}Debate Team Error{% endblock %}
 {% block head-title %}
-  <span class="emoji">‼️</span>{% translate "Debate Team Missing" %}
+  <span class="emoji">‼️</span>{% trans "Debate Team Missing" %}
 {% endblock %}
 
 
@@ -13,61 +13,61 @@
   <div class="card-body">
 
     <p class="card-text">
-      {% blocktranslate trimmed %}
+      {% blocktrans trimmed %}
         Tabbycat always requires that, in every debate, one and only one team is
         assigned to each side. When that is not the case, this error occurs.
         Usually, this is the result of debates having been manually edited.
-      {% endblocktranslate %}
+      {% endblocktrans %}
     </p>
 
     <p class="card-text">
-      {% blocktranslate trimmed %}
+      {% blocktrans trimmed %}
         A list of offending debates is presented below. To fix them, you'll need
         to do the following:
-      {% endblocktranslate %}
+      {% endblocktrans %}
     </p>
 
     <ol>
       <li>
         {# Translators: This is in a list of instructions. #}
-        {% blocktranslate trimmed %}
+        {% blocktrans trimmed %}
           Click the <strong>Fix this debate</strong> button for that debate.
-        {% endblocktranslate %}
+        {% endblocktrans %}
       </li>
       <li>
         {# Translators: This is in a list of instructions. #}
-        {% blocktranslate trimmed %}
+        {% blocktrans trimmed %}
           Ensure that every <strong>side</strong> that should be present in the
           debate is present and has a <strong>team</strong> assigned. If a team
           is missing, find an empty row and use the magnifying glass to select a
           team. Then set the new team's <strong>side</strong> accordingly.
-        {% endblocktranslate %}
+        {% endblocktrans %}
       </li>
       <li>
         {# Translators: This is in a list of instructions. #}
-        {% blocktranslate trimmed %}
+        {% blocktrans trimmed %}
           Ensure that no <strong>side</strong> appears more than once in the
           debate.
-        {% endblocktranslate %}
+        {% endblocktrans %}
       </li>
       <li>
         {# Translators: This is in a list of instructions. #}
-        {% blocktranslate trimmed %}
+        {% blocktrans trimmed %}
           <strong>Save</strong> the changes.
-        {% endblocktranslate %}
+        {% endblocktrans %}
       </li>
     </ol>
 
     <p class="card-text">
-      {% blocktranslate trimmed %}
+      {% blocktrans trimmed %}
         Once you've fixed all the debates, you should then be
         able to return to whatever page you were originally on without the error
         reoccurring.
-      {% endblocktranslate %}
+      {% endblocktrans %}
       {% url 'admin:draw_debate_changelist' as edit_debates_url %}
-      {% blocktranslate trimmed %}
+      {% blocktrans trimmed %}
         You can also see all the debates in the <a href="{{ edit_debates_url }}" target="_blank">Debates section of the Edit Database Area</a>.
-      {% endblocktranslate %}
+      {% endblocktrans %}
     </p>
   </div>
 </div>
@@ -79,15 +79,15 @@
       <table class="table">
         <thead>
           <tr>
-            <th>{% translate "Debate ID" %}</th>
+            <th>{% trans "Debate ID" %}</th>
             {% for side in side_names %}
               <th>
-                {% blocktranslate trimmed %}
+                {% blocktrans trimmed %}
                   Team(s) on {{ side }}
-                {% endblocktranslate %}
+                {% endblocktrans %}
               </th>
             {% endfor %}
-            <th>{% translate "Link to fix this debate" %}</th>
+            <th>{% trans "Link to fix this debate" %}</th>
           </tr>
         </thead>
         <tbody>
@@ -98,7 +98,7 @@
                 {% with nteams=teams_on_side|length %}
                   {% if nteams == 0 %}
                     <td class="text-danger">
-                      <strong>{% translate "No teams" %}</strong>
+                      <strong>{% trans "No teams" %}</strong>
                     </td>
                   {% elif nteams == 1 %}
                     <td>
@@ -106,7 +106,7 @@
                     </td>
                   {% else %}
                     <td class="text-danger">
-                      <strong>{% translate "Multiple teams" %}</strong><br>
+                      <strong>{% trans "Multiple teams" %}</strong><br>
                       {% for team in teams_on_side %}
                         {{ team.short_name }}<br>
                       {% endfor %}
@@ -117,15 +117,15 @@
               <td>
                 <a href="{% url 'admin:draw_debate_change' debate.id %}#/tab/inline_0/"
                    class="btn btn-block btn-success" target="_blank">
-                   {% translate "Fix this debate" context "button label" %}
+                   {% trans "Fix this debate" context "button label" %}
                 </a>
               </td>
             </tr>
           {% empty %}
             <tr>
               <td colspan="{{ side_names|length|add:2 }}" class="text-center table-success">
-                <p>{% translate "It looks like all debates are in good shape!" %}</p>
-                <p>{% translate "If you keep getting redirected to this page and you're not sure why, please contact the developers of Tabbycat." %}</p>
+                <p>{% trans "It looks like all debates are in good shape!" %}</p>
+                <p>{% trans "If you keep getting redirected to this page and you're not sure why, please contact the developers of Tabbycat." %}</p>
               </td>
             </tr>
           {% endfor %}

--- a/tabbycat/tournaments/templates/public_tournament_index.html
+++ b/tabbycat/tournaments/templates/public_tournament_index.html
@@ -2,20 +2,20 @@
 {% load debate_tags i18n static %}
 
 {% block head-title %}<span class="emoji">👋</span>
-{% blocktranslate trimmed with tournament=tournament.name %}
+{% blocktrans trimmed with tournament=tournament.name %}
     Welcome to {{ tournament }}
-{% endblocktranslate %}{% endblock %}
+{% endblocktrans %}{% endblock %}
 {% block page-title %}
-  {% blocktranslate trimmed with tournament=tournament.name %}
+  {% blocktrans trimmed with tournament=tournament.name %}
     Welcome to {{ tournament }}
-  {% endblocktranslate %}
+  {% endblocktrans %}
 {% endblock %}
 
 {% block page-alerts %}
   {% if not pref.team_tab_released and not pref.motion_tab_released and pref.public_draw == 'off' and not pref.public_results and not pref.public_motions and not pref.public_team_standings and not pref.public_breaking_teams and not pref.public_breaking_adjs and not pref.public_participants and not pref.feedback_progress and pref.participant_ballots == 'off' and pref.participant_feedback == 'off' %}
     <div class="alert alert-info">
       <i data-feather="alert-circle"></i>
-      {% translate "There is currently no public information available for this tournament." %}
+      {% trans "There is currently no public information available for this tournament." %}
     </div>
   {% endif %}
 {% endblock %}
@@ -37,23 +37,23 @@
       <div class="list-group mt-2">
 
         {% if pref.team_tab_released > 0 %}
-          {% translate "Team Tab" as text %}
+          {% trans "Team Tab" as text %}
           {% tournamenturl 'standings-public-tab-team' as url %}
           {% include "components/item-action.html" with icon="users" %}
         {% endif %}
 
         {% if pref.break_category_tabs_released > 0 %}
           {% for category in tournament.break_categories_nongeneral %}
-            {% blocktranslate asvar text trimmed with category=category.name %}
+            {% blocktrans asvar text trimmed with category=category.name %}
               {{ category }} Team Tab
-            {% endblocktranslate %}
+            {% endblocktrans %}
             {% tournamenturl 'standings-public-tab-break-category' category=category.slug as url %}
             {% include "components/item-action.html" with icon="users" %}
           {% endfor %}
         {% endif %}
 
         {% if pref.speaker_tab_released > 0 %}
-          {% translate "Speaker Tab" as text %}
+          {% trans "Speaker Tab" as text %}
           {% tournamenturl 'standings-public-tab-speaker' as url %}
           {% include "components/item-action.html" with icon="user" %}
         {% endif %}
@@ -61,9 +61,9 @@
         {% if pref.speaker_category_tabs_released > 0 %}
           {% for category in tournament.speakercategory_set.all %}
             {% if category.public %}
-              {% blocktranslate asvar text trimmed with category=category.name %}
+              {% blocktrans asvar text trimmed with category=category.name %}
                 {{ category }} Speaker Tab
-              {% endblocktranslate %}
+              {% endblocktrans %}
               {% tournamenturl 'standings-public-tab-speaker-category' category=category.slug as url %}
               {% include "components/item-action.html" with icon="user" %}
             {% endif %}
@@ -71,25 +71,25 @@
         {% endif %}
 
         {% if pref.replies_tab_released > 0 %}
-          {% translate "Replies Tab" as text %}
+          {% trans "Replies Tab" as text %}
           {% tournamenturl 'standings-public-tab-replies' as url %}
           {% include "components/item-action.html" with icon="corner-up-right" %}
         {% endif %}
 
         {% if pref.adjudicators_tab_released %}
-          {% translate "Adjudicator Tab" as text %}
+          {% trans "Adjudicator Tab" as text %}
           {% tournamenturl 'standings-public-adjudicators-tab' as url %}
           {% include "components/item-action.html" with icon="sun" %}
         {% endif %}
 
         {% if pref.motion_tab_released %}
-          {% translate "Motions Tab" as text %}
+          {% trans "Motions Tab" as text %}
           {% tournamenturl 'motions-public-statistics' as url %}
           {% include "components/item-action.html" with icon="file-text" %}
         {% endif %}
 
         {% if public_side_allocations %}
-          {% translate "Sides" as text %}
+          {% trans "Sides" as text %}
           {% tournamenturl 'draw-public-side-allocations' as url %}
           {% include "components/item-action.html" with icon="shuffle" %}
         {% endif %}
@@ -98,105 +98,105 @@
           {% tournamenturl 'draw-public-current-rounds' as url %}
           {% if tournament.public_draws_available %}
             {% if tournament.current_rounds|length == 1 %}
-              {% blocktranslate trimmed with round=current_round.name asvar draw_for_round_text %}
+              {% blocktrans trimmed with round=current_round.name asvar draw_for_round_text %}
                 Draw for {{ round }}
-              {% endblocktranslate %}
+              {% endblocktrans %}
             {% else %}
-              {% translate "Draws for Current Rounds" as draw_for_round_text %}
+              {% trans "Draws for Current Rounds" as draw_for_round_text %}
             {% endif %}
             {% include "components/item-action.html" with icon="eye" text=draw_for_round_text %}
           {% else %}
             {% if tournament.current_rounds|length == 1 %}
-              {% blocktranslate trimmed with round=current_round.name asvar draw_for_round_text %}
+              {% blocktrans trimmed with round=current_round.name asvar draw_for_round_text %}
                 {{ round }}'s draw has yet to be released
-              {% endblocktranslate %}
+              {% endblocktrans %}
             {% else %}
-              {% translate "The draw for the next round has yet to be released" as draw_for_round_text %}
+              {% trans "The draw for the next round has yet to be released" as draw_for_round_text %}
             {% endif %}
             {% include "components/item-info.html" with icon="eye-off" text=draw_for_round_text type="muted" nopad=True %}
           {% endif %}
         {% endif %}
 
         {% if pref.public_checkins %}
-          {% translate "Check-Ins" as text %}
+          {% trans "Check-Ins" as text %}
           {% tournamenturl 'checkins-public-status' as url %}
           {% include "components/item-action.html" with icon="compass" %}
         {% endif %}
 
         {% if pref.public_results and tournament.rounds_with_released_results.exists %}
-          {% translate "Results" as text %}
+          {% trans "Results" as text %}
           {% tournamenturl 'results-public-index' as url %}
           {% include "components/item-action.html" with icon="trending-up" %}
         {% endif %}
 
         {% if pref.public_motions %}
-          {% translate "Motions" as text %}
+          {% trans "Motions" as text %}
           {% tournamenturl 'motions-public' as url %}
           {% include "components/item-action.html" with icon="file-text" %}
         {% endif %}
 
         {% if pref.public_motions and not pref.motion_tab_released and pref.draw_side_allocations == 'manual-ballot' %}
-          {% translate "Sides" as text %}
+          {% trans "Sides" as text %}
           {% tournamenturl 'draw-public-side-allocations' as url %}
           {% include "components/item-action.html" with icon="shuffle" %}
         {% endif %}
 
         {% if pref.public_team_standings and current_round.prev and not pref.team_tab_released %}
-          {% translate "Team Standings" as text %}
+          {% trans "Team Standings" as text %}
           {% tournamenturl 'standings-public-teams-current' as url %}
           {% include "components/item-action.html" with icon="bar-chart-2" %}
         {% endif %}
 
         {% if pref.public_breaking_teams %}
           {% for category in tournament.breakcategory_set.all %}
-            {% blocktranslate trimmed asvar text with category=category.name %}
+            {% blocktrans trimmed asvar text with category=category.name %}
               {{ category }} Break
-            {% endblocktranslate %}
+            {% endblocktrans %}
             {% tournamenturl 'breakqual-public-teams' category.slug as url %}
             {% include "components/item-action.html" with icon="pie-chart" %}
           {% endfor %}
         {% endif %}
 
         {% if pref.public_breaking_adjs %}
-          {% translate "Breaking Adjudicators" as text %}
+          {% trans "Breaking Adjudicators" as text %}
           {% tournamenturl 'breakqual-public-adjs' as url %}
           {% include "components/item-action.html" with icon="shield" %}
         {% endif %}
 
         {% if pref.public_diversity %}
-          {% translate "Diversity" as text %}
+          {% trans "Diversity" as text %}
           {% tournamenturl 'standings-public-diversity' as url %}
           {% include "components/item-action.html" with icon="globe" %}
         {% endif %}
 
         {% if pref.public_participants %}
-          {% translate "Participants" as text %}
+          {% trans "Participants" as text %}
           {% tournamenturl 'participants-public-list' as url %}
           {% include "components/item-action.html" with icon="users" %}
         {% endif %}
 
         {% if pref.public_institutions_list %}
-          {% translate "Institutions" as text %}
+          {% trans "Institutions" as text %}
           {% tournamenturl 'participants-public-institutions-list' as url %}
           {% include "components/item-action.html" with icon="flag" %}
         {% endif %}
 
         {% if pref.feedback_progress %}
-          {% translate "Feedback Progress" as text %}
+          {% trans "Feedback Progress" as text %}
           {% tournamenturl 'public_feedback_progress' as url %}
           {% include "components/item-action.html" with icon="aperture" %}
         {% endif %}
 
         {% if pref.participant_ballots == 'public' %}
           {% for round in tournament.current_rounds %}
-            {% blocktranslate trimmed with round=round.name asvar text %}Enter Ballot for {{round }}{% endblocktranslate %}
+            {% blocktrans trimmed with round=round.name asvar text %}Enter Ballot for {{round }}{% endblocktrans %}
             {% roundurl 'results-public-ballot-submission-index' as url %}
             {% include "components/item-action.html" with icon="plus-circle" %}
           {% endfor %}
         {% endif %}
 
         {% if pref.participant_feedback == 'public' %}
-          {% translate "Enter Feedback" as text %}
+          {% trans "Enter Feedback" as text %}
           {% tournamenturl 'adjfeedback-public-add-index' as url %}
           {% include "components/item-action.html" with icon="plus-square" %}
         {% endif %}

--- a/tabbycat/tournaments/templates/round_complete_check.html
+++ b/tabbycat/tournaments/templates/round_complete_check.html
@@ -1,28 +1,28 @@
 {% extends "base.html" %}
 {% load i18n debate_tags %}
 
-{% block page-title %}{% translate "Confirm Round Completion" %}{% endblock %}
+{% block page-title %}{% trans "Confirm Round Completion" %}{% endblock %}
 {% block head-title %}
-  <span class="emoji">🙏</span> {% translate "Confirm Round Completion" %}
+  <span class="emoji">🙏</span> {% trans "Confirm Round Completion" %}
 {% endblock %}
-{% block sub-title %}{% blocktranslate trimmed with round=round.name %}for {{ round }}{% endblocktranslate %}{% endblock %}
+{% block sub-title %}{% blocktrans trimmed with round=round.name %}for {{ round }}{% endblocktrans %}{% endblock %}
 
 {% block page-subnav-actions %}
 
   <a href="{% roundurl 'results-round-list' %}" class="btn btn-outline-primary">
-    <i data-feather="chevron-left"></i>{% translate "Enter Results" %}
+    <i data-feather="chevron-left"></i>{% trans "Enter Results" %}
   </a>
 
 
   {% if emails_sent %}
-    <a href="{% roundurl 'progress-email' %}" class="btn btn-outline-secondary" data-toggle="tooltip" title="{% translate "Emails have already been sent." %}">
+    <a href="{% roundurl 'progress-email' %}" class="btn btn-outline-secondary" data-toggle="tooltip" title="{% trans "Emails have already been sent." %}">
   {% else %}
     <a href="{% roundurl 'progress-email' %}" class="btn btn-outline-primary active">
   {% endif %}
     {% if pref.teams_in_debate == "two" %}
-      {% translate "Email Team Wins/Losses" %}
+      {% trans "Email Team Wins/Losses" %}
     {% else %}
-      {% translate "Email Team Points" %}
+      {% trans "Email Team Points" %}
     {% endif %}
   </a>
 
@@ -31,25 +31,25 @@
       {% csrf_token %}
         {% if increment_ok and not prior_rounds_not_completed %}
           <button class="btn btn-success" id="completeRound" type="submit">
-            {% blocktranslate trimmed with round=round.name %}
+            {% blocktrans trimmed with round=round.name %}
               Mark {{ round }} as Completed
-            {% endblocktranslate %}
+            {% endblocktrans %}
             <i data-feather="chevron-right"></i>
           </button>
         {% else %}
           <button class="btn btn-danger" id="completeRound" type="submit">
-            {% blocktranslate trimmed with round=round.name %}
+            {% blocktrans trimmed with round=round.name %}
               Mark {{ round }} as Completed Anyway
-            {% endblocktranslate %}
+            {% endblocktrans %}
             <i data-feather="chevron-right"></i>
           </button>
         {% endif %}
     </form>
   {% elif round.next %}
     <a href="{% roundurl 'availability-index' round.next %}" class="btn btn-outline-primary">
-      {% blocktranslate trimmed with round=round.next.name %}
+      {% blocktrans trimmed with round=round.next.name %}
         Go to {{ round }}
-      {% endblocktranslate %}
+      {% endblocktrans %}
       <i data-feather="chevron-right"></i>
     </a>
   {% endif %}
@@ -59,28 +59,28 @@
 {% block page-alerts %}
 
   {% if round.completed %}
-    {% blocktranslate trimmed with round=round.name asvar message %}
+    {% blocktrans trimmed with round=round.name asvar message %}
       {{ round }} has already been marked as completed!
-    {% endblocktranslate %}
+    {% endblocktrans %}
     {% include 'components/alert.html' with type='danger' icon='alert-circle' %}
   {% elif prior_rounds_not_completed %}
-    {% blocktranslate trimmed count n=number_of_prior_rounds_not_completed asvar message %}
+    {% blocktrans trimmed count n=number_of_prior_rounds_not_completed asvar message %}
       The following prior round has not yet been completed: {{ prior_rounds_not_completed }}.
       You should complete it before marking this round as completed.
     {% plural %}
       The following prior rounds have not yet been completed: {{ prior_rounds_not_completed }}.
       You should complete those before marking this round as completed.
-    {% endblocktranslate %}
+    {% endblocktrans %}
     {% include 'components/alert.html' with type='danger' icon='alert-circle' %}
 
   {% elif increment_ok %}
-    {% blocktranslate trimmed with round=round.name asvar message %}
+    {% blocktrans trimmed with round=round.name asvar message %}
       All ballots from {{ round }} are confirmed. You should be good to go!
-    {% endblocktranslate %}
+    {% endblocktrans %}
     {% include 'components/alert.html' with type='success' icon='check-circle' %}
 
   {% else %}
-    {% blocktranslate trimmed count num_unconfirmed=num_unconfirmed asvar message %}
+    {% blocktrans trimmed count num_unconfirmed=num_unconfirmed asvar message %}
       There is still {{ num_unconfirmed }} ballot that is not confirmed.
       You should <strong>not</strong> proceed to the next round until all
       ballots are confirmed.
@@ -88,7 +88,7 @@
       There are still {{ num_unconfirmed }} ballots that are not confirmed.
       You should <strong>not</strong> proceed to the next round until all
       ballots are confirmed.
-    {% endblocktranslate %}
+    {% endblocktrans %}
     {% include 'components/alert.html' with type='danger' icon='alert-circle' %}
   {% endif %}
 
@@ -96,7 +96,7 @@
     {% url 'admin:tournaments_round_changelist' as round_changelist_url %}
     {% tournamenturl 'options-tournament-section' section='public_features' as public_features_url %}
     {% if round.silent %}
-      {% blocktranslate trimmed asvar message %}
+      {% blocktrans trimmed asvar message %}
         <p>This round is a silent round.</p>
         <p>
           Even though public view of results is enabled, results for
@@ -107,10 +107,10 @@
           You can change which rounds are silent in the
           <a href="{{ round_changelist_url }}">Edit Database area</a>.
         </p>
-      {% endblocktranslate %}
+      {% endblocktrans %}
       {% include 'components/alert.html' with type='info' icon='eye-off' %}
     {% else %}
-      {% blocktranslate trimmed with round=round.name asvar message %}
+      {% blocktrans trimmed with round=round.name asvar message %}
         <p><strong>
           Results for {{ round }} will be published online once you mark
           this round as complete!
@@ -128,7 +128,7 @@
           If you want to disable the public view of results, you can do so in
           the <a href="{{ public_features_url }}">tournament configuration</a>.
         </p>
-      {% endblocktranslate %}
+      {% endblocktrans %}
       {% include 'components/alert.html' with type='warning' icon='alert-triangle' %}
     {% endif %}
   {% endif %}

--- a/tabbycat/tournaments/templates/set_current_round.html
+++ b/tabbycat/tournaments/templates/set_current_round.html
@@ -2,16 +2,16 @@
 {% load debate_tags %}
 {% load add_field_css i18n %}
 
-{% block page-title %}{% translate "Set Current Round" %}{% endblock %}
+{% block page-title %}{% trans "Set Current Round" %}{% endblock %}
 {% block head-title %}
-  <span class="emoji">🙏</span>{% translate "Set Current Round" %}
+  <span class="emoji">🙏</span>{% trans "Set Current Round" %}
 {% endblock %}
 
 {% block page-subnav-sections %}
   {% if current_round %}
     <a class="btn btn-primary "
        href="{% tournamenturl 'options-tournament-index' %}">
-      <i data-feather="chevron-left"></i> {% translate "Back to Configuration" %}
+      <i data-feather="chevron-left"></i> {% trans "Back to Configuration" %}
     </a>
   {% endif %}
 {% endblock %}
@@ -30,19 +30,19 @@
 {% if next %}
   <div class="alert alert-warning">
     <i data-feather="alert-circle"></i>
-    {% blocktranslate trimmed with tournament=tournament.name %}
+    {% blocktrans trimmed with tournament=tournament.name %}
       No round is currently set. In order for Tabbycat to work, please set the
       <strong>current round</strong> of the tournament
       <strong>{{ tournament }}</strong>.
-    {% endblocktranslate %}
+    {% endblocktrans %}
   </div>
 {% else %}
   <div class="alert alert-info">
     <i data-feather="alert-circle"></i>
-    {% blocktranslate trimmed with tournament=tournament.name %}
+    {% blocktrans trimmed with tournament=tournament.name %}
       On this page, you can set the <strong>current round</strong> of the tournament
       <strong>{{ tournament }}</strong>.
-    {% endblocktranslate %}
+    {% endblocktrans %}
   </div>
 {% endif %}
 
@@ -50,12 +50,12 @@
   <div class="alert alert-danger">
     <i data-feather="alert-circle"></i>
     {% url 'admin:tournaments_round_changelist' as round_changelist_url %}
-    {% blocktranslate trimmed with tournament=tournament.name %}
+    {% blocktrans trimmed with tournament=tournament.name %}
       The tournament <strong>{{ tournament }}</strong> has no rounds.
       You'll need to <a href="{{ round_changelist_url }}">add rounds and
       associate them with this tournament</a> before you can set the current
       round.
-    {% endblocktranslate %}
+    {% endblocktrans %}
   </div>
 {% endif %}
 
@@ -69,7 +69,7 @@
       {% include 'components/form-main.html' %}
 
       <button type="submit" class="btn btn-block btn-success form-control">
-        {% translate "Set Current Round" %}
+        {% trans "Set Current Round" %}
       </button>
 
     </form>

--- a/tabbycat/tournaments/templates/set_round_weights.html
+++ b/tabbycat/tournaments/templates/set_round_weights.html
@@ -1,14 +1,14 @@
 {% extends "base.html" %}
 {% load static debate_tags add_field_css i18n %}
 
-{% block head-title %}<span class="emoji">⚖️</span> {% translate 'Set Round Weights for Tapered Scoring' context 'page title' %}{% endblock %}
-{% block page-title %}{% translate 'Set Round Weights for Tapered Scoring' context 'page title' %}{% endblock %}
+{% block head-title %}<span class="emoji">⚖️</span> {% trans 'Set Round Weights for Tapered Scoring' context 'page title' %}{% endblock %}
+{% block page-title %}{% trans 'Set Round Weights for Tapered Scoring' context 'page title' %}{% endblock %}
 
 {% block page-alerts %}
-{% blocktranslate trimmed asvar p1 %}
+{% blocktrans trimmed asvar p1 %}
   Round weights are coefficients for the points received in each round.
   A team would get triple their team points obtained in a round with a weight of 3.
-{% endblocktranslate %}
+{% endblocktrans %}
 {% include "components/explainer-card.html" with p2="" type="info" %}
 {% endblock %}
 
@@ -38,7 +38,7 @@
           </li>
         {% endfor %}
 
-        {% translate "Set weights" context "button" as title %}
+        {% trans "Set weights" context "button" as title %}
         {% include "components/form-submit.html" %}
 
       </ul>

--- a/tabbycat/tournaments/templates/site_inactive_tournaments.html
+++ b/tabbycat/tournaments/templates/site_inactive_tournaments.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 {% load i18n %}
 
-{% block head-title %}<span class="emoji">🗄️</span> {% translate "Inactive Tournaments" %}{% endblock %}
-{% block page-title %}{% translate "Inactive Tournaments" %}{% endblock %}
+{% block head-title %}<span class="emoji">🗄️</span> {% trans "Inactive Tournaments" %}{% endblock %}
+{% block page-title %}{% trans "Inactive Tournaments" %}{% endblock %}
 
 {% block content %}
 

--- a/tabbycat/tournaments/templates/site_index.html
+++ b/tabbycat/tournaments/templates/site_index.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load i18n %}
 
-{% block head-title %}<span class="emoji">👋</span> {% translate "Welcome!" %}{% endblock %}
+{% block head-title %}<span class="emoji">👋</span> {% trans "Welcome!" %}{% endblock %}
 {% block page-title %}Home{% endblock %}
 
 {% block page-alerts %}
@@ -18,22 +18,22 @@
   <div class="list-group">
     {% if user.is_authenticated and not has_inactive %}
 
-      {% blocktranslate trimmed asvar text %}
+      {% blocktrans trimmed asvar text %}
         It looks like there aren't any tournaments on this site. Would you like to create one?
-      {% endblocktranslate %}
+      {% endblocktrans %}
       {% url 'tournament-create' as url %}
       {% include "components/item-action.html" with alone=True type="success" to_complete=True %}
 
     {% else %}
 
       {% if has_inactive %}
-        {% blocktranslate trimmed asvar p1 %}
+        {% blocktrans trimmed asvar p1 %}
           There are currently no active tournaments set up on this site.
-        {% endblocktranslate %}
+        {% endblocktrans %}
       {% else %}
-        {% blocktranslate trimmed asvar p1 %}
+        {% blocktrans trimmed asvar p1 %}
           There are currently no tournaments set up on this site.
-        {% endblocktranslate %}
+        {% endblocktrans %}
       {% endif %}
       {% include "components/explainer-card.html" with type="info" %}
 
@@ -44,7 +44,7 @@
 
 {% if has_inactive %}
   <div class="list-group mt-2">
-    {% translate "Inactive Tournaments" as text %}{% url 'tabbycat-inactive-tournaments' as url %}
+    {% trans "Inactive Tournaments" as text %}{% url 'tabbycat-inactive-tournaments' as url %}
     {% include "components/item-action.html" with icon="layers" %}
   </div>
 {% endif %}
@@ -52,16 +52,16 @@
 <div class="list-group mt-2">
   {% if user.is_superuser %}
 
-    {% translate "New Tournament" as text %}{% url 'tournament-create' as url %}
+    {% trans "New Tournament" as text %}{% url 'tournament-create' as url %}
     {% include "components/item-action.html" with icon="plus-circle" %}
 
-    {% translate "Edit Database Area" as text %}{% url 'admin:index' as url %}
+    {% trans "Edit Database Area" as text %}{% url 'admin:index' as url %}
     {% include "components/item-action.html" with icon="edit" %}
 
-    {% translate "Send a Test Email" as text %}{% url 'notifications-test-email' as url %}
+    {% trans "Send a Test Email" as text %}{% url 'notifications-test-email' as url %}
     {% include "components/item-action.html" with icon="send" %}
 
-    {% translate "Import DebateXML" as text %}{% url 'importer-archive' as url %}
+    {% trans "Import DebateXML" as text %}{% url 'importer-archive' as url %}
     {% include "components/item-action.html" with icon="archive" %}
 
   {% endif %}
@@ -70,17 +70,17 @@
 <div class="list-group mt-2">
   {% if user.is_authenticated %}
 
-    {% blocktranslate asvar text %}Get API Token / Change Password ({{ user }}){% endblocktranslate %}
+    {% blocktrans asvar text %}Get API Token / Change Password ({{ user }}){% endblocktrans %}
     {% url 'password_change' as url %}
     {% include "components/item-action.html" with icon="rotate-cw" %}
 
-    {% blocktranslate asvar text %}Log Out ({{ user }}){% endblocktranslate %}
+    {% blocktrans asvar text %}Log Out ({{ user }}){% endblocktrans %}
     {% url 'logout' as url %}
     {% include "components/item-action.html" with icon="log-out" %}
 
   {% else %}
 
-    {% translate "Log In as Admin" as text %}{% url 'login' as url %}
+    {% trans "Log In as Admin" as text %}{% url 'login' as url %}
     {% include "components/item-action.html" with icon="log-in" %}
 
   {% endif %}

--- a/tabbycat/tournaments/templates/tournament_index.html
+++ b/tabbycat/tournaments/templates/tournament_index.html
@@ -5,14 +5,14 @@
 
   {% if round.is_break_round %}
     {% tournamenturl 'tournament-donations' as url %}
-    {% blocktranslate trimmed with amount=tournament.billable_teams asvar text %}
+    {% blocktrans trimmed with amount=tournament.billable_teams asvar text %}
       We hope you've enjoyed using Tabbycat for your tournament. We would appreciate if you would
       make a donation to the project in order to support its ongoing development and maintenance.
       For a tournament of this size, we suggest a donation of <strong>${{ amount }}</strong>.
       Note that if your tournament is run for profit, or for fundraising, making this payment is a
       mandatory condition of Tabbycat's software license.
       <a href="{{ url }}">Learn more about donating.</a>
-    {% endblocktranslate %}
+    {% endblocktrans %}
     {% include "components/item-info.html" with type="info" icon="heart" %}
     <hr>
   {% endif %}
@@ -21,59 +21,59 @@
 
     <div class="card border-info text-info mb-3">
       <div class="card-body">
-        <h4 class="card-title">{% translate "Welcome to your new tournament!" %}</h4>
+        <h4 class="card-title">{% trans "Welcome to your new tournament!" %}</h4>
         <p class="card-text">
-          {% blocktranslate trimmed %}
+          {% blocktrans trimmed %}
             The next step is to import your initial tournament data: the
             institutions, teams, adjudicators and rooms that are in your
             tournament. There are a number of ways to do this. For small-to-medium
             tournaments, the simple importer is your best bet.
-          {% endblocktranslate %}
+          {% endblocktrans %}
           {# Translators: The documentation where the link goes to is in English; translations should mention this with "(in English)" after the link. #}
-          {% blocktranslate trimmed %}
+          {% blocktrans trimmed %}
             For more information, please consult our
             <a href="https://tabbycat.readthedocs.io/en/{{ readthedocs_version }}/use/importing-data.html" class="alert-link" target="_blank">
             documentation on importing initial data</a>.
-          {% endblocktranslate %}
+          {% endblocktrans %}
         </p>
       </div>
     </div>
 
     {% tournamenturl 'importer-simple-index' as url %}
-    {% translate "Use the simple importer to add your initial data." as text %}
+    {% trans "Use the simple importer to add your initial data." as text %}
     {% include "components/item-action.html" with alone=True to_complete=True %}
 
   {% elif round.draw_status == round.STATUS_NONE %}
 
     {% roundurl 'availability-index' round as url %}
-    {% blocktranslate trimmed with round=round.name asvar text %}
+    {% blocktrans trimmed with round=round.name asvar text %}
       Go to the checkins area to begin creating a draw for {{ round }}
-    {% endblocktranslate %}
+    {% endblocktrans %}
     {% include "components/item-action.html" with alone=True to_complete=True %}
 
   {% elif round.draw_status == round.STATUS_CONFIRMED %}
 
     {% roundurl 'draw' round as url %}
-    {% blocktranslate trimmed with round=round.name asvar text %}
+    {% blocktrans trimmed with round=round.name asvar text %}
       Go to the draw area to allocate adjudicators for {{ round }}
-    {% endblocktranslate %}
+    {% endblocktrans %}
     {% include "components/item-action.html" with alone=True to_complete=True %}
 
   {% elif round.draw_status == round.STATUS_RELEASED %}
 
     {% roundurl 'results-round-list' round as url %}
-    {% blocktranslate trimmed with round=round.name asvar text %}
+    {% blocktrans trimmed with round=round.name asvar text %}
       Go to the results area to begin entering ballots for {{ round }}
-    {% endblocktranslate %}
+    {% endblocktrans %}
     {% include "components/item-action.html" with alone=True to_complete=True %}
 
   {% endif %}
 
   {% if global_preferences.accounts__admin_account_key or global_preferences.accounts__assistant_account_key %}
     {% tournamenturl 'options-tournament-section' section='global' as url %}
-    {% blocktranslate trimmed asvar text %}
+    {% blocktrans trimmed asvar text %}
       You have enabled a URL that allows users to create new accounts. You should <strong>disable it once the tournament starts</strong>.
-    {% endblocktranslate %}
+    {% endblocktrans %}
     <div class="mt-3">
       {% include "components/item-action.html" with alone=True type="warning" icon="alert-triangle" to_complete=True %}
     </div>

--- a/tabbycat/tournaments/templates/tournament_index_links.html
+++ b/tabbycat/tournaments/templates/tournament_index_links.html
@@ -7,21 +7,21 @@
   {% url 'tournament-public-index' tournament_slug=tournament.slug as public_url %}
 
   {% if user.is_superuser %}
-    {% blocktranslate trimmed asvar text with tn=tournament.name %}
+    {% blocktrans trimmed asvar text with tn=tournament.name %}
       Administrator area for <strong>{{ tn }}</strong>
-    {% endblocktranslate %}
+    {% endblocktrans %}
     {% include "components/item-action.html" with icon="settings" url=admin_url %}
   {% endif %}
 
   {% if user.is_authenticated %}
-    {% blocktranslate trimmed asvar text with tn=tournament.name %}
+    {% blocktrans trimmed asvar text with tn=tournament.name %}
       Assistant area for <strong>{{ tn }}</strong>
-    {% endblocktranslate %}
+    {% endblocktrans %}
    {% include "components/item-action.html" with icon="pocket" url=assistant_url %}
 
-    {% blocktranslate trimmed asvar text with tn=tournament.name %}
+    {% blocktrans trimmed asvar text with tn=tournament.name %}
       Public area for <strong>{{ tn }}</strong>
-    {% endblocktranslate %}
+    {% endblocktrans %}
     {% include "components/item-action.html" with icon="globe" url=public_url %}
 
   {% else %}

--- a/tabbycat/users/templates/admin/auth/delete_user_warning.html
+++ b/tabbycat/users/templates/admin/auth/delete_user_warning.html
@@ -3,9 +3,9 @@
 {% if protected %}
   <div style="background-color: #f0dada; padding: 15px 15px 5px; margin-bottom: 20px; border-radius: 4px;">
     <p>
-      {% blocktranslate trimmed %}
+      {% blocktrans trimmed %}
         <strong>Warning:</strong> You shouldn't delete users from the database once they've done something, because the database logs actions taken by those users, and deleting the users also deletes the related logs. If you wish to deactivate a user account, go back to edit the user, click on the “Permissions” tab, unchecked the “Active” box, and save the user.
-      {% endblocktranslate %}
+      {% endblocktrans %}
     </p>
   </div>
 {% endif %}

--- a/tabbycat/users/templates/signup.html
+++ b/tabbycat/users/templates/signup.html
@@ -1,8 +1,8 @@
 {% extends 'base.html' %}
 {% load i18n %}
 
-{% block page-title %}{% translate "Sign-Up" %}{% endblock %}
-{% block head-title %}{% translate "Sign-Up" %}{% endblock %}
+{% block page-title %}{% trans "Sign-Up" %}{% endblock %}
+{% block head-title %}{% trans "Sign-Up" %}{% endblock %}
 {% block extra-head %}<meta name="robots" content="noindex" />{% endblock %}
 
 {% block content %}
@@ -13,16 +13,16 @@
     <div class="card">
       <div class="list-group list-group-flush">
         {% if for_admin %}
-          {% translate "Create a New Administrator Account" context "page title" as title %}
+          {% trans "Create a New Administrator Account" context "page title" as title %}
         {% else %}
-          {% translate "Create a New Assistant Account" context "page title" as title %}
+          {% trans "Create a New Assistant Account" context "page title" as title %}
         {% endif %}
 
         {% include "components/form-title.html" with icon="user-plus" %}
 
         {% include "components/form-main.html" %}
 
-        {% translate "Create Account" as title %}
+        {% trans "Create Account" as title %}
         {% include "components/form-submit.html" %}
 
       </div>

--- a/tabbycat/venues/templates/venue_categories_edit.html
+++ b/tabbycat/venues/templates/venue_categories_edit.html
@@ -1,23 +1,23 @@
 {% extends "base.html" %}
 {% load add_field_css debate_tags i18n %}
 
-{% block head-title %}<span class="emoji">🏪</span> {% translate "Room Categories" %}{% endblock %}
-{% block page-title %}🏪{% translate "Room Categories" %}{% endblock %}
+{% block head-title %}<span class="emoji">🏪</span> {% trans "Room Categories" %}{% endblock %}
+{% block page-title %}🏪{% trans "Room Categories" %}{% endblock %}
 
 {% block content %}
 
-  {% blocktranslate trimmed asvar p1 %}
+  {% blocktrans trimmed asvar p1 %}
     Room categories allow you to group rooms together into "zones" to display in the draw and make navigation easier for participants, and/or specify constraints on room allocation that require teams, adjudicators or institutions to be put in a room in a particular category.
-  {% endblocktranslate %}
+  {% endblocktrans %}
 
   {% url 'admin:venues_venuecategory_changelist' as edit_db_url %}
-  {% blocktranslate trimmed asvar p2 %}
+  {% blocktrans trimmed asvar p2 %}
     If you want to delete room categories, use the <a href="{{ edit_db_url }}" class="alert-link">Edit Database</a> area.
-  {% endblocktranslate %}
+  {% endblocktrans %}
 
   {% include "components/explainer-card.html" with type="info" %}
 
-  {% translate "Save Room Categories" as save_text %}
+  {% trans "Save Room Categories" as save_text %}
   {% include "components/formset.html" with double=True %}
 
 {% endblock content %}

--- a/tabbycat/venues/templates/venue_constraints_edit.html
+++ b/tabbycat/venues/templates/venue_constraints_edit.html
@@ -1,12 +1,12 @@
 {% extends "base.html" %}
 {% load add_field_css debate_tags i18n %}
 
-{% block head-title %}<span class="emoji">🏰</span>{% translate "Room Constraints" %}{% endblock %}
-{% block page-title %}🏰{% translate "Room Constraints" %}{% endblock %}
+{% block head-title %}<span class="emoji">🏰</span>{% trans "Room Constraints" %}{% endblock %}
+{% block page-title %}🏰{% trans "Room Constraints" %}{% endblock %}
 
 {% block content %}
 
-  {% blocktranslate trimmed asvar p1 %}
+  {% blocktrans trimmed asvar p1 %}
     Room constraints tell the room allocator to try to keep the specified
     team or adjudicator, or all teams (but not adjudicators) from the
     specified institution, in a room in the given category. The "priority"
@@ -14,10 +14,10 @@
     precedence. You can also use the priority field to specify
     "lower-preference" constraints, which are taken if a higher-priority
     constraint couldn't be met.
-  {% endblocktranslate %}
+  {% endblocktrans %}
   {% include "components/explainer-card.html" with type="info" %}
 
-  {% translate "Save Room Constraints" as save_text %}
+  {% trans "Save Room Constraints" as save_text %}
   {% include "components/formset.html" with quadruple=True %}
 
 {% endblock content %}


### PR DESCRIPTION
Reverts #1994. It was causing an errant "s" to appear as a message on some pages.