### PR TITLE
API: Add motion seq field back for rounds

### DIFF
--- a/tabbycat/api/serializers.py
+++ b/tabbycat/api/serializers.py
@@ -147,10 +147,11 @@ class RoundSerializer(serializers.ModelSerializer):
         text = serializers.CharField(source='motion.text', max_length=500, required=False)
         reference = serializers.CharField(source='motion.reference', max_length=100, required=False)
         info_slide = serializers.CharField(source='motion.info_slide', required=False)
+        seq = serializers.IntegerField(read_only=True)
 
         class Meta:
             model = RoundMotion
-            exclude = ('round', 'motion', 'seq')
+            exclude = ('round', 'motion')
 
         def create(self, validated_data):
             motion_data = validated_data.pop('motion')


### PR DESCRIPTION
The sequence field had been removed in the Round API endpoint in favour of relying on the ordering in the array. However, as the field was still in use, it caused an unintended breakage. The sequence will now remain, but be read-only as we look to the ordering when creating them.