### PR TITLE
Support selecting multiple scroll speeds on draws page (Fixes #2360)

### DIFF
--- a/tabbycat/draw/templates/draw_display_by.html
+++ b/tabbycat/draw/templates/draw_display_by.html
@@ -94,10 +94,6 @@
       $('#stop_scrolling').hide();
       $(".scroll-speeds .btn").click(function(event){
         var speed = $(document).height() / $(this).attr('data-target');
-        
-        // first call stop scrolling so that we stop scrolling with
-        // previosul selected speed (if any) and then start scrolling
-        // with the new speed. (issue #2360)
         stopScrolling()
         startScrolling()
         $('html, body').animate(

--- a/tabbycat/draw/templates/draw_display_by.html
+++ b/tabbycat/draw/templates/draw_display_by.html
@@ -94,6 +94,11 @@
       $('#stop_scrolling').hide();
       $(".scroll-speeds .btn").click(function(event){
         var speed = $(document).height() / $(this).attr('data-target');
+        
+        // first call stop scrolling so that we stop scrolling with
+        // previosul selected speed (if any) and then start scrolling
+        // with the new speed. (issue #2360)
+        stopScrolling()
         startScrolling()
         $('html, body').animate(
           { scrollTop: $(document).height() - $(window).height()},


### PR DESCRIPTION
This PR fixes #2360 where selecting multiple scroll speeds on the draws page would cause the stop scrolling to not work.

The fix used is to simply call `stopScrolling()` before calling `startScrolling()` whenever a scroll button is clicked. This way the scroll animation is first reset to no scroll and then a new animation is run with the new speed and so stop scrolling button keeps working as if that was the only scroll speed ever selected.