### PR TITLE
Capitalize side name in draw table

### DIFF
--- a/tabbycat/draw/tables.py
+++ b/tabbycat/draw/tables.py
@@ -65,7 +65,7 @@ class PublicDrawTableBuilder(BaseDrawTableBuilder):
             if self.tournament.pref('teams_in_debate') == 'bp':
                 side_name = get_side_name(self.tournament, side, 'abbr')
             else:
-                side_name = get_side_name(self.tournament, side, 'full')
+                side_name = get_side_name(self.tournament, side, 'full').title()
 
             team_data = []
             for debate, hl in zip_longest(debates, highlight):


### PR DESCRIPTION
Capitalize side name for two-team debate format in draw tables. Capitalization makes the columns more consistent with the others.