### PR TITLE
Add validation between settings

### DIFF
--- a/tabbycat/options/forms.py
+++ b/tabbycat/options/forms.py
@@ -1,3 +1,5 @@
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext as _
 from dynamic_preferences.forms import GlobalPreferenceForm, preference_form_builder, PreferenceForm
 
 from .preferences import global_preferences_registry, tournament_preferences_registry
@@ -5,6 +7,41 @@ from .preferences import global_preferences_registry, tournament_preferences_reg
 
 class TournamentPreferenceForm(PreferenceForm):
     registry = tournament_preferences_registry
+
+    def clean(self):
+        super().clean()
+        section, first_pref = self.manager.parse_lookup(next(iter(self.cleaned_data.keys())))
+        t = self.manager.instance
+
+        def get_pref(name, section=section):
+            return self.cleaned_data.get(section + "__" + name) or t.pref(name)
+
+        score_range_msg = _("Mininum score must be less than maximum score")
+
+        if section == 'scoring':
+            if get_pref('score_min') > get_pref('score_max'):
+                raise ValidationError({'scoring__score_min': score_range_msg, 'scoring__score_max': score_range_msg})
+
+            if get_pref('reply_score_min') > get_pref('reply_score_max'):
+                raise ValidationError({'scoring__reply_score_min': score_range_msg, 'scoring__reply_score_max': score_range_msg})
+
+        elif section == 'draw_rules':
+            if get_pref('draw_side_allocations') != 'preallocated' and get_pref('draw_odd_bracket') in ['intermediate1', 'intermediate2']:
+                raise ValidationError({'draw_rules__draw_odd_bracket': _("Intermediate 1 or 2 require preallocated sides")})
+
+        elif section == 'debate_rules':
+            if get_pref('teams_in_debate') == 'bp' and (get_pref('ballots_per_debate_prelim') == 'per-adj' or get_pref('ballots_per_debate_elim') == 'per-adj'):
+                raise ValidationError({'debate_rules__teams_in_debate': _("Four-team formats require consensus ballots")})
+
+        elif section == 'feedback':
+            if get_pref('adj_min_score') > get_pref('adj_max_score'):
+                raise ValidationError({'feedback__adj_min_score': score_range_msg, 'feedback__adj_max_score': score_range_msg})
+
+        elif section == 'ui_options':
+            if get_pref('team_code_names') not in ['off', 'all-tooltips'] and get_pref('show_team_institutions'):
+                raise ValidationError({'ui_options__show_team_institutions': _("Showing team institutions defeats the purpose of code names")})
+
+        return self.cleaned_data
 
 
 def tournament_preference_form_builder(instance, preferences=[], **kwargs):

--- a/tabbycat/options/forms.py
+++ b/tabbycat/options/forms.py
@@ -14,7 +14,7 @@ class TournamentPreferenceForm(PreferenceForm):
         t = self.manager.instance
 
         def get_pref(name, section=section):
-            return self.cleaned_data.get(section + "__" + name) or t.pref(name)
+            return self.cleaned_data.get(section + "__" + name) if (section + "__" + name) in self.cleaned_data else t.pref(name)
 
         score_range_msg = _("Mininum score must be less than maximum score")
 
@@ -36,6 +36,10 @@ class TournamentPreferenceForm(PreferenceForm):
         elif section == 'feedback':
             if get_pref('adj_min_score') > get_pref('adj_max_score'):
                 raise ValidationError({'feedback__adj_min_score': score_range_msg, 'feedback__adj_max_score': score_range_msg})
+
+        elif section == 'data_entry':
+            if get_pref('public_use_password') and len(get_pref('public_password')) == 0:
+                raise ValidationError({'data_entry__public_password': _("Must set a password if using a password is enabled")})
 
         elif section == 'ui_options':
             if get_pref('team_code_names') not in ['off', 'all-tooltips'] and get_pref('show_team_institutions'):

--- a/tabbycat/options/preferences.py
+++ b/tabbycat/options/preferences.py
@@ -863,7 +863,8 @@ class PublicPassword(StringPreference):
     verbose_name = _("Password for public submission")
     section = data_entry
     name = 'public_password'
-    default = 'Enter Password'
+    default = ''
+    required = False
 
 
 @tournament_preferences_registry.register

