### PR TITLE
Added Mailgun installation if statement

### DIFF
--- a/tabbycat/settings/heroku.py
+++ b/tabbycat/settings/heroku.py
@@ -100,13 +100,13 @@ CHANNEL_LAYERS = {
 # Email / SendGrid
 # ==============================================================================
 
-if environ.get('EMAIL_HOST', ''):
-    SERVER_EMAIL = environ['DEFAULT_FROM_EMAIL']
-    DEFAULT_FROM_EMAIL = environ['DEFAULT_FROM_EMAIL']
-    EMAIL_HOST = environ['EMAIL_HOST']
-    EMAIL_HOST_USER = environ['EMAIL_HOST_USER']
-    EMAIL_HOST_PASSWORD = environ['EMAIL_HOST_PASSWORD']
-    EMAIL_PORT = int(environ.get('EMAIL_PORT', 587))
+if environ.get('MAILGUN_SMTP_SERVER', ''):
+    SERVER_EMAIL = environ['MAILGUN_SMTP_LOGIN']
+    DEFAULT_FROM_EMAIL = environ['MAILGUN_SMTP_LOGIN']
+    EMAIL_HOST = environ['MAILGUN_SMTP_SERVER']
+    EMAIL_HOST_USER = environ['MAILGUN_SMTP_LOGIN']
+    EMAIL_HOST_PASSWORD = environ['MAILGUN_SMTP_PASSWORD']
+    EMAIL_PORT = int(environ.get('MAILGUN_SMTP_PORT', 587))
     EMAIL_USE_TLS = environ.get('EMAIL_USE_TLS', 'true').lower() == 'true'
 
 elif environ.get('SENDGRID_API_KEY', ''):

--- a/tabbycat/settings/heroku.py
+++ b/tabbycat/settings/heroku.py
@@ -100,6 +100,14 @@ CHANNEL_LAYERS = {
 # Email / SendGrid
 # ==============================================================================
 
+if environ.get('EMAIL_HOST', ''):
+    SERVER_EMAIL = environ['DEFAULT_FROM_EMAIL']
+    DEFAULT_FROM_EMAIL = environ['DEFAULT_FROM_EMAIL']
+    EMAIL_HOST = environ['EMAIL_HOST']
+    EMAIL_HOST_USER = environ['EMAIL_HOST_USER']
+    EMAIL_HOST_PASSWORD = environ['EMAIL_HOST_PASSWORD']
+    EMAIL_PORT = int(environ.get('EMAIL_PORT', 587))
+
 if environ.get('MAILGUN_SMTP_SERVER', ''):
     SERVER_EMAIL = environ['MAILGUN_SMTP_LOGIN']
     DEFAULT_FROM_EMAIL = environ['MAILGUN_SMTP_LOGIN']


### PR DESCRIPTION
Added some code if installation uses Mailgun. SendGrid is very finnicky with getting new user accounts, for some reason neither me or a few others have been able to. Heroku offers Mailgun as a free/cheap way to send emails. Adding this means that configuring Mailgun for Tabbycat no longer requires editing the codebase.