### PR TITLE
Add default to bye room ranks

### DIFF
--- a/tabbycat/draw/manager.py
+++ b/tabbycat/draw/manager.py
@@ -200,7 +200,7 @@ class BaseDrawManager:
         pairings = drawer.generate()
         self._make_debates(pairings)
 
-        self._make_bye_debates(byes, max([p.room_rank for p in pairings]))
+        self._make_bye_debates(byes, max([p.room_rank for p in pairings], default=0))
 
         self.round.draw_status = Round.Status.DRAFT
         self.round.save()


### PR DESCRIPTION
If there are no pairings in a round, the draw generation fails due to not having the room rank to use when creating bye "debates" (even if there are no byes). We default to 0, in order to give them the room rank of 1.

Fixes BACKEND-BWA