### PR TITLE
Update django-channels to the latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "tabbycat",
       "version": "3.18.1",
-      "license": "GNU Affero General Public License v3.0",
+      "license": "AGPL-3.0-only",
       "dependencies": {
         "@babel/cli": "^7.16.0",
         "@babel/core": "^7.16.0",
@@ -24,7 +24,7 @@
         "core-js": "^3.19.2",
         "cpx": "1.5.x",
         "d3": "^6.3.1",
-        "django-channels": "1.1.8",
+        "django-channels": "^2.1.3",
         "feather-icons": "^4.28.0",
         "inter-ui": "^3.15.0",
         "jquery": "^3.6.0",
@@ -45,10 +45,6 @@
       },
       "devDependencies": {
         "eslint-plugin-html": "^6.2.0"
-      },
-      "engines": {
-        "node": "16.15.x",
-        "npm": "8.11.x"
       }
     },
     "node_modules/@achrinza/node-ipc": {
@@ -6270,14 +6266,13 @@
       }
     },
     "node_modules/django-channels": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/django-channels/-/django-channels-1.1.8.tgz",
-      "integrity": "sha1-Fg1H7fu9cbjzheQuEcC3d10reI0=",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/django-channels/-/django-channels-2.1.3.tgz",
+      "integrity": "sha512-H0jzdw3XvBR3HC4FqMqhoM0M4iUlOJ1TCRpyL51r//8LX2KGAK7lA1+4JeTxvnlaq8xBvZ3mMTf55eaRoDcgKA==",
       "dependencies": {
-        "reconnecting-websocket": "^3.0.3"
-      },
-      "engines": {
-        "npm": ">=5"
+        "@babel/runtime": "^7.5.5",
+        "event-target-shim": "^5.0.1",
+        "reconnecting-websocket": "^4.1.10"
       }
     },
     "node_modules/dns-equal": {
@@ -6687,6 +6682,14 @@
       "integrity": "sha512-z7IyloorXvKbFx9Bpie2+vMJKKx1fH1EN5yiTfp8CiLOTptSYy1g8H4yDpGlEdshL1PBiFtBHepF2cNsqeEeFQ==",
       "engines": {
         "node": ">=4.0.0"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/eventemitter3": {
@@ -11162,9 +11165,9 @@
       }
     },
     "node_modules/reconnecting-websocket": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/reconnecting-websocket/-/reconnecting-websocket-3.2.2.tgz",
-      "integrity": "sha512-SWSfoXiaHVOqXuPWFgGWeUxKnb5HIY7I/Fh5C/hy4wUOgeOh7YIMXEiv5/eHBlNs4tNzCrO5YDR9AH62NWle0Q=="
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/reconnecting-websocket/-/reconnecting-websocket-4.4.0.tgz",
+      "integrity": "sha512-D2E33ceRPga0NvTDhJmphEgJ7FUYF0v4lr1ki0csq06OdlxKfugGzN0dSkxM/NfqCxYELK4KcaTOUOjTV6Dcng=="
     },
     "node_modules/regenerate": {
       "version": "1.4.2",
@@ -18702,11 +18705,13 @@
       }
     },
     "django-channels": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/django-channels/-/django-channels-1.1.8.tgz",
-      "integrity": "sha1-Fg1H7fu9cbjzheQuEcC3d10reI0=",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/django-channels/-/django-channels-2.1.3.tgz",
+      "integrity": "sha512-H0jzdw3XvBR3HC4FqMqhoM0M4iUlOJ1TCRpyL51r//8LX2KGAK7lA1+4JeTxvnlaq8xBvZ3mMTf55eaRoDcgKA==",
       "requires": {
-        "reconnecting-websocket": "^3.0.3"
+        "@babel/runtime": "^7.5.5",
+        "event-target-shim": "^5.0.1",
+        "reconnecting-websocket": "^4.1.10"
       }
     },
     "dns-equal": {
@@ -19030,6 +19035,11 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/event-pubsub/-/event-pubsub-4.3.0.tgz",
       "integrity": "sha512-z7IyloorXvKbFx9Bpie2+vMJKKx1fH1EN5yiTfp8CiLOTptSYy1g8H4yDpGlEdshL1PBiFtBHepF2cNsqeEeFQ=="
+    },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
     "eventemitter3": {
       "version": "4.0.7",
@@ -22327,9 +22337,9 @@
       }
     },
     "reconnecting-websocket": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/reconnecting-websocket/-/reconnecting-websocket-3.2.2.tgz",
-      "integrity": "sha512-SWSfoXiaHVOqXuPWFgGWeUxKnb5HIY7I/Fh5C/hy4wUOgeOh7YIMXEiv5/eHBlNs4tNzCrO5YDR9AH62NWle0Q=="
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/reconnecting-websocket/-/reconnecting-websocket-4.4.0.tgz",
+      "integrity": "sha512-D2E33ceRPga0NvTDhJmphEgJ7FUYF0v4lr1ki0csq06OdlxKfugGzN0dSkxM/NfqCxYELK4KcaTOUOjTV6Dcng=="
     },
     "regenerate": {
       "version": "1.4.2",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "core-js": "^3.19.2",
     "cpx": "1.5.x",
     "d3": "^6.3.1",
-    "django-channels": "1.1.8",
+    "django-channels": "^2.1.3",
     "feather-icons": "^4.28.0",
     "inter-ui": "^3.15.0",
     "jquery": "^3.6.0",
@@ -64,10 +64,6 @@
     "last 1 version",
     "not dead"
   ],
-  "engines": {
-    "node": "16.15.x",
-    "npm": "8.11.x"
-  },
   "license": "AGPL-3.0-only",
   "repository": "https://github.com/TabbycatDebate/tabbycat",
   "version": "3.18.1",

--- a/tabbycat/templates/ajax/WebSocketMixin.vue
+++ b/tabbycat/templates/ajax/WebSocketMixin.vue
@@ -38,8 +38,8 @@ export default {
       })
 
       // Listen for messages and pass to the defined handleSocketMessage()
-      webSocketBridge.listen((payload) => {
-        receiveFromSocket(socketLabel, payload)
+      webSocketBridge.addEventListener('message', (payload) => {
+        receiveFromSocket(socketLabel, payload.data)
       })
 
       // Logs


### PR DESCRIPTION
This commit updates the django-channels npm package to 2.1.3 (or non- breaking higher versions) to suppress an npm warning that it gives.