### PR TITLE
Create metric for number of times in pullup room

### DIFF
--- a/tabbycat/options/preferences.py
+++ b/tabbycat/options/preferences.py
@@ -180,6 +180,15 @@ class AvoidTeamHistory(BooleanPreference):
 
 
 @tournament_preferences_registry.register
+class SawPullupsPenalty(IntegerPreference):
+    help_text = _("Penalty applied by conflict avoidance method for teams being in a pullup many times. Leave 0 for no penalty.")
+    verbose_name = _("Previously saw pullup penalty")
+    section = draw_rules
+    name = 'saw_pullups_penalty'
+    default = 0
+
+
+@tournament_preferences_registry.register
 class DrawOddBracket(ChoicePreference):
     help_text = _("How odd brackets are resolved (see documentation for further details)")
     verbose_name = _("Odd bracket resolution method")

--- a/tabbycat/standings/teams.py
+++ b/tabbycat/standings/teams.py
@@ -228,7 +228,7 @@ class TeamPullupsMetricAnnotator(TeamScoreQuerySetMetricAnnotator):
     an associated DebateTeam object)."""
 
     key = "npullups"
-    name = _("number of pullups before this round")
+    name = _("number of pullups")
     abbr = _("PU")
 
     function = Count
@@ -240,6 +240,20 @@ class TeamPullupsMetricAnnotator(TeamScoreQuerySetMetricAnnotator):
 
     def get_where_field(self):
         return 'debateteam__flags__contains'
+
+
+class TeamSawPullupsMetricAnnotator(TeamPullupsMetricAnnotator):
+    """Metric annotator for number of times the team in a pull-up room.
+
+    How many teams the team has faced a pulled up team (i.e., has a pullup
+    flag in an associated Debate object)."""
+
+    key = "saw_pullups"
+    name = _("number of times in pullup debates")
+    abbr = _("SPu")
+
+    def get_where_field(self):
+        return 'debateteam__debate__flags__contains'
 
 
 class NumberOfAdjudicatorsMetricAnnotator(TeamScoreQuerySetMetricAnnotator):
@@ -396,6 +410,7 @@ class TeamStandingsGenerator(BaseStandingsGenerator):
         "margin_sum"          : SumMarginMetricAnnotator,
         "margin_avg"          : AverageMarginMetricAnnotator,
         "npullups"            : TeamPullupsMetricAnnotator,
+        "saw_pullups"         : TeamSawPullupsMetricAnnotator,
         "num_adjs"            : NumberOfAdjudicatorsMetricAnnotator,
         "firsts"              : NumberOfFirstsMetricAnnotator,
         "seconds"             : NumberOfSecondsMetricAnnotator,

--- a/tabbycat/standings/tests/test_standings.py
+++ b/tabbycat/standings/tests/test_standings.py
@@ -29,8 +29,8 @@ class TestTrivialStandings(TestCase):
         adj = Adjudicator.objects.create(tournament=self.tournament, name="Adjudicator")
         for i in [1, 2]:
             rd = Round.objects.create(tournament=self.tournament, seq=i)
-            debate = Debate.objects.create(round=rd)
-            dt1 = DebateTeam.objects.create(debate=debate, team=self.team1, side=DebateTeam.SIDE_AFF)
+            debate = Debate.objects.create(round=rd, flags=['pullup'])
+            dt1 = DebateTeam.objects.create(debate=debate, team=self.team1, side=DebateTeam.SIDE_AFF, flags=['pullup'])
             dt2 = DebateTeam.objects.create(debate=debate, team=self.team2, side=DebateTeam.SIDE_NEG)
             DebateAdjudicator.objects.create(debate=debate, adjudicator=adj, type=DebateAdjudicator.TYPE_CHAIR)
             ballotsub = BallotSubmission.objects.create(debate=debate, confirmed=True)
@@ -138,12 +138,18 @@ class TestTrivialStandings(TestCase):
         self._base_metric_test({'wbw': {'wbw1': [2, 0]}})
 
     def test_wbw_tied(self):
-        # npullups should be 0 for both teams, so is a tied first metric,
-        # allowing wbw to be tested as a second metric (the normal use case)
-        self._base_metric_test({'npullups': [0, 0], 'wbw': {'wbw1': [2, 0]}})
+        # firsts should be 0 for both teams as only applicable in BP, so is a tied
+        # first metric, allowing wbw to be tested as a second metric (the normal use case)
+        self._base_metric_test({'firsts': [0, 0], 'wbw': {'wbw1': [2, 0]}})
 
     def test_npullups(self):
-        self._base_metric_test({'npullups': [0, 0]})
+        self._base_metric_test({'npullups': [2, 0]})
+
+    def test_saw_pullups(self):
+        self._base_metric_test({'saw_pullups': [2, 2]})
+
+    def test_saw_pullups_combinable(self):
+        self._base_metric_test({'points': [2, 0], 'npullups': [2, 0], 'saw_pullups': [2, 2]})
 
     def test_points_ranked(self):
         generator = TeamStandingsGenerator(('points',), ('rank',))


### PR DESCRIPTION
This metric was requested by APDA tournaments, which attempt to minimize not only the number of times a team gets pulled up, but also the times teams debate against pullups, as facing a pullup may confer an outsized advantage to the stronger team. This metric is not expected to be used in standings, only in draw generation.

It is named "number of times in pullup debates" and has a weird abbreviation.

The commit also renames the "number of pullups" metric to remove the "before this round" comment as extraneous.

Ref #1667