### PR TITLE
Install npm in Docker explicitly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ENV IN_DOCKER 1
 RUN apt-get update
 RUN apt-get install -y curl nginx
 RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
-RUN apt-get install -y nodejs
+RUN apt-get install -y nodejs npm
 
 # Copy all our files into the baseimage and cd to that directory
 RUN mkdir /tcd


### PR DESCRIPTION
The Docker builds have started failing because npm is no longer packaged with node when installing them. This commit adds npm to the list of packages to install.