### PR TITLE
Add missing key to draw options

### DIFF
--- a/tabbycat/draw/generator/common.py
+++ b/tabbycat/draw/generator/common.py
@@ -167,6 +167,7 @@ class BasePairDrawGenerator(BaseDrawGenerator):
         "side_penalty"          : 0,
         "pullup_debates_penalty": 0,
         "pairing_penalty"       : 0,
+        "avoid_conflicts"       : "off",
     }
 
     TEAMS_PER_DEBATE = 2


### PR DESCRIPTION
The new draw generation option `avoid_conflicts` was missing from the defaults list, causing a crash.

Fixes #2333