### PR TITLE
Add Private URL preset to tournament configure

### DIFF
--- a/tabbycat/options/presets.py
+++ b/tabbycat/options/presets.py
@@ -29,8 +29,14 @@ def presets_for_form():
 
 
 def public_presets_for_form():
-    return [(_('Public Information Options'), _('Enable Public Information')),
+    return [(True, _('Enable Public Information')),
             (False, _('Disable Public Information'))]
+
+
+def data_entry_presets_for_form():
+    return [(False, _('Disabled (tab staff only)')),
+            ("private-urls", _('Use private URLs')),
+            ("public", _('Use publicly accessible form'))]
 
 
 def get_preferences_data(selected_preset, tournament):
@@ -363,6 +369,14 @@ class PrivateURLS(PreferencesPreset):
     show_in_list = False
     description = _("Enables participant data entry through private URLs.")
 
-    data_entry__participant_ballots             = 'private-urls'
-    data_entry__participant_feedback            = 'private-urls'
-    data_entry__public_checkins_submit          = True
+    data_entry__participant_ballots            = 'private-urls'
+    data_entry__participant_feedback           = 'private-urls'
+
+
+class PublicForms(PreferencesPreset):
+    name = _("Use Public Forms")
+    show_in_list = False
+    description = _("Enables participant data entry through public forms.")
+
+    data_entry__participant_ballots            = 'public'
+    data_entry__participant_feedback           = 'public'

--- a/tabbycat/tournaments/forms.py
+++ b/tabbycat/tournaments/forms.py
@@ -11,7 +11,7 @@ from adjfeedback.models import AdjudicatorFeedbackQuestion
 from breakqual.models import BreakCategory
 from breakqual.utils import auto_make_break_rounds
 from options.preferences import TournamentStaff
-from options.presets import all_presets, get_preferences_data, presets_for_form, public_presets_for_form
+from options.presets import all_presets, data_entry_presets_for_form, presets_for_form, PrivateURLS, public_presets_for_form, PublicForms, PublicInformation, save_presets
 
 from .models import Round, Tournament
 from .signals import update_tournament_cache
@@ -82,15 +82,21 @@ class TournamentConfigureForm(ModelForm):
         fields = ('preset_rules', 'public_info')
 
     preset_rules = ChoiceField(
-        choices=presets_for_form(), # Tuple with (Present_Index, Preset_Name)
+        choices=presets_for_form(), # Tuple with (Preset_Index, Preset_Name)
         label=_("Format Configuration"),
         help_text=_("Apply a standard set of settings to match a common debate format"))
 
     public_info = ChoiceField(
-        choices=public_presets_for_form(), # Tuple with (Present_Index, Preset_Name)
+        choices=public_presets_for_form(),
         label=_("Public Configuration"),
         help_text=_("Show non-sensitive information on the public-facing side of this site, "
             "like draws (once released) and the motions of previous rounds"))
+
+    data_entry = ChoiceField(
+        choices=data_entry_presets_for_form(),
+        label=_("Participant Data Entry"),
+        help_text=_("Whether participants can submit ballots and feedback themselves, and "
+            "how they do so"))
 
     tournament_staff = CharField(
         label=TournamentStaff.verbose_name,
@@ -110,17 +116,19 @@ class TournamentConfigureForm(ModelForm):
         # Identify + apply selected preset
         selected_index = self.cleaned_data["preset_rules"]
         selected_preset = next(p for p in presets if p.name == selected_index)
-        selected_preferences = get_preferences_data(selected_preset, t)
-        for preference in selected_preferences:
-            t.preferences[preference['key']] = preference['new_value']
+        save_presets(t, selected_preset)
 
         # Apply public info presets
         do_public = self.cleaned_data["public_info"]
-        public_preset = next((p for p in presets if p.name == do_public), False)
-        if public_preset:
-            public_preferences = get_preferences_data(public_preset, t)
-            for preference in public_preferences:
-                t.preferences[preference['key']] = preference['new_value']
+        if do_public:
+            save_presets(t, PublicInformation)
+
+        # Apply data entry method preset
+        data_entry_method = self.cleaned_data["data_entry"]
+        if data_entry_method == "private-urls":
+            save_presets(t, PrivateURLS)
+        elif data_entry_method == "public":
+            save_presets(t, PublicForms)
 
         # Apply the credits
         if self.cleaned_data['tournament_staff'] != self.fields['tournament_staff'].initial:

--- a/tabbycat/tournaments/forms.py
+++ b/tabbycat/tournaments/forms.py
@@ -125,10 +125,8 @@ class TournamentConfigureForm(ModelForm):
 
         # Apply data entry method preset
         data_entry_method = self.cleaned_data["data_entry"]
-        if data_entry_method == "private-urls":
-            save_presets(t, PrivateURLS)
-        elif data_entry_method == "public":
-            save_presets(t, PublicForms)
+        if data_entry_method:
+            save_presets(t, {"private-urls": PrivateURLS, "public": PublicForms}[data_entry_method])
 
         # Apply the credits
         if self.cleaned_data['tournament_staff'] != self.fields['tournament_staff'].initial:


### PR DESCRIPTION
Added the existing Private URLs preset to the tournament configure page similar to Enable Public Features, since they are common settings that many tournaments use. As part of this, I removed the `public_checkins_submit` (allow participant self-check in permission) since this doesn't seem in line with the description of the preset and is also generally not a preferred behaviour (most tournaments online or in person want to manage check ins to avoid people checking in when they are not actually present).

I also swapped the settings on the configure page to use `save_preset` rather than re-implementing the logic in that helper function to reduce the duplication and make it a bit more readable. The removal of a space before the equals in the preset is just to bring the equals in line with every other equals in that file (previously they were slightly offset which just bugged me a little).