### PR TITLE
API: Add convenience plain-text attr for infoslide

### DIFF
--- a/tabbycat/api/serializers.py
+++ b/tabbycat/api/serializers.py
@@ -147,6 +147,7 @@ class RoundSerializer(serializers.ModelSerializer):
         text = serializers.CharField(source='motion.text', max_length=500, required=False)
         reference = serializers.CharField(source='motion.reference', max_length=100, required=False)
         info_slide = serializers.CharField(source='motion.info_slide', required=False)
+        info_slide_plain = serializers.CharField(source='motion.info_slide_plain', read_only=True)
         seq = serializers.IntegerField(read_only=True)
 
         class Meta:
@@ -315,6 +316,7 @@ class MotionSerializer(serializers.ModelSerializer):
 
     url = fields.TournamentHyperlinkedIdentityField(view_name='api-motion-detail')
     rounds = RoundsSerializer(many=True, source='roundmotion_set')
+    info_slide_plain = serializers.CharField(read_only=True)
 
     class Meta:
         model = Motion

--- a/tabbycat/motions/models.py
+++ b/tabbycat/motions/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 from django.utils.translation import gettext_lazy as _
+from html2text import html2text
 
 
 class Motion(models.Model):
@@ -26,6 +27,12 @@ class Motion(models.Model):
 
     def __str__(self):
         return self.text
+
+    @property
+    def info_slide_plain(self):
+        if (self.info_slide or '').startswith('<p'):
+            return html2text(self.info_slide).strip()
+        return self.info_slide
 
 
 class DebateTeamMotionPreference(models.Model):


### PR DESCRIPTION
As the info-slide for motions is now in HTML, it can cause problems now when expecting plain text, receiving plenty of unparsable markup. This commit adds a new `info_slide_plain` attribute for motions within the Round serializer, and within the dedicated Motion serializer, both read- only.