### PR TITLE
Fix crash when running out of emoji

### DIFF
--- a/tabbycat/api/serializers.py
+++ b/tabbycat/api/serializers.py
@@ -668,14 +668,13 @@ class TeamSerializer(serializers.ModelSerializer):
         break_categories = validated_data.pop('break_categories', [])
         venue_constraints = validated_data.pop('venue_constraints', [])
 
-        emoji = pick_unused_emoji(validated_data['tournament'].id)
-        if emoji:
-            if 'emoji' not in validated_data or validated_data.get('emoji') is None:
-                validated_data['emoji'] = emoji[0]
-            if 'code_name' not in validated_data or validated_data.get('code_name') is None:
-                validated_data['code_name'] = emoji[1]
+        emoji, code_name = pick_unused_emoji(validated_data['tournament'].id)
+        if 'emoji' not in validated_data or validated_data.get('emoji') is None:
+            validated_data['emoji'] = emoji
+        if 'code_name' not in validated_data or validated_data.get('code_name') is None:
+            validated_data['code_name'] = code_name
 
-        if validated_data.get('emoji') == '':
+        if validated_data['emoji'] == '':
             validated_data['emoji'] = None  # Must convert to null to avoid uniqueness errors
 
         team = super().create(validated_data)

--- a/tabbycat/api/serializers.py
+++ b/tabbycat/api/serializers.py
@@ -668,14 +668,14 @@ class TeamSerializer(serializers.ModelSerializer):
         break_categories = validated_data.pop('break_categories', [])
         venue_constraints = validated_data.pop('venue_constraints', [])
 
-        emoji = pick_unused_emoji()
+        emoji = pick_unused_emoji(validated_data['tournament'].id)
         if emoji:
             if 'emoji' not in validated_data or validated_data.get('emoji') is None:
                 validated_data['emoji'] = emoji[0]
             if 'code_name' not in validated_data or validated_data.get('code_name') is None:
                 validated_data['code_name'] = emoji[1]
 
-        if validated_data['emoji'] == '':
+        if validated_data.get('emoji') == '':
             validated_data['emoji'] = None  # Must convert to null to avoid uniqueness errors
 
         team = super().create(validated_data)

--- a/tabbycat/api/serializers.py
+++ b/tabbycat/api/serializers.py
@@ -668,11 +668,12 @@ class TeamSerializer(serializers.ModelSerializer):
         break_categories = validated_data.pop('break_categories', [])
         venue_constraints = validated_data.pop('venue_constraints', [])
 
-        emoji, code_name = pick_unused_emoji()
-        if 'emoji' not in validated_data or validated_data.get('emoji') is None:
-            validated_data['emoji'] = emoji
-        if 'code_name' not in validated_data or validated_data.get('code_name') is None:
-            validated_data['code_name'] = code_name
+        emoji = pick_unused_emoji()
+        if emoji:
+            if 'emoji' not in validated_data or validated_data.get('emoji') is None:
+                validated_data['emoji'] = emoji[0]
+            if 'code_name' not in validated_data or validated_data.get('code_name') is None:
+                validated_data['code_name'] = emoji[1]
 
         if validated_data['emoji'] == '':
             validated_data['emoji'] = None  # Must convert to null to avoid uniqueness errors

--- a/tabbycat/participants/admin.py
+++ b/tabbycat/participants/admin.py
@@ -138,9 +138,7 @@ class TeamAdmin(ModelAdmin):
 
     def formfield_for_choice_field(self, db_field, request, **kwargs):
         if db_field.name == 'emoji' and kwargs.get("initial") is None:
-            emoji = pick_unused_emoji()
-            if emoji:
-                kwargs["initial"] = emoji[0]
+            kwargs["initial"] = pick_unused_emoji()[0]
         return super().formfield_for_choice_field(db_field, request, **kwargs)
 
     def formfield_for_manytomany(self, db_field, request, **kwargs):

--- a/tabbycat/participants/admin.py
+++ b/tabbycat/participants/admin.py
@@ -138,7 +138,9 @@ class TeamAdmin(ModelAdmin):
 
     def formfield_for_choice_field(self, db_field, request, **kwargs):
         if db_field.name == 'emoji' and kwargs.get("initial") is None:
-            kwargs["initial"] = pick_unused_emoji()[0]
+            emoji = pick_unused_emoji()
+            if emoji:
+                kwargs["initial"] = emoji[0]
         return super().formfield_for_choice_field(db_field, request, **kwargs)
 
     def formfield_for_manytomany(self, db_field, request, **kwargs):

--- a/tabbycat/participants/emoji.py
+++ b/tabbycat/participants/emoji.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import random
 import logging
+from typing import Tuple, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +25,7 @@ def set_emoji(teams, tournament):
         team.save()
 
 
-def pick_unused_emoji(tournament_id=None):
+def pick_unused_emoji(tournament_id=None) -> Tuple[Optional[str], Optional[str]]:
     """Picks an emoji that is not already in use by any team in the database. If
     no emoji are left, it returns `None`."""
     from .models import Team
@@ -36,7 +37,7 @@ def pick_unused_emoji(tournament_id=None):
     try:
         return random.choice(unused_emoji)
     except IndexError:
-        return None
+        return None, None
 
 
 def populate_code_names_from_emoji(teams, overwrite=True):

--- a/tabbycat/participants/emoji.py
+++ b/tabbycat/participants/emoji.py
@@ -24,12 +24,14 @@ def set_emoji(teams, tournament):
         team.save()
 
 
-def pick_unused_emoji():
+def pick_unused_emoji(tournament_id=None):
     """Picks an emoji that is not already in use by any team in the database. If
     no emoji are left, it returns `None`."""
     from .models import Team
-    used_emoji = Team.objects.filter(emoji__isnull=False).values_list('emoji', flat=True)
-    unused_emoji = [e for e in EMOJI_RANDOM_OPTIONS if e[0] not in used_emoji]
+    teams = Team.objects.filter(emoji__isnull=False)
+    if tournament_id is not None:
+        teams = teams.filter(tournament_id=tournament_id)
+    unused_emoji = [e for e in EMOJI_RANDOM_OPTIONS if e[0] not in teams.values_list('emoji', flat=True)]
 
     try:
         return random.choice(unused_emoji)


### PR DESCRIPTION
This fixes a critical issue we ran into yesterday, where running out of available emoji makes it impossible to add teams from either the API or the admin site. When all emoji are already used, `pick_unused_emoji` returns `None`, but none of the calling code handles that option. 

And no, we didn't have 488 teams at a tournament, it's just that `pick_unused_emoji` considers all teams on the instance and not just the current tournament (and we have a big archive).

This PR:

- makes `pick_unused_emoji` look only inside one tournament if provided
- provides the tournament when creating teams from the API
- in the unlikely case that there are still no emoji left, simply leaves the field blank