### PR TITLE
Remove empty HTML info-slide if nothing inputted

### DIFF
--- a/tabbycat/motions/models.py
+++ b/tabbycat/motions/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 from django.utils.translation import gettext_lazy as _
+from html2text import html2text
 
 
 class Motion(models.Model):
@@ -26,6 +27,11 @@ class Motion(models.Model):
 
     def __str__(self):
         return self.text
+
+    def clean_fields(self, exclude=None):
+        super().clean_fields(exclude=exclude)
+        if html2text(self.info_slide or '').isspace() and 'info_slide' not in exclude:
+            self.info_slide = ''
 
 
 class DebateTeamMotionPreference(models.Model):


### PR DESCRIPTION
This commit adds a cleaning method for motions, so that if no info-slide has been added, or it was removed, the info-slide re-becomes None rather than something like "`<p><br></p>`".