### PR TITLE
API: Allow answers to be in any type

### DIFF
--- a/tabbycat/api/fields.py
+++ b/tabbycat/api/fields.py
@@ -4,9 +4,11 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Q
 from django.urls import get_script_prefix, resolve, Resolver404
 from django.utils.encoding import uri_to_iri
+from drf_spectacular.utils import extend_schema_field
 from rest_framework.relations import Hyperlink, HyperlinkedIdentityField, HyperlinkedRelatedField, SlugRelatedField
 from rest_framework.reverse import reverse
-from rest_framework.serializers import CharField
+from rest_framework.serializers import CharField, Field
+
 
 from participants.models import Adjudicator, Speaker, Team
 from venues.models import Venue
@@ -280,3 +282,12 @@ class ParticipantSourceField(BaseSourceField):
             obj = getattr(value.participant_submitter, model.__name__.lower(), None)
             if obj is not None:
                 return self.get_url(obj, view_name, self.context['request'], format)
+
+
+@extend_schema_field({'anyOf': [{"type": "number"}, {"type": "boolean"}, {"type": "string"}, {"type": "array", "items": {"type": "string"}}]})
+class AnyField(Field):
+    def to_representation(self, value):
+        return value
+
+    def to_internal_value(self, data):
+        return data


### PR DESCRIPTION
This commit creates a new field which takes in a value of Any type and returns it, to allow for the polymorphism of adjudicator feedback questions' answers. The correct type for the question is then checked in validation, or rejected otherwise.

This fixes the bad handling of multiple choice questions as arrays are now permitted and well deserialized.

Extra validations are also added to make sure the answers are suitable (in the available choices) and that all required questions are answered.

Closes #2294