### PR TITLE
API: Add endpoint to generate draw

### DIFF
--- a/tabbycat/api/urls.py
+++ b/tabbycat/api/urls.py
@@ -81,7 +81,7 @@ urlpatterns = [
 
                         path('/pairings', include([
                             path('',
-                                views.PairingViewSet.as_view({'get': 'list', 'post': 'create', 'delete': 'delete_all'}),
+                                views.PairingViewSet.as_view({'get': 'list', 'post': 'create', 'delete': 'delete_all', 'put': 'generate'}),
                                 name='api-pairing-list'),
                             path('/<int:debate_pk>', include([
                                 path('',


### PR DESCRIPTION
This new verb PUT for the draw endpoint will take the current draw rules settings to create a draw using the backend's draw generator.

This could be expanded to include parameters for how the draw should be generated. If so, should it modify the preference/round objects?