### PR TITLE
Overhaul merging ballots

### DIFF
--- a/tabbycat/motions/utils.py
+++ b/tabbycat/motions/utils.py
@@ -8,7 +8,7 @@ from .models import DebateTeamMotionPreference, RoundMotion
 def merge_motions(new_bs, bses):
     n_motions = bses.aggregate(n_motions=Count('motion', distinct=True))['n_motions']
     if n_motions > 1:
-        raise ValidationError(_("Not all latest ballots list the same motion, so could not be merged."))
+        raise ValidationError(_("Not all latest ballots have the same motion. The correct motion must be set manually."))
     elif n_motions == 1:
         new_bs.motion = bses[0].motion
 
@@ -26,7 +26,7 @@ def merge_motion_vetos(new_bs, bses):
     if len({p[0] for p in preferences}) != len(preferences):
         # If a team is repeated, means different values were given and the length of both sets would
         # be different. First term could just be "2" (expected to be {'aff', 'neg'}).
-        raise ValidationError(_("Motion vetos are inconsistent, so could not be merged."))
+        raise ValidationError(_("Motion vetos are inconsistent; they must be set manually."))
 
     for dt, side, motion, preference in preferences:
         vetos[side] = DebateTeamMotionPreference(

--- a/tabbycat/results/forms.py
+++ b/tabbycat/results/forms.py
@@ -328,8 +328,8 @@ class BaseBallotSetForm(BaseResultForm):
         if self.using_vetoes:
             for side in self.sides:
                 self.fields[self._fieldname_motion_veto(side)] = MotionModelChoiceField(
-                    label=_("%(side)s's motion veto") % {'side': get_side_name(self.tournament, side, 'abbr')},
-                    queryset=self.motions, required=False, help_text=get_side_name(self.tournament, side, 'full'),
+                    label=_("%(side)s's motion veto") % {'side': get_side_name(self.tournament, side, 'full').title()},
+                    queryset=self.motions, required=False,
                 )
 
         # 3. Speaker fields


### PR DESCRIPTION
This commit implements a merging strategy for consensus ballots, making sure that speaker order, ghosts, as well as declared winners and speaker scores, are identical, lest an error be raised.

Now, rather than aborting the merge when an error is detected, the error(s) are applied to the new ballot, blanking the fields that were errored. It also shows more general errors of the detected divergences, rather than pointing out where it thinks the error was made. That wasn't needed anymore as the specific fields are now obvious.