--- a/tabbycat/options/templates/preferences_index.html
+++ b/tabbycat/options/templates/preferences_index.html
@@ -4,44 +4,6 @@
 {% block page-title %}{% trans "Configuration" %}{% endblock %}
 {% block head-title %}<span class="emoji">🔧</span> {% trans "Configuration" %}{% endblock %}
 
-{% block page-alerts %}
-  {% if pref.teams_in_debate == 'bp' %}
-    {% if pref.ballots_per_debate_prelim == 'per-adj' or pref.ballots_per_debate_elim == 'per-adj' %}
-      {% tournamenturl 'options-tournament-section' section='debate_rules' as options_url %}
-      {% blocktrans trimmed asvar message %}
-        Your draw rules specify four teams per-debate but your ballot setting specifies that
-        adjudicators submit independent ballots. These settings <strong>are not compatible
-        and will cause results entry to crash</strong>. You need to go back to the
-        <a href="{{ options_url }}" class="alert-link">Debate Rules section</a> and change
-        your configuration to use consensus ballots.
-      {% endblocktrans %}
-      {% include "components/alert.html" with type="danger" icon="alert-circle" %}
-    {% endif %}
-  {% endif %}
-  {% if pref.draw_side_allocations != 'preallocated' %}
-    {% if pref.draw_odd_bracket == 'intermediate1' or pref.draw_odd_bracket == 'intermediate2' %}
-      {% tournamenturl 'options-tournament-section' section='draw_rules' as options_url %}
-      {% blocktrans trimmed asvar message %}
-        You do not use preallocated side allocation yet the odd bracket resolution method
-        uses preallocated sides. This will cause draw generation to fail. You need to edit
-        odd bracket resolution, avoiding <i>Intermediate 1</i> and <i>Intermediate 2</i> in
-        the <a href="{{ options_url }}" class="alert-link">Draw Rules section</a>.
-      {% endblocktrans %}
-      {% include "components/alert.html" with type="danger" icon="alert-circle" %}
-    {% endif %}
-  {% endif %}
-  {% if pref.team_code_names != 'off' and pref.team_code_names != 'all-tooltips' and pref.show_team_institutions %}
-    {% tournamenturl 'options-tournament-section' section='ui_options' as ui_url %}
-    {% blocktrans trimmed asvar message %}
-      You both have team code names enabled, and team institutions showing on public pages.
-      If your objective in enabling team code names is to obscure team institutions, this
-      probably defeats the purpose of code names. You can edit these settings in the
-      <a href="{{ ui_url }}" class="alert-link">UI Options section</a>.
-    {% endblocktrans %}
-    {% include "components/alert.html" with type="warning" icon="alert-circle" %}
-  {% endif %}
-{% endblock %}
-
 {% block content %}
 
 <div class="row">

--- a/tabbycat/results/templates/assistant_results.html
+++ b/tabbycat/results/templates/assistant_results.html
@@ -12,13 +12,6 @@
     {% trans "This page automatically updates with the new ballot entries and checkins as they occur." as message %}
     {% include "components/alert.html" with type="info" %}
 
-    {% if pref.teams_in_debate == "bp" and round.ballots_per_debate == "per-adj" %}
-      {% blocktrans trimmed asvar message %}
-        This tournament's configuration is set to <strong>British Parliamentary</strong> with <strong>one ballot per voting adjudicator</strong>. This combination isn't allowed: BP tournaments must use consensus ballots. Results can't be entered while this configuration is in place. Please ask an administrator to change this configuration.
-      {% endblocktrans %}
-      {% include "components/alert.html" with type="danger" %}
-    {% endif %}
-
     {% if pref.enable_motions and round.motion_set.count == 0 %}
       {% blocktrans trimmed asvar message %}
         Currently there are no motions entered for this round, so debate results


### PR DESCRIPTION
This commit replaces the after-the-fact warning messages about having incompatible settings with form validations that prevent saving the offending settings. With this new approach, the error messages can be shorter, as they are shown with the setting(s) to be changed.

An improvement could be if the validations could be separated by section, to avoid listing them all in the same place, disorganized.

There can be more validations added later in the same place and format. The current validations are:
- Adj/Speaker [reply] score minimums must be less than their maximums
- Intermediate 1/2 brackets require preallocated sides
- BP can't use voting ballots
- Institutions shouldn't be shown with team names

I'd suggest that future tickets keep with specific items to address.

Closes #106
Closes #500