### PR TITLE
Remove "mark debate as status" dropdown actions

### DIFF
--- a/tabbycat/draw/admin.py
+++ b/tabbycat/draw/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 from django.db.models import Prefetch
-from django.utils.translation import gettext_lazy, ngettext
+from django.utils.translation import ngettext
 
 from adjallocation.models import DebateAdjudicator
 from utils.admin import ModelAdmin, TabbycatModelAdminFieldsMixin
@@ -49,6 +49,7 @@ class DebateAdmin(ModelAdmin):
     list_editable = ('result_status', 'sides_confirmed')
     inlines = (DebateTeamInline, DebateAdjudicatorInline)
     raw_id_fields = ('venue',)
+    actions = ('mark_as_sides_confirmed', 'mark_as_sides_not_confirmed')
 
     def get_queryset(self, request):
         return super().get_queryset(request).select_related(
@@ -57,28 +58,6 @@ class DebateAdmin(ModelAdmin):
             Prefetch('debateteam_set', queryset=DebateTeam.objects.select_related('team__tournament')),
             'venue__venuecategory_set',
         )
-
-    actions = list()
-    for value, verbose_name in Debate.STATUS_CHOICES:
-
-        def _make_set_result_status(value, verbose_name): # noqa: N805
-            def _set_result_status(modeladmin, request, queryset):
-                count = queryset.update(result_status=value)
-                for obj in queryset:
-                    modeladmin.log_change(request, obj, [{"changed": {"fields": ["result_status"]}}])
-                message = ngettext("%(count)d debate had its status set to %(status)s.",
-                    "%(count)d debates had their statuses set to %(status)s.", count) % {
-                        'count': count, 'status': verbose_name}
-                modeladmin.message_user(request, message)
-
-            # so that they look different to DebateAdmin
-            _set_result_status.__name__ = "set_result_status_%s" % verbose_name.lower()
-            _set_result_status.short_description = gettext_lazy("Set result status to "
-                    "%(status)s") % {'status': verbose_name}
-            return _set_result_status
-
-        actions.append(_make_set_result_status(value, verbose_name))
-    del value, verbose_name  # for fail-fast
 
     def mark_as_sides_confirmed(self, request, queryset):
         updated = queryset.update(sides_confirmed=True)
@@ -101,5 +80,3 @@ class DebateAdmin(ModelAdmin):
             updated,
         ) % {'count': updated}
         self.message_user(request, message)
-
-    actions.extend(['mark_as_sides_confirmed', 'mark_as_sides_not_confirmed'])


### PR DESCRIPTION
This commit removes the status dropdown actions from the database area for Debates as that field is modifiable more intuitively with the drop-downs available on each row.