### PR TITLE
Check for code names in ballot form

### DIFF
--- a/tabbycat/results/forms.py
+++ b/tabbycat/results/forms.py
@@ -134,7 +134,7 @@ class BaseResultForm(forms.Form):
 
     result_class = None
 
-    def __init__(self, ballotsub, password=False, *args, **kwargs):
+    def __init__(self, ballotsub, tabroom, password=False, *args, **kwargs):
         self.ballotsub = ballotsub
         self.result = kwargs.pop('result', self.result_class(self.ballotsub))
         self.filled = kwargs.pop('filled', False)
@@ -144,6 +144,8 @@ class BaseResultForm(forms.Form):
         self.tournament = self.debate.round.tournament
 
         self.has_tournament_password = password and self.tournament.pref('public_use_password')
+        self.tabroom = tabroom
+        self.use_codes = use_team_code_names_data_entry(self.tournament, tabroom)
 
         status_choices = Debate.STATUS_CHOICES if self.tournament.pref('enable_postponements') else Debate.STATUS_CHOICES_RESTRICTED
         self.fields['debate_result_status'] = forms.ChoiceField(choices=status_choices)
@@ -309,10 +311,11 @@ class BaseBallotSetForm(BaseResultForm):
             assert len(teams) == 2
             side_choices = [
                 (None, _("---------")),
-                (str(teams[0].id) + "," + str(teams[1].id),
-                    _("%(aff_team)s affirmed, %(neg_team)s negated") % {'aff_team': teams[0].short_name, 'neg_team': teams[1].short_name}),
-                (str(teams[1].id) + "," + str(teams[0].id),
-                    _("%(aff_team)s affirmed, %(neg_team)s negated") % {'aff_team': teams[1].short_name, 'neg_team': teams[0].short_name}),
+                *[(str(teams[i].id) + "," + str(teams[(i+1) % 2].id),
+                    _("%(aff_team)s affirmed, %(neg_team)s negated") % {
+                        'aff_team': team_name_for_data_entry(teams[i], self.use_codes),
+                        'neg_team': team_name_for_data_entry(teams[(i+1) % 2], self.use_codes),
+                }) for i in range(2)],
             ]
             self.fields['choose_sides'] = forms.TypedChoiceField(
                 choices=side_choices,
@@ -339,7 +342,7 @@ class BaseBallotSetForm(BaseResultForm):
     def create_declared_winner_dropdown(self):
         """This method creates a drop-down with a list of the teams in the debate"""
         teams = [(s, _("%(team)s (%(side)s)") % {
-            'team': self.debate.get_team(s).short_name, 'side': get_side_name(self.tournament, s, 'full')}) for s in self.sides]
+            'team': team_name_for_data_entry(self.debate.get_team(s), self.use_codes), 'side': get_side_name(self.tournament, s, 'full')}) for s in self.sides]
         return forms.TypedChoiceField(
             label=_("Winner"), required=True, empty_value=None,
             choices=[(None, _("---------"))] + teams,
@@ -536,8 +539,6 @@ class ScoresMixin:
     def clean_speakers(self, cleaned_data):
         """Checks that the speaker selections are valid."""
 
-        use_codes = use_team_code_names_data_entry(self.tournament, True)
-
         # Pull team info again, in case it's changed since the form was loaded.
         if self.choosing_sides:
             teams = cleaned_data.get('choose_sides', [None] * len(self.sides))
@@ -559,7 +560,7 @@ class ScoresMixin:
                 if team is not None and speaker not in team.speakers:
                     self.add_error(self._fieldname_speaker(side, pos), forms.ValidationError(
                         _("The speaker %(speaker)s doesn't appear to be on team %(team)s."),
-                        params={'speaker': speaker.get_public_name(self.tournament), 'team': team_name_for_data_entry(team, use_codes)},
+                        params={'speaker': speaker.get_public_name(self.tournament), 'team': team_name_for_data_entry(team, self.use_codes)},
                         code='speaker_wrongteam'),
                     )
 
@@ -947,7 +948,7 @@ class TeamsMixin:
     def create_team_selector(self):
         # 3(a). List of teams in multiple-select
         side_choices = [(side, _("%(team)s (%(side)s)") % {
-            'team': self.debate.get_team(side).short_name,
+            'team': team_name_for_data_entry(self.debate.get_team(side), self.use_codes),
             'side': self._side_name(side)}) for side in self.tournament.sides]
         return forms.MultipleChoiceField(choices=side_choices,
                 widget=forms.CheckboxSelectMultiple)

--- a/tabbycat/results/views.py
+++ b/tabbycat/results/views.py
@@ -313,6 +313,7 @@ class BaseBallotSetView(LogActionMixin, TournamentMixin, FormView):
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
         kwargs['ballotsub'] = self.ballotsub
+        kwargs['tabroom'] = self.tabroom
         return kwargs
 
     def add_success_message(self):


### PR DESCRIPTION
This commit adds missing code name checks in the ballot forms. Ballot templates have the team code name check, but was missing from most places within the Django form, including:
* Side choice
* Declared winner dropdown
* Winning team(s) selector

This required the "tabroom" attribute to be passed, and we no longer assume tabroom in the speaker validation.