### PR TITLE
Determine info-slide is HTML without closing tag

### DIFF
--- a/tabbycat/motions/templates/motions_info.html
+++ b/tabbycat/motions/templates/motions_info.html
@@ -11,7 +11,7 @@
         </button>
       </div>
       <div class="modal-body lead">
-        {% if motion.info_slide|slice:":3" == "<p>" %}
+        {% if motion.info_slide|slice:":2" == "<p" %}
           {{ motion.info_slide|safe }}
         {% else %}
           {{ motion.info_slide|linebreaks }}

--- a/tabbycat/motions/templates/show.html
+++ b/tabbycat/motions/templates/show.html
@@ -83,7 +83,7 @@
 
           <div class="modal-body d-flex align-items-center justify-content-center text-center">
             <small>
-              {% if infos.0.motion.info_slide|slice:":3" == "<p>" %}
+              {% if infos.0.motion.info_slide|slice:":2" == "<p" %}
                 {{ infos.0.motion.info_slide|safe }}
               {% else %}
                 {{ infos.0.motion.info_slide|linebreaks }}
@@ -101,7 +101,7 @@
                     <span class="text-muted">{{ info.seq }}.</span>
                   {% endif %}
                   <small>
-                    {% if info.motion.info_slide|slice:":3" == "<p>" %}
+                    {% if info.motion.info_slide|slice:":2" == "<p" %}
                       {{ info.motion.info_slide|safe }}
                     {% else %}
                       {{ info.motion.info_slide|linebreaks }}


### PR DESCRIPTION
As a lot of tags if copied into Summernote may have `style` attributes, including the first `<p` tag, the info-slide views may treat it as plain text as the test included the closing ">" character, which would be much later. To fix, the check is only for "<p".