### PR TITLE
Display check-in barcode on private URL

### DIFF
--- a/tabbycat/privateurls/templates/public_url_landing.html
+++ b/tabbycat/privateurls/templates/public_url_landing.html
@@ -1,5 +1,5 @@
 {% extends "tables/base_vue_table.html" %}
-{% load i18n debate_tags %}
+{% load i18n static debate_tags %}
 
 {% block page-title %}{% trans "Private URL" %}{% endblock %}
 {% block head-title %}{% trans "Private URL" %}{% endblock %}
@@ -50,11 +50,16 @@
         {% blocktrans trimmed with check_time=event.time asvar text %}
           You have been checked in at {{ check_time }}
         {% endblocktrans %}
-        {% include "components/item-info.html" with type='success' %}
+        {% include "components/item-info.html" with type='success' nopad=True %}
       {% else %}
         {% trans "You are not currently checked in." as text %}
-        {% include "components/item-info.html" with type='warning' %}
+        {% include "components/item-info.html" with type='warning' nopad=True %}
       {% endif %}
+    {% endif %}
+
+    {% if checkins_used %}
+      {% trans "Show barcode for check-in" as text %}
+      {% include "components/item-action.html" with id="openBarcode" url="" icon="grid" child=False %}
     {% endif %}
 
     {% if object.adjudicator and pref.participant_ballots == 'private-urls' %}
@@ -95,6 +100,25 @@
     {{ block.super }} {# this is the Vue table, which is populated with previous results #}
   </div>
 
+<div class="modal fade" id="barcodeModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body text-center">
+                <svg id="{{ identifier.barcode }}" title="{{ identifier.owner }}"
+                               class="barcode-placeholder w-100 h-auto" jsbarcode-value="{{ identifier.barcode }}"
+                               jsbarcode-text="{{ identifier.barcode }} {{ identifier.owner.name|abbreviatename }}"
+                               jsbarcode-width="7" jsbarcode-height="150">
+            </div>
+        </div>
+    </div>
+</div>
+
+
 {% endblock %}
 
 
@@ -108,4 +132,14 @@
       });
     });
   </script>
+  {% if checkins_used %}
+    <script src="{% static 'js/vendor/JsBarcode.all.min.js' %}"></script>
+    <script>
+      JsBarcode(".barcode-placeholder").init();
+      $("#openBarcode").click( function() {
+        $("#barcodeModal").modal('show');
+        return false;
+      });
+    </script>
+  {% endif %}
 {% endblock js %}

--- a/tabbycat/privateurls/views.py
+++ b/tabbycat/privateurls/views.py
@@ -209,6 +209,7 @@ class PersonIndexView(SingleObjectByRandomisedUrlMixin, PersonalizablePublicTour
         try:
             checkin_id = PersonIdentifier.objects.get(person=self.object)
             kwargs['checkins_used'] = True
+            kwargs['identifier'] = checkin_id
 
             checkins = get_unexpired_checkins(t, 'checkin_window_people')
 


### PR DESCRIPTION
**TL;DR:** Adds a "show barcode for check-in" button to everyone's private URLs, which shows the same barcode as would be printed on accreditations. Useful especially for tournaments that want to do on-site check-in, but don't print accreditations.

**Motivation:** Online self-check-in is great, but there are a few situations where it's not the best solution. Many times you need/want to do in-person check-in, but printed accreditations with barcodes bring a lot of extra logistics with them. This is meant to be a good middle-ground: it "ensures" physical presence for check-in, without creating additional work for the organizers.

**Details:** The button shows up only if the person has an identifier, but is shown even if already checked-in (this lets you use the barcode for other things too). Adjusts to screen size and scans fine even in the worst case (vertical iPhone SE).

<details>
<summary>Screenshots: </summary>

![Screen Shot 2024-03-03 at 14 13 45](https://github.com/TabbycatDebate/tabbycat/assets/3891092/08a56983-621f-4454-8261-9c339eaae29b) ![Screen Shot 2024-03-03 at 14 13 49](https://github.com/TabbycatDebate/tabbycat/assets/3891092/86a7a0ad-674f-414f-add8-78e45ad52b8c)

</details>