### PR TITLE
Set docker to reload on code changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,10 +16,8 @@ RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
 RUN apt-get install -y nodejs npm
 
 # Copy all our files into the baseimage and cd to that directory
-RUN mkdir /tcd
 WORKDIR /tcd
-# Can this be skipped? Takes ages
-ADD . /tcd/
+COPY . /tcd/
 
 # Set git to use HTTPS (SSH is often blocked by firewalls)
 RUN git config --global url."https://".insteadOf git://

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -1,16 +1,14 @@
 # This is customised from https://github.com/heroku/heroku-buildpack-nginx.git
-# Done so in order to properly proxy to both and asgi and wasgi server
-# Super useful template:
-# https://github.com/CLClark/fcc-stock-trading-app/blob/9017f001255718c2e0fd24eb8267df02267d6cd8/config/nginx.conf.erb
+# Done so in order to properly proxy to both and asgi and wsgi server
 
 daemon off;
 # Heroku dynos have at least 4 cores.
-worker_processes <%= ENV['NGINX_WORKERS'] || 4 %>;
+worker_processes 4;
 
 events {
     use epoll;
     accept_mutex on;
-    worker_connections <%= ENV['NGINX_WORKER_CONNECTIONS'] || 1024 %>;
+    worker_connections 1024;
 }
 
 http {

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -1,5 +1,5 @@
 # This is customised from https://github.com/heroku/heroku-buildpack-nginx.git
-# Done so in order to properly proxy to both and asgi and wasgi server
+# Done so in order to properly proxy to both and asgi and wsgi server
 # Super useful template:
 # https://github.com/CLClark/fcc-stock-trading-app/blob/9017f001255718c2e0fd24eb8267df02267d6cd8/config/nginx.conf.erb
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,9 +41,9 @@ services:
       - DOCKER_REDIS=1
       - USING_NGINX=1
     ports:
-      - "127.0.0.1:8000:8000"
+      - "8000:8000"
     volumes:
-      - ./tabbycat/settings:/tcd/tabbycat/settings
+      - .:/tcd
     working_dir: /tcd
 
   worker:
@@ -60,7 +60,7 @@ services:
       - DOCKER_REDIS=1
       - USING_NGINX=1
     volumes:
-      - ./tabbycat/settings:/tcd/tabbycat/settings
+      - .:/tcd
     working_dir: /tcd
 
 volumes:


### PR DESCRIPTION
This commit sets the volumes for web and worker to be the full directory in order for changes made in the code to immediately be reflected in the Docker instance. We can also use the COPY command rather than ADD, which gives a good performance advantage.

Further, the nginx configuration did not work as it was copied from a Ruby (.erb) template, so some syntax wasn't recognized.