### PR TITLE
API: PATCH for conflicts keep existing ones

### DIFF
--- a/tabbycat/api/serializers.py
+++ b/tabbycat/api/serializers.py
@@ -579,6 +579,11 @@ class AdjudicatorSerializer(serializers.ModelSerializer):
             vc._validated_data = venue_constraints  # Data was already validated
             vc.save(adjudicator=instance)
 
+        if self.partial:
+            # Avoid removing conflicts if merely PATCHing
+            for field in ['institution_conflicts', 'adjudicator_conflicts', 'team_conflicts']:
+                validated_data[field] = list(getattr(instance, field).all()) + validated_data.get(field, [])
+
         return super().update(instance, validated_data)
 
 
@@ -711,6 +716,10 @@ class TeamSerializer(serializers.ModelSerializer):
             vc = VenueConstraintSerializer(many=True, context=self.context)
             vc._validated_data = venue_constraints  # Data was already validated
             vc.save(institution=instance)
+
+        if self.partial:
+            # Avoid removing conflicts if merely PATCHing
+            validated_data['institution_conflicts'] = list(instance.institution_conflicts.all()) + validated_data.get('institution_conflicts', [])
 
         return super().update(instance, validated_data)
 


### PR DESCRIPTION
This commit changes the behaviour when using PATCH to change conflicts on the /adjudicators and /teams endpoints. Rather than deleting existing conflicts, PATCH should merely add the new ones to the object. This also makes the behaviour more consistent with speaker/team categories and other M2Ms.