### PR TITLE
Create list of actionlog entries in API

### DIFF
--- a/tabbycat/api/serializers.py
+++ b/tabbycat/api/serializers.py
@@ -1352,13 +1352,6 @@ class TeamRoundScoresSerializer(serializers.ModelSerializer):
 
 class ActionLogSerializer(serializers.ModelSerializer):
 
-    id = serializers.CharField(read_only=True)
-    user = serializers.CharField(read_only=True)
-    ip_address = serializers.IPAddressField(read_only=True)
-    timestamp = serializers.DateTimeField(read_only=True)
-    type = serializers.ChoiceField(choices=ActionLogEntry.ACTION_TYPE_CHOICES, read_only=True)
-    object_id = serializers.CharField(read_only=True)
-
     class Meta:
         model = ActionLogEntry
         fields = ('id', 'user', 'ip_address', 'timestamp', 'type', 'object_id')

--- a/tabbycat/api/serializers.py
+++ b/tabbycat/api/serializers.py
@@ -11,6 +11,7 @@ from rest_framework import serializers
 from rest_framework.fields import get_error_detail, SkipField
 from rest_framework.settings import api_settings
 
+from actionlog.models import ActionLogEntry
 from adjallocation.models import DebateAdjudicator, PreformedPanel
 from adjfeedback.models import AdjudicatorFeedback, AdjudicatorFeedbackQuestion
 from breakqual.models import BreakCategory, BreakingTeam
@@ -1344,3 +1345,17 @@ class TeamRoundScoresSerializer(serializers.ModelSerializer):
     class Meta:
         model = Team
         fields = ('team', 'rounds')
+
+
+class ActionLogSerializer(serializers.ModelSerializer):
+
+    id = serializers.CharField(read_only=True)
+    user = serializers.CharField(read_only=True)
+    ip_address = serializers.IPAddressField(read_only=True)
+    timestamp = serializers.DateTimeField(read_only=True)
+    type = serializers.ChoiceField(choices=ActionLogEntry.ACTION_TYPE_CHOICES, read_only=True)
+    object_id = serializers.CharField(read_only=True)
+
+    class Meta:
+        model = ActionLogEntry
+        fields = ('id', 'user', 'ip_address', 'timestamp', 'type', 'object_id')

--- a/tabbycat/api/serializers.py
+++ b/tabbycat/api/serializers.py
@@ -130,6 +130,9 @@ class TournamentSerializer(serializers.ModelSerializer):
         preferences = serializers.HyperlinkedIdentityField(
             view_name='tournamentpreferencemodel-list',
             lookup_field='slug', lookup_url_kwarg='tournament_slug')
+        actionlog = serializers.HyperlinkedIdentityField(
+            view_name='api-actionlog-list',
+            lookup_field='slug', lookup_url_kwarg='tournament_slug')
 
     _links = TournamentLinksSerializer(source='*', read_only=True)
 

--- a/tabbycat/api/urls.py
+++ b/tabbycat/api/urls.py
@@ -224,6 +224,14 @@ urlpatterns = [
                         views.VenueCategoryViewSet.as_view(detail_methods),
                         name='api-venuecategory-detail'),
                 ])),
+                path('/actionlog', include([
+                    path('',
+                        views.ActionLogViewSet.as_view(list_methods),
+                        name='api-actionlog-list'),
+                    path('/<int:pk>',
+                         views.ActionLogViewSet.as_view(detail_methods),
+                         name='api-actionlog-detail'),
+                ])),
 
                 path('/', include(pref_router.urls)),  # Preferences
             ])),

--- a/tabbycat/api/urls.py
+++ b/tabbycat/api/urls.py
@@ -226,10 +226,10 @@ urlpatterns = [
                 ])),
                 path('/actionlog', include([
                     path('',
-                        views.ActionLogViewSet.as_view(list_methods),
+                        views.ActionLogViewSet.as_view({'get': 'list'}),
                         name='api-actionlog-list'),
                     path('/<int:pk>',
-                         views.ActionLogViewSet.as_view(detail_methods),
+                         views.ActionLogViewSet.as_view({'get': 'retrieve'}),
                          name='api-actionlog-detail'),
                 ])),
 

--- a/tabbycat/api/views.py
+++ b/tabbycat/api/views.py
@@ -1084,5 +1084,10 @@ class PreformedPanelViewSet(RoundAPIMixin, AdministratorAPIMixin, ModelViewSet):
         return self.get(request, *args, **kwargs)
 
 
+@extend_schema(tags=['actionlog'], parameters=[tournament_parameter])
+@extend_schema_view(
+    list=extend_schema(summary="List all actionlog entries for this tournament"),
+    retrieve=extend_schema(summary="Get actionlog entry", parameters=[id_parameter]),
+)
 class ActionLogViewSet(TournamentAPIMixin, AdministratorAPIMixin, ModelViewSet):
     serializer_class = serializers.ActionLogSerializer

--- a/tabbycat/api/views.py
+++ b/tabbycat/api/views.py
@@ -1082,3 +1082,7 @@ class PreformedPanelViewSet(RoundAPIMixin, AdministratorAPIMixin, ModelViewSet):
             })
 
         return self.get(request, *args, **kwargs)
+
+
+class ActionLogViewSet(TournamentAPIMixin, AdministratorAPIMixin, ModelViewSet):
+    serializer_class = serializers.ActionLogSerializer


### PR DESCRIPTION
Closes #1993 

Right now this leans quite heavily on generic fields. Would it be better to add a serializer for, for example, the `user` field?

I'm also not too sure on the current information given, `"type"` and `"object_id"` might be quite unclear?