### PR TITLE
Add missing get_speaker_rank methods to Results

### DIFF
--- a/tabbycat/results/result.py
+++ b/tabbycat/results/result.py
@@ -770,6 +770,9 @@ class DebateResultWithScoresMixin:
     def set_ghost(self, side, position, is_ghost):
         self.ghosts[side][position] = is_ghost
 
+    def get_speaker_rank(self, side: str, position: int) -> int:
+        return self.scoresheet.get_speaker_rank(side, position)
+
     def set_speaker_rank(self, side, position, rank):
         self.scoresheet.set_speaker_rank(side, position, rank)
 
@@ -1067,6 +1070,9 @@ class DebateResultByAdjudicatorWithScores(DebateResultWithScoresMixin, DebateRes
             logger.exception("Tried to set score by adjudicator %s, but this adjudicator "
                 "doesn't have a scoresheet.", adjudicator)
             return
+
+    def get_speaker_rank(self, adjudicator: 'Adjudicator', side: str, position: int) -> int:
+        return self.scoresheets[adjudicator].get_speaker_rank(side, position)
 
     # --------------------------------------------------------------------------
     # Model fields

--- a/tabbycat/results/scoresheet.py
+++ b/tabbycat/results/scoresheet.py
@@ -73,7 +73,7 @@ class ScoresMixin:
     def set_speaker_rank(self, side, position, score):
         self.speaker_ranks[side][position] = score
 
-    def get_speaker_rank(self, side, position):
+    def get_speaker_rank(self, side: str, position: int) -> int:
         return self.speaker_ranks[side][position]
 
     def get_total(self, side):


### PR DESCRIPTION
This commit adds the missing `get_speaker_rank()` methods for score- based results in order to show speaker ranks in the API and ballots.