### PR TITLE
Check truthiness of configuration presets

### DIFF
--- a/tabbycat/tournaments/forms.py
+++ b/tabbycat/tournaments/forms.py
@@ -120,12 +120,12 @@ class TournamentConfigureForm(ModelForm):
 
         # Apply public info presets
         do_public = self.cleaned_data["public_info"]
-        if do_public:
+        if do_public == "True":
             save_presets(t, PublicInformation)
 
         # Apply data entry method preset
         data_entry_method = self.cleaned_data["data_entry"]
-        if data_entry_method:
+        if data_entry_method != "False":
             save_presets(t, {"private-urls": PrivateURLS, "public": PublicForms}[data_entry_method])
 
         # Apply the credits


### PR DESCRIPTION
The tournament configuration form crashes when trying to set the data entry method preset as the form thinks that false is a key for a preset. This change skips setting the preset if false.