### PR TITLE
Workaround to render selects correctly in CSVs

### DIFF
--- a/tabbycat/templates/tables/SmartTable.vue
+++ b/tabbycat/templates/tables/SmartTable.vue
@@ -89,7 +89,14 @@ export default {
     async copyTableData () {
       let tableCSV = this.tableHeaders.map(x => x.key).join('\t') + '\r\n'
       for (const row of this.tableContent) {
-        tableCSV += row.map(x => x.text ? x.text.replace(/<[^>]*>?/gm, '') : '').join('\t') + '\r\n'
+        tableCSV += row.map(x => {
+          if (x.text?.startsWith('<select')) {
+            const selectedOption = x.text.split('\n').find((l) => l.includes('selected'))
+            return selectedOption?.trim().replace(/<.*?>/g, '') ?? ''
+          }
+
+          return x.text ? x.text.replace(/<[^>]*>?/gm, '') : ''
+        }).join('\t') + '\r\n'
       }
       await navigator.clipboard.writeText(tableCSV)
     },


### PR DESCRIPTION
Currently when there is a select in a table, such as in the admin break tables, and you try to use the Copy to CSV button, you end up with a malformed CSV such as the following:

```
Rk	break	team	Pts	Spk	1sts	2nds	eligible-for	edit-remark
1	1	Team 1	13	816.00	3	2	Open, ESL	
  ---------

  Capped

  Ineligible

  Different break

  Disqualified

  Lost coin toss

  Withdrawn


2	2	Team 2	12	819.00	2	3	Open	
  ---------
...
```

This is because the cells are read as their raw HTML during the CSV conversion process, and only the HTML tags are stripped by the cleaning RegExp, which retains the newlines and doesn't actually provide useful information. This small snippet checks to see if the cell begins with `<select`, then splits it into the separate lines and finds the line with the 'selected' attribute, extracting its label as the value for the cell. If there is no selected option, it uses a blank string. This results in the more correct output:

```
Rk	break	team	Pts	Spk	1sts	2nds	eligible-for	edit-remark
1	(withdrawn)	Erebor OS	3	—	1	0	Open	Withdrawn
2	(lost coin toss)	Rivendell BA	2	158.00	0	1	Open	Lost coin toss
3	(different break)	Ithilien YT	1	—	0	0	Open	Different break
4	(disqualified)	Erebor RJ	0	—	0	0	Open, Novice	Disqualified
```

Alternative options included stripping this column (since the info is contained in the break column) or implementing a more integrated solution, however both would've involved much more involved changes to the current behaviours.

(Side note none of these are actually CSVs, they are all TSVs)