### PR TITLE
Correct ballot stats widths in future rounds

### DIFF
--- a/tabbycat/participants/views.py
+++ b/tabbycat/participants/views.py
@@ -199,7 +199,7 @@ class BaseRecordView(SingleObjectFromTournamentMixin, VueTableTemplateView):
         model_related = {'Team': 'debateteam_set', 'Adjudicator': 'debateadjudicator_set'}[type(obj).__name__]
         try:
             qs = getattr(obj, model_related).filter(
-                debate__round__in=tournament.current_rounds).select_related('debate__round')
+                debate__round__draw_status=Round.STATUS_RELEASED, debate__round__completed=False).select_related('debate__round')
             if admin:
                 qs = qs.prefetch_related(Prefetch('debate__round__roundmotion_set',
                     queryset=RoundMotion.objects.select_related('motion')))

--- a/tabbycat/results/templates/ResultsStats.vue
+++ b/tabbycat/results/templates/ResultsStats.vue
@@ -56,8 +56,8 @@ export default {
   props: { checks: Object, statuses: Object },
   methods: {
     widthForType: function (value, type) {
-      const sumValues = obj => Object.values(obj).reduce((a, b) => a + b)
-      return `${String((value / sumValues(type)) * 100)}%`
+      const sumValues = obj => (Object.values(obj).reduce((a, b) => a + b) || 1)
+      return `${value / sumValues(type) * 100}%`
     },
   },
   computed: {


### PR DESCRIPTION
This commit fixes the ballot stats graphs in result entry for rounds with no draw. The graphs had stubs for each ballot status, due to a faulty calculation when there are no debates to count from. Now, the graphs will not have any status shown.