### PR TITLE
Specify hidden value for tournament in break cats

### DIFF
--- a/tabbycat/breakqual/views.py
+++ b/tabbycat/breakqual/views.py
@@ -269,7 +269,10 @@ class EditBreakCategoriesView(EditSpeakerCategoriesView):
         }
 
     def get_formset_kwargs(self):
-        return {'form_kwargs': {'tournament': self.tournament}}
+        return {
+            'initial': [{'tournament': self.tournament}] * 2,
+            'form_kwargs': {'tournament': self.tournament},
+        }
 
     def prepare_related(self, cat):
         auto_make_break_rounds(cat, prefix=True)


### PR DESCRIPTION
This commit adds the initial value for the tournament (hidden field) in the break category formset. It being absent made the formset fail to create new break categories with a general error message.

The reliance on the hidden field should be removed in the future, with uniqueness checks done with the tournament attribute.