### PR TITLE
Correct ballot stats widths in future rounds

### DIFF
--- a/tabbycat/results/templates/ResultsStats.vue
+++ b/tabbycat/results/templates/ResultsStats.vue
@@ -56,8 +56,8 @@ export default {
   props: { checks: Object, statuses: Object },
   methods: {
     widthForType: function (value, type) {
-      const sumValues = obj => Object.values(obj).reduce((a, b) => a + b)
-      return `${String((value / sumValues(type)) * 100)}%`
+      const sumValues = obj => (Object.values(obj).reduce((a, b) => a + b) || 1)
+      return `${value / sumValues(type) * 100}%`
     },
   },
   computed: {


### PR DESCRIPTION
This commit fixes the ballot stats graphs in result entry for rounds with no draw. The graphs had stubs for each ballot status, due to a faulty calculation when there are no debates to count from. Now, the graphs will not have any status shown.