### PR TITLE
API: Fix couple problems when creating results

### DIFF
--- a/tabbycat/api/serializers.py
+++ b/tabbycat/api/serializers.py
@@ -23,7 +23,7 @@ from participants.utils import populate_code_names
 from privateurls.utils import populate_url_keys
 from results.mixins import TabroomSubmissionFieldsMixin
 from results.models import BallotSubmission, SpeakerScore, TeamScore
-from results.result import DebateResult
+from results.result import DebateResult, ResultError
 from standings.speakers import SpeakerStandingsGenerator
 from standings.teams import TeamStandingsGenerator
 from tournaments.models import Round, Tournament
@@ -1149,8 +1149,8 @@ class BallotSerializer(TabroomSubmissionFieldsMixin, serializers.ModelSerializer
 
                     if result.get_scoresheet_class().uses_declared_winners and self.validated_data.get('win', False):
                         args = [self.validated_data['side']]
-                        if self.validated_data.get('adjudicator') is not None:
-                            args.insert(0, self.validated_data['adjudicator'])
+                        if kwargs.get('adjudicator') is not None and not result.ballotsub.single_adj:
+                            args.insert(0, kwargs.get('adjudicator'))
                         result.add_winner(*args)
 
                     speech_serializer = self.SpeechSerializer(context=self.context)
@@ -1217,7 +1217,11 @@ class BallotSerializer(TabroomSubmissionFieldsMixin, serializers.ModelSerializer
                 sheets._validated_data = sheet
                 sheets.save(result=result)
 
-            result.save()
+            try:
+                result.save()
+            except ResultError as e:
+                raise serializers.ValidationError(str(e))
+
             return result
 
     class VetoSerializer(serializers.ModelSerializer):
@@ -1230,8 +1234,9 @@ class BallotSerializer(TabroomSubmissionFieldsMixin, serializers.ModelSerializer
             exclude = ('id', 'ballot_submission', 'preference', 'debate_team')
 
         def create(self, validated_data):
+            team = validated_data.pop('debate_team').pop('team')
             try:
-                validated_data['debate_team'] = DebateTeam.objects.get(debate=self.context['debate'], team=validated_data.pop('team'))
+                validated_data['debate_team'] = DebateTeam.objects.get(debate=self.context['debate'], team=team)
             except (DebateTeam.DoesNotExist, DebateTeam.MultipleObjectsReturned):
                 raise serializers.ValidationError('Team is not in debate')
             return super().create(validated_data)
@@ -1239,7 +1244,7 @@ class BallotSerializer(TabroomSubmissionFieldsMixin, serializers.ModelSerializer
     result = ResultSerializer(source='result.get_result_info')
     motion = fields.TournamentHyperlinkedRelatedField(view_name='api-motion-detail', required=False, queryset=Motion.objects.all())
     url = fields.DebateHyperlinkedIdentityField(view_name='api-ballot-detail')
-    participant_submitter = fields.ParticipantSourceField(allow_null=True)
+    participant_submitter = fields.ParticipantSourceField(allow_null=True, required=False)
     vetos = VetoSerializer(many=True, source='debateteammotionpreference_set', required=False, allow_null=True)
 
     class Meta:
@@ -1247,14 +1252,14 @@ class BallotSerializer(TabroomSubmissionFieldsMixin, serializers.ModelSerializer
         exclude = ('debate',)
         read_only_fields = ('timestamp', 'version',
             'submitter_type', 'submitter', 'participant_submitter',
-            'confirmer', 'confirm_timestamp', 'ip_address', 'single_adj', 'private_url')
+            'confirmer', 'confirm_timestamp', 'ip_address', 'private_url')
 
     def get_request(self):
         return self.context['request']
 
     def create(self, validated_data):
         result_data = validated_data.pop('result').pop('get_result_info')
-        veto_data = validated_data.pop('vetos', None)
+        veto_data = validated_data.pop('debateteammotionpreference_set', None)
 
         validated_data.update(self.get_submitter_fields())
         if validated_data.get('confirmed', False):
@@ -1263,12 +1268,19 @@ class BallotSerializer(TabroomSubmissionFieldsMixin, serializers.ModelSerializer
 
         stage = 'elim' if self.context['round'].stage == Round.Stage.ELIMINATION else 'prelim'
         if self.context['tournament'].pref('ballots_per_debate_' + stage) == 'per-adj':
-            if self.context['debate'].debateadjudicator_set.all().count() > 1:
+            debateadj_count = self.context['debate'].debateadjudicator_set.exclude(type=DebateAdjudicator.TYPE_TRAINEE).count()
+            if debateadj_count > 1:
                 if len(result_data['sheets']) == 1:
                     validated_data['participant_submitter'] = result_data['sheets'][0]['adjudicator']
                     validated_data['single_adj'] = True
-                else:
-                    raise serializers.ValidationError('Single-adjudicator ballots must have only one scoresheet')
+                elif validated_data.get('single_adj', False):
+                    raise serializers.ValidationError({'single_adj': 'Single-adjudicator ballots can only have one scoresheet'})
+                elif len(result_data['sheets']) != debateadj_count:
+                    raise serializers.ValidationError({
+                        'result': 'Voting ballots must either have one scoresheet or ballots from all voting adjudicators',
+                    })
+        elif len(result_data['sheets']) > 1:
+            raise serializers.ValidationError({'result': 'Consensus ballots can only have one scoresheet'})
 
         ballot = super().create(validated_data)
 
@@ -1278,8 +1290,9 @@ class BallotSerializer(TabroomSubmissionFieldsMixin, serializers.ModelSerializer
         result.save(ballot=ballot)
 
         if veto_data:
-            vetos = self.VetoSerializer(context=self.context)
+            vetos = self.VetoSerializer(context=self.context, many=True)
             vetos._validated_data = veto_data
+            vetos._errors = []
             vetos.save(ballot_submission=ballot, preference=3)
 
         return ballot

--- a/tabbycat/api/tests/test_serializers.py
+++ b/tabbycat/api/tests/test_serializers.py
@@ -1,13 +1,21 @@
+import logging
+
+from django.contrib.auth import get_user_model
 from rest_framework.test import APIClient, APITestCase
 
-from tournaments.models import Round
+from adjallocation.models import DebateAdjudicator
+from draw.models import Debate, DebateTeam
+from motions.models import Motion, RoundMotion
+from options.presets import CanadianParliamentaryPreferences
+from participants.models import Adjudicator, Speaker, Team
+from tournaments.models import Round, Tournament
 from utils.misc import reverse_round, reverse_tournament
 from utils.tests import CompletedTournamentTestMixin
 
+User = get_user_model()
+
 
 class RoundSerializerTests(CompletedTournamentTestMixin, APITestCase):
-
-    # user = User.objects.get(username='admin')
 
     def test_exclude_motions_if_list(self):
         response = self.client.get(reverse_tournament('api-round-list', self.tournament))
@@ -134,3 +142,730 @@ class AdjudicatorSerializerTests(CompletedTournamentTestMixin, APITestCase):
             "url_key": "laZzBPo6FsGEr12VtB8LSHM8",
         })
         self.assertEqual(response.status_code, 201)
+
+
+class BallotSerializerTests(APITestCase):
+
+    def setUp(self):
+        logging.disable(logging.CRITICAL)
+        self.user = User.objects.create_superuser(username='admin1', password='admin', is_active=True)
+        self.tournament = Tournament.objects.create(slug='apitest')
+        self.round = Round.objects.create(seq=1, tournament=self.tournament)
+        self.debate = Debate.objects.create(round=self.round)
+
+        CanadianParliamentaryPreferences.save(self.tournament)
+
+        self.t1 = Team.objects.create(tournament=self.tournament, reference='A')
+        self.s1 = Speaker.objects.create(name='1', team=self.t1)
+        self.s2 = Speaker.objects.create(name='2', team=self.t1)
+
+        self.t2 = Team.objects.create(tournament=self.tournament, reference='B')
+        self.s3 = Speaker.objects.create(name='3', team=self.t2)
+        self.s4 = Speaker.objects.create(name='4', team=self.t2)
+
+        self.t3 = Team.objects.create(tournament=self.tournament, reference='C')
+
+        self.a1 = Adjudicator.objects.create(name='A1', tournament=self.tournament)
+        self.a2 = Adjudicator.objects.create(name='A2', tournament=self.tournament)
+        self.a3 = Adjudicator.objects.create(name='A3', tournament=self.tournament)
+
+        DebateTeam.objects.bulk_create([DebateTeam(side=side, team=team, debate=self.debate) for side, team in zip(['aff', 'neg'], [self.t1, self.t2])])
+        DebateAdjudicator.objects.bulk_create([
+            DebateAdjudicator(adjudicator=self.a1, debate=self.debate, type='C'), DebateAdjudicator(adjudicator=self.a2, debate=self.debate, type='P'),
+        ])
+
+        self.m1 = Motion.objects.create(tournament=self.tournament)
+        self.m2 = Motion.objects.create(tournament=self.tournament)
+        self.m3 = Motion.objects.create(tournament=self.tournament)
+        RoundMotion.objects.bulk_create([RoundMotion(seq=i, motion=motion, round=self.round) for i, motion in enumerate([self.m1, self.m2])])
+
+    def tearDown(self):
+        self.debate.delete()
+        self.tournament.delete()
+        self.user.delete()
+        logging.disable(logging.NOTSET)
+
+    def test_can_create_consensus_ballot_scores(self):
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+        response = client.post(reverse_round('api-ballot-list', self.round, kwargs={'debate_pk': self.debate.pk}), {
+            'result': {
+                'sheets': [{
+                    'teams': [
+                        {
+                            'side': 'aff',
+                            'team': reverse_tournament('api-team-detail', self.tournament, kwargs={'pk': self.t1.pk}),
+                            'speeches': [
+                                {
+                                    'ghost': False,
+                                    'score': 80,
+                                    'speaker': reverse_tournament('api-speaker-detail', self.tournament, kwargs={'pk': self.s1.pk}),
+                                },
+                                {
+                                    'ghost': False,
+                                    'score': 80,
+                                    'speaker': reverse_tournament('api-speaker-detail', self.tournament, kwargs={'pk': self.s2.pk}),
+                                },
+                            ],
+                        },
+                        {
+                            'side': 'neg',
+                            'team': reverse_tournament('api-team-detail', self.tournament, kwargs={'pk': self.t2.pk}),
+                            'speeches': [
+                                {
+                                    'ghost': False,
+                                    'score': 79,
+                                    'speaker': reverse_tournament('api-speaker-detail', self.tournament, kwargs={'pk': self.s3.pk}),
+                                },
+                                {
+                                    'ghost': False,
+                                    'score': 79,
+                                    'speaker': reverse_tournament('api-speaker-detail', self.tournament, kwargs={'pk': self.s4.pk}),
+                                },
+                            ],
+                        },
+                    ],
+                }],
+            },
+        })
+        self.assertEqual(response.status_code, 201)
+
+    def test_can_create_voting_ballot_scores(self):
+        self.tournament.preferences['debate_rules__ballots_per_debate_prelim'] = 'per-adj'
+
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+        response = client.post(reverse_round('api-ballot-list', self.round, kwargs={'debate_pk': self.debate.pk}), {
+            'result': {
+                'sheets': [
+                    {
+                        'adjudicator': reverse_tournament('api-adjudicator-detail', self.tournament, kwargs={'pk': self.a1.pk}),
+                        'teams': [
+                            {
+                                'side': 'aff',
+                                'team': reverse_tournament('api-team-detail', self.tournament, kwargs={'pk': self.t1.pk}),
+                                'speeches': [
+                                    {
+                                        'ghost': False,
+                                        'score': 80,
+                                        'speaker': reverse_tournament('api-speaker-detail', self.tournament, kwargs={'pk': self.s1.pk}),
+                                    },
+                                    {
+                                        'ghost': False,
+                                        'score': 80,
+                                        'speaker': reverse_tournament('api-speaker-detail', self.tournament, kwargs={'pk': self.s2.pk}),
+                                    },
+                                ],
+                            },
+                            {
+                                'side': 'neg',
+                                'team': reverse_tournament('api-team-detail', self.tournament, kwargs={'pk': self.t2.pk}),
+                                'speeches': [
+                                    {
+                                        'ghost': False,
+                                        'score': 79,
+                                        'speaker': reverse_tournament('api-speaker-detail', self.tournament, kwargs={'pk': self.s3.pk}),
+                                    },
+                                    {
+                                        'ghost': False,
+                                        'score': 79,
+                                        'speaker': reverse_tournament('api-speaker-detail', self.tournament, kwargs={'pk': self.s4.pk}),
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                    {
+                        'adjudicator': reverse_tournament('api-adjudicator-detail', self.tournament, kwargs={'pk': self.a2.pk}),
+                        'teams': [
+                            {
+                                'side': 'aff',
+                                'team': reverse_tournament('api-team-detail', self.tournament, kwargs={'pk': self.t1.pk}),
+                                'speeches': [
+                                    {
+                                        'ghost': False,
+                                        'score': 79,
+                                        'speaker': reverse_tournament('api-speaker-detail', self.tournament, kwargs={'pk': self.s1.pk}),
+                                    },
+                                    {
+                                        'ghost': False,
+                                        'score': 79,
+                                        'speaker': reverse_tournament('api-speaker-detail', self.tournament, kwargs={'pk': self.s2.pk}),
+                                    },
+                                ],
+                            },
+                            {
+                                'side': 'neg',
+                                'team': reverse_tournament('api-team-detail', self.tournament, kwargs={'pk': self.t2.pk}),
+                                'speeches': [
+                                    {
+                                        'ghost': False,
+                                        'score': 80,
+                                        'speaker': reverse_tournament('api-speaker-detail', self.tournament, kwargs={'pk': self.s3.pk}),
+                                    },
+                                    {
+                                        'ghost': False,
+                                        'score': 80,
+                                        'speaker': reverse_tournament('api-speaker-detail', self.tournament, kwargs={'pk': self.s4.pk}),
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            },
+        })
+        self.assertEqual(response.status_code, 201)
+
+    def test_can_create_consensus_ballot_winner(self):
+        self.tournament.preferences['debate_rules__speakers_in_ballots'] = 'never'
+
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+        response = client.post(reverse_round('api-ballot-list', self.round, kwargs={'debate_pk': self.debate.pk}), {
+            'result': {
+                'sheets': [{
+                    'teams': [
+                        {
+                            'side': 'aff',
+                            'team': reverse_tournament('api-team-detail', self.tournament, kwargs={'pk': self.t1.pk}),
+                            'win': True,
+                        },
+                        {
+                            'side': 'neg',
+                            'team': reverse_tournament('api-team-detail', self.tournament, kwargs={'pk': self.t2.pk}),
+                            'win': False,
+                        },
+                    ],
+                }],
+            },
+        })
+        self.assertEqual(response.status_code, 201)
+
+    def test_can_create_voting_ballot_winner(self):
+        self.tournament.preferences['debate_rules__ballots_per_debate_prelim'] = 'per-adj'
+        self.tournament.preferences['debate_rules__speakers_in_ballots'] = 'never'
+
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+        response = client.post(reverse_round('api-ballot-list', self.round, kwargs={'debate_pk': self.debate.pk}), {
+            'result': {
+                'sheets': [
+                    {
+                        'adjudicator': reverse_tournament('api-adjudicator-detail', self.tournament, kwargs={'pk': self.a1.pk}),
+                        'teams': [
+                            {
+                                'side': 'aff',
+                                'team': reverse_tournament('api-team-detail', self.tournament, kwargs={'pk': self.t1.pk}),
+                                'win': True,
+                            },
+                            {
+                                'side': 'neg',
+                                'team': reverse_tournament('api-team-detail', self.tournament, kwargs={'pk': self.t2.pk}),
+                                'win': False,
+                            },
+                        ],
+                    },
+                    {
+                        'adjudicator': reverse_tournament('api-adjudicator-detail', self.tournament, kwargs={'pk': self.a2.pk}),
+                        'teams': [
+                            {
+                                'side': 'aff',
+                                'team': reverse_tournament('api-team-detail', self.tournament, kwargs={'pk': self.t1.pk}),
+                                'win': False,
+                            },
+                            {
+                                'side': 'neg',
+                                'team': reverse_tournament('api-team-detail', self.tournament, kwargs={'pk': self.t2.pk}),
+                                'win': True,
+                            },
+                        ],
+                    },
+                ],
+            },
+        })
+        self.assertEqual(response.status_code, 201)
+
+    def test_voting_motion_vetos(self):
+        self.tournament.preferences['debate_rules__speakers_in_ballots'] = 'never'
+        self.tournament.preferences['motions__motion_vetoes_enabled'] = True
+
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+        response = client.post(reverse_round('api-ballot-list', self.round, kwargs={'debate_pk': self.debate.pk}), {
+            'result': {
+                'sheets': [{
+                    'teams': [
+                        {
+                            'side': 'aff',
+                            'team': reverse_tournament('api-team-detail', self.tournament, kwargs={'pk': self.t1.pk}),
+                            'win': True,
+                        },
+                        {
+                            'side': 'neg',
+                            'team': reverse_tournament('api-team-detail', self.tournament, kwargs={'pk': self.t2.pk}),
+                            'win': False,
+                        },
+                    ],
+                }],
+            },
+            'vetos': [
+                {
+                    'team': reverse_tournament('api-team-detail', self.tournament, kwargs={'pk': self.t1.pk}),
+                    'motion': reverse_tournament('api-motion-detail', self.tournament, kwargs={'pk': self.m1.pk}),
+                },
+                {
+                    'team': reverse_tournament('api-team-detail', self.tournament, kwargs={'pk': self.t2.pk}),
+                    'motion': reverse_tournament('api-motion-detail', self.tournament, kwargs={'pk': self.m2.pk}),
+                },
+            ],
+        })
+        self.assertEqual(response.status_code, 201)
+
+    def test_single_adj_ballot(self):
+        self.tournament.preferences['debate_rules__ballots_per_debate_prelim'] = 'per-adj'
+        self.tournament.preferences['debate_rules__speakers_in_ballots'] = 'never'
+
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+        response = client.post(reverse_round('api-ballot-list', self.round, kwargs={'debate_pk': self.debate.pk}), {
+            'result': {
+                'sheets': [{
+                    'adjudicator': reverse_tournament('api-adjudicator-detail', self.tournament, kwargs={'pk': self.a1.pk}),
+                    'teams': [
+                        {
+                            'side': 'aff',
+                            'team': reverse_tournament('api-team-detail', self.tournament, kwargs={'pk': self.t1.pk}),
+                            'win': True,
+                        },
+                        {
+                            'side': 'neg',
+                            'team': reverse_tournament('api-team-detail', self.tournament, kwargs={'pk': self.t2.pk}),
+                            'win': False,
+                        },
+                    ],
+                }],
+            },
+        })
+        self.assertEqual(response.status_code, 201)
+
+    def test_team_not_in_debate(self):
+        self.tournament.preferences['debate_rules__speakers_in_ballots'] = 'never'
+
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+        response = client.post(reverse_round('api-ballot-list', self.round, kwargs={'debate_pk': self.debate.pk}), {
+            'result': {
+                'sheets': [{
+                    'teams': [
+                        {
+                            'side': 'aff',
+                            'team': reverse_tournament('api-team-detail', self.tournament, kwargs={'pk': self.t2.pk}),
+                            'win': True,
+                        },
+                        {
+                            'side': 'neg',
+                            'team': reverse_tournament('api-team-detail', self.tournament, kwargs={'pk': self.t3.pk}),
+                            'win': False,
+                        },
+                    ],
+                }],
+            },
+        })
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(str(response.data['result']['sheets'][0]['teams'][0]), 'Inconsistent team')
+
+    def test_team_not_in_correct_side(self):
+        self.tournament.preferences['debate_rules__speakers_in_ballots'] = 'never'
+
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+        response = client.post(reverse_round('api-ballot-list', self.round, kwargs={'debate_pk': self.debate.pk}), {
+            'result': {
+                'sheets': [{
+                    'teams': [
+                        {
+                            'side': 'aff',
+                            'team': reverse_tournament('api-team-detail', self.tournament, kwargs={'pk': self.t2.pk}),
+                            'win': True,
+                        },
+                        {
+                            'side': 'neg',
+                            'team': reverse_tournament('api-team-detail', self.tournament, kwargs={'pk': self.t1.pk}),
+                            'win': False,
+                        },
+                    ],
+                }],
+            },
+        })
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(str(response.data['result']['sheets'][0]['teams'][0]), 'Inconsistent team')
+
+    def test_team_not_in_debate_veto(self):
+        self.tournament.preferences['debate_rules__speakers_in_ballots'] = 'never'
+        self.tournament.preferences['motions__motion_vetoes_enabled'] = True
+
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+        response = client.post(reverse_round('api-ballot-list', self.round, kwargs={'debate_pk': self.debate.pk}), {
+            'result': {
+                'sheets': [{
+                    'teams': [
+                        {
+                            'side': 'aff',
+                            'team': reverse_tournament('api-team-detail', self.tournament, kwargs={'pk': self.t1.pk}),
+                            'win': True,
+                        },
+                        {
+                            'side': 'neg',
+                            'team': reverse_tournament('api-team-detail', self.tournament, kwargs={'pk': self.t2.pk}),
+                            'win': False,
+                        },
+                    ],
+                }],
+            },
+            'vetos': [
+                {
+                    'team': reverse_tournament('api-team-detail', self.tournament, kwargs={'pk': self.t3.pk}),
+                    'motion': reverse_tournament('api-motion-detail', self.tournament, kwargs={'pk': self.m1.pk}),
+                },
+                {
+                    'team': reverse_tournament('api-team-detail', self.tournament, kwargs={'pk': self.t2.pk}),
+                    'motion': reverse_tournament('api-motion-detail', self.tournament, kwargs={'pk': self.m2.pk}),
+                },
+            ],
+        })
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(str(response.data[0]), 'Team is not in debate')
+
+    def test_adj_not_in_debate(self):
+        self.tournament.preferences['debate_rules__ballots_per_debate_prelim'] = 'per-adj'
+        self.tournament.preferences['debate_rules__speakers_in_ballots'] = 'never'
+
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+        response = client.post(reverse_round('api-ballot-list', self.round, kwargs={'debate_pk': self.debate.pk}), {
+            'result': {
+                'sheets': [{
+                    'adjudicator': reverse_tournament('api-adjudicator-detail', self.tournament, kwargs={'pk': self.a3.pk}),
+                    'teams': [
+                        {
+                            'side': 'aff',
+                            'team': reverse_tournament('api-team-detail', self.tournament, kwargs={'pk': self.t1.pk}),
+                            'win': True,
+                        },
+                        {
+                            'side': 'neg',
+                            'team': reverse_tournament('api-team-detail', self.tournament, kwargs={'pk': self.t2.pk}),
+                            'win': False,
+                        },
+                    ],
+                }],
+            },
+        })
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(str(response.data['result']['sheets'][0]['adjudicator'][0]), 'Adjudicator must be in debate')
+
+    def test_single_adj_many_ballots_fail(self):
+        self.tournament.preferences['debate_rules__ballots_per_debate_prelim'] = 'per-adj'
+        self.tournament.preferences['debate_rules__speakers_in_ballots'] = 'never'
+
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+        response = client.post(reverse_round('api-ballot-list', self.round, kwargs={'debate_pk': self.debate.pk}), {
+            'single_adj': True,
+            'result': {
+                'sheets': [
+                    {
+                        'adjudicator': reverse_tournament('api-adjudicator-detail', self.tournament, kwargs={'pk': self.a1.pk}),
+                        'teams': [
+                            {
+                                'side': 'aff',
+                                'team': reverse_tournament('api-team-detail', self.tournament, kwargs={'pk': self.t1.pk}),
+                                'win': True,
+                            },
+                            {
+                                'side': 'neg',
+                                'team': reverse_tournament('api-team-detail', self.tournament, kwargs={'pk': self.t2.pk}),
+                                'win': False,
+                            },
+                        ],
+                    },
+                    {
+                        'adjudicator': reverse_tournament('api-adjudicator-detail', self.tournament, kwargs={'pk': self.a2.pk}),
+                        'teams': [
+                            {
+                                'side': 'aff',
+                                'team': reverse_tournament('api-team-detail', self.tournament, kwargs={'pk': self.t1.pk}),
+                                'win': False,
+                            },
+                            {
+                                'side': 'neg',
+                                'team': reverse_tournament('api-team-detail', self.tournament, kwargs={'pk': self.t2.pk}),
+                                'win': True,
+                            },
+                        ],
+                    },
+                ],
+            },
+        })
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(str(response.data['single_adj']), 'Single-adjudicator ballots can only have one scoresheet')
+
+    def test_incomplete_ballots_fail(self):
+        self.tournament.preferences['debate_rules__ballots_per_debate_prelim'] = 'per-adj'
+        self.tournament.preferences['debate_rules__speakers_in_ballots'] = 'never'
+        DebateAdjudicator.objects.create(adjudicator=self.a3, type=DebateAdjudicator.TYPE_PANEL, debate=self.debate)
+
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+        response = client.post(reverse_round('api-ballot-list', self.round, kwargs={'debate_pk': self.debate.pk}), {
+            'result': {
+                'sheets': [
+                    {
+                        'adjudicator': reverse_tournament('api-adjudicator-detail', self.tournament, kwargs={'pk': self.a1.pk}),
+                        'teams': [
+                            {
+                                'side': 'aff',
+                                'team': reverse_tournament('api-team-detail', self.tournament, kwargs={'pk': self.t1.pk}),
+                                'win': True,
+                            },
+                            {
+                                'side': 'neg',
+                                'team': reverse_tournament('api-team-detail', self.tournament, kwargs={'pk': self.t2.pk}),
+                                'win': False,
+                            },
+                        ],
+                    },
+                    {
+                        'adjudicator': reverse_tournament('api-adjudicator-detail', self.tournament, kwargs={'pk': self.a2.pk}),
+                        'teams': [
+                            {
+                                'side': 'aff',
+                                'team': reverse_tournament('api-team-detail', self.tournament, kwargs={'pk': self.t1.pk}),
+                                'win': False,
+                            },
+                            {
+                                'side': 'neg',
+                                'team': reverse_tournament('api-team-detail', self.tournament, kwargs={'pk': self.t2.pk}),
+                                'win': True,
+                            },
+                        ],
+                    },
+                ],
+            },
+        })
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(str(response.data['result']), 'Voting ballots must either have one scoresheet or ballots from all voting adjudicators')
+
+    def test_many_ballots_consensus_fail(self):
+        self.tournament.preferences['debate_rules__speakers_in_ballots'] = 'never'
+
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+        response = client.post(reverse_round('api-ballot-list', self.round, kwargs={'debate_pk': self.debate.pk}), {
+            'result': {
+                'sheets': [
+                    {
+                        'adjudicator': reverse_tournament('api-adjudicator-detail', self.tournament, kwargs={'pk': self.a1.pk}),
+                        'teams': [
+                            {
+                                'side': 'aff',
+                                'team': reverse_tournament('api-team-detail', self.tournament, kwargs={'pk': self.t1.pk}),
+                                'win': True,
+                            },
+                            {
+                                'side': 'neg',
+                                'team': reverse_tournament('api-team-detail', self.tournament, kwargs={'pk': self.t2.pk}),
+                                'win': False,
+                            },
+                        ],
+                    },
+                    {
+                        'adjudicator': reverse_tournament('api-adjudicator-detail', self.tournament, kwargs={'pk': self.a2.pk}),
+                        'teams': [
+                            {
+                                'side': 'aff',
+                                'team': reverse_tournament('api-team-detail', self.tournament, kwargs={'pk': self.t1.pk}),
+                                'win': False,
+                            },
+                            {
+                                'side': 'neg',
+                                'team': reverse_tournament('api-team-detail', self.tournament, kwargs={'pk': self.t2.pk}),
+                                'win': True,
+                            },
+                        ],
+                    },
+                ],
+            },
+        })
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(str(response.data['result']), 'Consensus ballots can only have one scoresheet')
+
+    def test_inconsistent_speaker_order(self):
+        self.tournament.preferences['debate_rules__ballots_per_debate_prelim'] = 'per-adj'
+
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+        response = client.post(reverse_round('api-ballot-list', self.round, kwargs={'debate_pk': self.debate.pk}), {
+            'result': {
+                'sheets': [
+                    {
+                        'adjudicator': reverse_tournament('api-adjudicator-detail', self.tournament, kwargs={'pk': self.a1.pk}),
+                        'teams': [
+                            {
+                                'side': 'aff',
+                                'team': reverse_tournament('api-team-detail', self.tournament, kwargs={'pk': self.t1.pk}),
+                                'speeches': [
+                                    {
+                                        'ghost': False,
+                                        'score': 80,
+                                        'speaker': reverse_tournament('api-speaker-detail', self.tournament, kwargs={'pk': self.s1.pk}),
+                                    },
+                                    {
+                                        'ghost': False,
+                                        'score': 80,
+                                        'speaker': reverse_tournament('api-speaker-detail', self.tournament, kwargs={'pk': self.s2.pk}),
+                                    },
+                                ],
+                            },
+                            {
+                                'side': 'neg',
+                                'team': reverse_tournament('api-team-detail', self.tournament, kwargs={'pk': self.t2.pk}),
+                                'speeches': [
+                                    {
+                                        'ghost': False,
+                                        'score': 79,
+                                        'speaker': reverse_tournament('api-speaker-detail', self.tournament, kwargs={'pk': self.s3.pk}),
+                                    },
+                                    {
+                                        'ghost': False,
+                                        'score': 79,
+                                        'speaker': reverse_tournament('api-speaker-detail', self.tournament, kwargs={'pk': self.s4.pk}),
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                    {
+                        'adjudicator': reverse_tournament('api-adjudicator-detail', self.tournament, kwargs={'pk': self.a2.pk}),
+                        'teams': [
+                            {
+                                'side': 'aff',
+                                'team': reverse_tournament('api-team-detail', self.tournament, kwargs={'pk': self.t1.pk}),
+                                'speeches': [
+                                    {
+                                        'ghost': False,
+                                        'score': 79,
+                                        'speaker': reverse_tournament('api-speaker-detail', self.tournament, kwargs={'pk': self.s2.pk}),
+                                    },
+                                    {
+                                        'ghost': False,
+                                        'score': 79,
+                                        'speaker': reverse_tournament('api-speaker-detail', self.tournament, kwargs={'pk': self.s1.pk}),
+                                    },
+                                ],
+                            },
+                            {
+                                'side': 'neg',
+                                'team': reverse_tournament('api-team-detail', self.tournament, kwargs={'pk': self.t2.pk}),
+                                'speeches': [
+                                    {
+                                        'ghost': False,
+                                        'score': 80,
+                                        'speaker': reverse_tournament('api-speaker-detail', self.tournament, kwargs={'pk': self.s3.pk}),
+                                    },
+                                    {
+                                        'ghost': False,
+                                        'score': 80,
+                                        'speaker': reverse_tournament('api-speaker-detail', self.tournament, kwargs={'pk': self.s4.pk}),
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            },
+        })
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(str(response.data['result']['non_field_errors'][0]), 'Inconsistant speaker order')
+
+    def test_speaks_without_scores(self):
+        self.tournament.preferences['debate_rules__speakers_in_ballots'] = 'never'
+
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+        response = client.post(reverse_round('api-ballot-list', self.round, kwargs={'debate_pk': self.debate.pk}), {
+            'result': {
+                'sheets': [{
+                    'teams': [
+                        {
+                            'side': 'aff',
+                            'team': reverse_tournament('api-team-detail', self.tournament, kwargs={'pk': self.t1.pk}),
+                            'win': True,
+                            'score': 1,
+                        },
+                        {
+                            'side': 'neg',
+                            'team': reverse_tournament('api-team-detail', self.tournament, kwargs={'pk': self.t2.pk}),
+                            'win': False,
+                            'score': 0,
+                        },
+                    ],
+                }],
+            },
+        })
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(str(response.data['result']['sheets'][0]['teams'][0]['non_field_errors'][0]), 'Speeches are required to assign scores.')
+
+    def test_inconsistent_speaks(self):
+        self.tournament.preferences['debate_rules__speakers_in_ballots'] = 'never'
+
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+        response = client.post(reverse_round('api-ballot-list', self.round, kwargs={'debate_pk': self.debate.pk}), {
+            'result': {
+                'sheets': [{
+                    'teams': [
+                        {
+                            'side': 'aff',
+                            'team': reverse_tournament('api-team-detail', self.tournament, kwargs={'pk': self.t1.pk}),
+                            'win': True,
+                            'score': 1,
+                            'speeches': [
+                                {
+                                    'ghost': False,
+                                    'score': 80,
+                                    'speaker': reverse_tournament('api-speaker-detail', self.tournament, kwargs={'pk': self.s1.pk}),
+                                },
+                                {
+                                    'ghost': False,
+                                    'score': 80,
+                                    'speaker': reverse_tournament('api-speaker-detail', self.tournament, kwargs={'pk': self.s2.pk}),
+                                },
+                            ],
+                        },
+                        {
+                            'side': 'neg',
+                            'team': reverse_tournament('api-team-detail', self.tournament, kwargs={'pk': self.t2.pk}),
+                            'win': False,
+                            'score': 0,
+                            'speeches': [
+                                {
+                                    'ghost': False,
+                                    'score': 79,
+                                    'speaker': reverse_tournament('api-speaker-detail', self.tournament, kwargs={'pk': self.s3.pk}),
+                                },
+                                {
+                                    'ghost': False,
+                                    'score': 79,
+                                    'speaker': reverse_tournament('api-speaker-detail', self.tournament, kwargs={'pk': self.s4.pk}),
+                                },
+                            ],
+                        },
+                    ],
+                }],
+            },
+        })
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(str(response.data['result']['sheets'][0]['teams'][0]['non_field_errors'][0]), 'Score must be the sum of speech scores.')


### PR DESCRIPTION
This commit fixes adding vetos to a ballot through the API and now allows for voting ballots to be created, single_adj or full. We can then use the proper score-setting method signature with[out] adjudicator.

Tests are also now provided for this POST endpoint, silencing the logger as the tests do not expect any.