### PR TITLE
Allow score steps in increments of 0.1

### DIFF
--- a/tabbycat/results/forms.py
+++ b/tabbycat/results/forms.py
@@ -1,5 +1,6 @@
 import logging
 from itertools import product
+from math import log10
 
 from asgiref.sync import async_to_sync
 from channels.layers import get_channel_layer
@@ -74,7 +75,7 @@ class BaseScoreField(forms.FloatField):
         self.check_value(value)
 
     def check_value(self, value):
-        if value and self.step_value and value % self.step_value != 0:
+        if value and self.step_value and round(value % self.step_value, -(round(log10(self.step_value)) - 1)) != 0:
             if self.step_value == 1:
                 msg = _("Please enter a whole number.")
             else:


### PR DESCRIPTION
This commit fixes valid scores being shown as invalid when the score step is 0.1, due to floating point precision. Instead of taking the modulo directly, we now round the number to the decimal place after the step (using logarithms). Adding extra precision then makes sure that no further precision was given.

