### PR TITLE
Avoid duplicate runs of actions

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -3,8 +3,8 @@ name: Django CI
 on:
   push:
     branches:
-    - '**'
-    - '!l10n_develop'
+    - 'develop'
+    - 'master'
   pull_request:
     branches:
     - '**'


### PR DESCRIPTION
GitHub Actions run when pushing to the repo or creating a pull request, which may duplicate the runs when creating a pull request from a branch in the repo. This commit sets the "push" builds to only occur on pushing to the `develop` or `master` branches to avoid duplication.