### PR TITLE
Make last third of rounds silent by default

### DIFF
--- a/tabbycat/tournaments/utils.py
+++ b/tabbycat/tournaments/utils.py
@@ -68,9 +68,11 @@ BP_SIDE_NAMES = {  # stop-gap before this system gets refactored
 
 def auto_make_rounds(tournament, num_rounds):
     """Makes the number of rounds specified. The first one is random and the
-    rest are all power-paired. The last one is silent. This is intended as a
-    convenience function. For anything more complicated, a more advanced import
-    method should be used."""
+    rest are all power-paired. The last third of rounds (rounded down) are silent.
+    This is intended as a convenience function. For anything more complicated,
+    a more advanced import method should be used."""
+    silent_threshold = num_rounds * 2 / 3
+
     for i in range(1, num_rounds+1):
         Round(
             tournament=tournament,
@@ -81,7 +83,7 @@ def auto_make_rounds(tournament, num_rounds):
             stage=Round.Stage.PRELIMINARY,
             draw_type=Round.DrawType.RANDOM if (i == 1) else Round.DrawType.POWERPAIRED,
             feedback_weight=min((i-1)*0.1, 0.5),
-            silent=(i == num_rounds),
+            silent=(i > silent_threshold),
         ).save()
 
 


### PR DESCRIPTION
Make the last third of rounds auto-generated by the setup wizard silent by default. This is more inline with common tournament configurations, such as:

* 5 rounds: Rounds 1 - 3 are open, Rounds 4 & 5 are silent
* 9 rounds: Rounds 1 - 6 are open, Rounds 7 - 9 are silent

While this may not fit all tournament configurations, especially ones with fewer/no silent rounds, forgetting to mark a round as not silent is less of an issue than forgetting to mark a rounds as silent, so it is probably a preferable behaviour. An ideal solution in the future may be to have a way to pick which rounds are silent in the setup wizard.