### PR TITLE
Fixed side import from DebateXML

### DIFF
--- a/tabbycat/importer/archive.py
+++ b/tabbycat/importer/archive.py
@@ -576,7 +576,7 @@ class Importer:
 
                 # Debate-teams
                 for j, side in enumerate(debate.findall('side'), side_start):
-                    position = list(DebateTeam.Side)[j][0]
+                    position = list(DebateTeam.Side)[j]
                     debateteam_obj = DebateTeam(debate=debate_obj, team=self.teams[side.get('team')], side=position)
                     debateteam_obj.save()
                     self.debateteams[(debate.get('id'), side.get('team'))] = debateteam_obj


### PR DESCRIPTION
The DebateXML importer was broken in 050fa110a38259297dbcadd5913b0dafcee897f2 by the introduction of `DebateTeam.Side`.

Previously, SIDE_CHOICES was a list of tuples, so the `[0]` in `DebateTeam.SIDE_CHOICES[j][0]` was needed to get the side shortname (neg, aff...). Now that this uses an Enum, `DebateTeam.SIDE_CHOICES[j]` already returns a string (or string-compatible object) and so the `[0]` actually extracts the first letter of that string (neg → n, og → o...). This is, of course, invalid and causes a crash.

This patch was tested on v2.8.1 (30d93b60ba66685bfceddc7ea93c371294584711).