### PR TITLE
Don't show cumulative points whenever not credited

### DIFF
--- a/tabbycat/participants/tables.py
+++ b/tabbycat/participants/tables.py
@@ -19,7 +19,7 @@ class TeamResultTableBuilder(TabbycatTableBuilder):
         cumul = 0
         data = []
         for teamscore in teamscores:
-            if teamscore.debate_team.debate.round.is_break_round:
+            if teamscore.points is None:
                 data.append("—")
             else:
                 cumul += teamscore.points * teamscore.debate_team.debate.round.weight


### PR DESCRIPTION
This commit changes the condition to show a "-" in the private URL debate table whenever the team did not get a number of points, rather than for break rounds. This makes the table more general and prevents a crash when trying to multiply by the round weight.

It is preferable than defaulting to adding 0 as it indicates which debate has no points, and even if in the middle of a tournament, the number of points they have would be on the previous line.

Fixes BACKEND-BVY