### PR TITLE
Add break size validation to Break Category form

### DIFF
--- a/tabbycat/breakqual/views.py
+++ b/tabbycat/breakqual/views.py
@@ -3,15 +3,16 @@ import logging
 
 from django.conf import settings
 from django.contrib import messages
+from django.core.exceptions import ValidationError
 from django.db.models import Count, Q
-from django.forms import HiddenInput
-from django.forms.models import BaseModelFormSet
+from django.forms import HiddenInput, ModelForm
 from django.utils.html import escape
 from django.utils.translation import gettext as _, ngettext
 from django.views.generic import FormView, TemplateView
 
 from actionlog.mixins import LogActionMixin
 from actionlog.models import ActionLogEntry
+from draw.generator.utils import ispow2
 from participants.models import Team
 from participants.views import EditSpeakerCategoriesView, UpdateEligibilityEditView as BaseUpdateEligibilityEditView
 from tournaments.mixins import PublicTournamentPageMixin, SingleObjectFromTournamentMixin, TournamentMixin
@@ -230,19 +231,18 @@ class PublicBreakingAdjudicatorsView(PublicTournamentPageMixin, BaseBreakingAdju
 # ==============================================================================
 
 
-class BreakCategoryModelFormSet(BaseModelFormSet):
-    """Class to handle the different procedures for creation and modification
-    in BreakCategory objects."""
+class BreakCategoryModelForm(ModelForm):
+    """Class to handle validating the break size, as can't add validator"""
 
-    def save_new(self, form, commit=True):
-        """Create break rounds for new break categories"""
-        bc = super().save_new(form, commit)
-        auto_make_break_rounds(bc, prefix=True)
-        return bc
+    def __init__(self, *args, **kwargs):
+        self.tournament = kwargs.pop('tournament')
+        super().__init__(*args, **kwargs)
 
-    def save_existing(self, form, instance, commit=True):
-        """Stub for deleting/creating break rounds if break size changes"""
-        return super().save_existing(form, instance, commit)
+    def clean_break_size(self):
+        bs = self.cleaned_data['break_size']
+        if self.tournament.pref('teams_in_debate') == 'bp' and not ((bs % 6 == 0 and ispow2(bs // 6)) or (bs >= 4 and ispow2(bs))):
+            raise ValidationError(_("Four-team formats require the break size to be either six times or four times a power of two."))
+        return bs
 
 
 class EditBreakCategoriesView(EditSpeakerCategoriesView):
@@ -265,8 +265,14 @@ class EditBreakCategoriesView(EditSpeakerCategoriesView):
             'widgets': {
                 'tournament': HiddenInput,
             },
-            'formset': BreakCategoryModelFormSet,
+            'form': BreakCategoryModelForm,
         }
+
+    def get_formset_kwargs(self):
+        return {'form_kwargs': {'tournament': self.tournament}}
+
+    def prepare_related(self, cat):
+        auto_make_break_rounds(cat, prefix=True)
 
 
 class EditTeamEligibilityView(AdministratorMixin, TournamentMixin, VueTableTemplateView):

--- a/tabbycat/participants/views.py
+++ b/tabbycat/participants/views.py
@@ -348,6 +348,9 @@ class EditSpeakerCategoriesView(LogActionMixin, AdministratorMixin, TournamentMi
             'initial': [{'tournament': self.tournament}] * 2,
         }
 
+    def prepare_related(self, cat):
+        pass
+
     def formset_valid(self, formset):
         cats = formset.save(commit=False)
 
@@ -355,9 +358,11 @@ class EditSpeakerCategoriesView(LogActionMixin, AdministratorMixin, TournamentMi
             cat.save()
 
         for i, cat in enumerate(formset.new_objects, start=self.get_formset_queryset().aggregate(m=Coalesce(Max('seq'), 0) + 1)['m']):
-            raise
             cat.seq = i
+            cat.tournament = self.tournament  # Even with the tournament in the form, avoid it being changed
             cat.save()
+
+            self.prepare_related(cat)
 
         if cats:
             message = ngettext("Saved category: %(list)s",


### PR DESCRIPTION
This commit adds validation to the Break Category formset to prevent BP tournaments from having a break category with an invalid size (full or partial). Adding this validation required passing the tournament to the newly-subclassed model form.

Further, the saving sequence is fixed so that the break rounds are generated after saving the object.

The tournament field is now ignored as that information is found in the view object. It is however kept for IntegrityError catching.

Closes BACKEND-AXB
Closes BACKEND-AMJ