### PR TITLE
Add epsilon for decimal score validation

### DIFF
--- a/tabbycat/options/preferences.py
+++ b/tabbycat/options/preferences.py
@@ -1,9 +1,11 @@
+from decimal import Decimal
+
 from django.core.validators import MinValueValidator, validate_slug
 from django.utils.translation import gettext_lazy as _
 from django_summernote.widgets import SummernoteWidget
 from dynamic_preferences.preferences import Section
 from dynamic_preferences.registries import global_preferences_registry
-from dynamic_preferences.types import BooleanPreference, ChoicePreference, FloatPreference, IntegerPreference, LongStringPreference, StringPreference
+from dynamic_preferences.types import BooleanPreference, ChoicePreference, DecimalPreference, FloatPreference, IntegerPreference, LongStringPreference, StringPreference
 
 from standings.speakers import SpeakerStandingsGenerator
 from standings.teams import TeamStandingsGenerator
@@ -20,30 +22,30 @@ scoring = Section('scoring', verbose_name=_("Score Rules"))
 
 
 @tournament_preferences_registry.register
-class MinimumSpeakerScore(FloatPreference):
+class MinimumSpeakerScore(DecimalPreference):
     help_text = _("Minimum allowed score for substantive speeches")
     section = scoring
     name = 'score_min'
     verbose_name = _("Minimum speaker score")
-    default = 68.0
+    default = Decimal('68')
 
 
 @tournament_preferences_registry.register
-class MaximumSpeakerScore(FloatPreference):
+class MaximumSpeakerScore(DecimalPreference):
     verbose_name = _("Maximum speaker score")
     help_text = _("Maximum allowed score for substantive speeches")
     section = scoring
     name = 'score_max'
-    default = 82.0
+    default = Decimal('82')
 
 
 @tournament_preferences_registry.register
-class SpeakerScoreStep(FloatPreference):
+class SpeakerScoreStep(DecimalPreference):
     verbose_name = _("Speaker score step")
     help_text = _("Score steps allowed for substantive speeches, e.g. full points (1) or half points (0.5)")
     section = scoring
     name = 'score_step'
-    default = 1.0
+    default = Decimal('1')
 
 
 @tournament_preferences_registry.register
@@ -57,30 +59,30 @@ class MaximumMargin(FloatPreference):
 
 
 @tournament_preferences_registry.register
-class MinimumReplyScore(FloatPreference):
+class MinimumReplyScore(DecimalPreference):
     help_text = _("Minimum allowed score for reply speeches")
     verbose_name = _("Minimum reply score")
     section = scoring
     name = 'reply_score_min'
-    default = 34.0
+    default = Decimal('34.0')
 
 
 @tournament_preferences_registry.register
-class MaximumReplyScore(FloatPreference):
+class MaximumReplyScore(DecimalPreference):
     help_text = _("Maximum allowed score for reply speeches")
     verbose_name = _("Maximum reply score")
     section = scoring
     name = 'reply_score_max'
-    default = 41.0
+    default = Decimal('41.0')
 
 
 @tournament_preferences_registry.register
-class ReplyScoreStep(FloatPreference):
+class ReplyScoreStep(DecimalPreference):
     help_text = _("Score steps allowed for reply speeches, e.g. full points (1) or half points (0.5)")
     verbose_name = _("Reply score step")
     section = scoring
     name = 'reply_score_step'
-    default = 0.5
+    default = Decimal('0.5')
 
 
 @tournament_preferences_registry.register

--- a/tabbycat/options/presets.py
+++ b/tabbycat/options/presets.py
@@ -1,5 +1,6 @@
 import logging
 from copy import copy
+from decimal import Decimal
 
 from django.utils.text import slugify
 from django.utils.translation import gettext_lazy as _
@@ -84,12 +85,12 @@ class AustralsPreferences(PreferencesPreset):
     show_in_list = True
 
     # Scoring
-    scoring__score_min                         = 70.0 # Technically the speaks
-    scoring__score_max                         = 80.0 # range is at the adj
-    scoring__score_step                        = 1.0  # core's discretion (it's
-    scoring__reply_score_min                   = 35.0 # not in the constitution)
-    scoring__reply_score_max                   = 40.0
-    scoring__reply_score_step                  = 0.5
+    scoring__score_min                         = Decimal('70') # Technically the speaks
+    scoring__score_max                         = Decimal('80') # range is at the adj
+    scoring__score_step                        = Decimal('1')  # core's discretion (it's
+    scoring__reply_score_min                   = Decimal('35.0') # not in the constitution)
+    scoring__reply_score_max                   = Decimal('40.0')
+    scoring__reply_score_step                  = Decimal('0.5')
     scoring__maximum_margin                    = 0.0  # Rob Confirmed
     # Draws
     draw_rules__avoid_same_institution         = True
@@ -122,9 +123,9 @@ class BritishParliamentaryPreferences(PreferencesPreset):
     description  = _("2 vs 2 vs 2 vs 2. Compliant with WUDC rules.")
     show_in_list = True
 
-    scoring__score_min                         = 50.0
-    scoring__score_max                         = 99.0
-    scoring__score_step                        = 1.0
+    scoring__score_min                         = Decimal('50')
+    scoring__score_max                         = Decimal('99')
+    scoring__score_step                        = Decimal('1')
     scoring__maximum_margin                    = 0.0
     scoring__teamscore_includes_ghosts         = True  # WUDC 34.9.3.2
     # Debate Rules
@@ -168,8 +169,8 @@ class CanadianParliamentaryPreferences(PreferencesPreset):
     description  = _("2 vs 2 with replies (unscored) and POIs. May require "
         "additional configuration depending on regional variations.")
     # Scoring
-    scoring__score_min                         = 50.0
-    scoring__score_max                         = 100.0
+    scoring__score_min                         = Decimal('50')
+    scoring__score_max                         = Decimal('100')
     # Debate Rules
     debate_rules__reply_scores_enabled         = False # Not scored
     debate_rules__substantive_speakers         = 2
@@ -194,8 +195,8 @@ class AustralianEastersPreferences(AustralsPreferences):
         "bubbles, one-up-one-down. Compliant with AIDA rules.")
 
     # Scoring
-    scoring__score_min                         = 70.0
-    scoring__score_max                         = 80.0
+    scoring__score_min                         = Decimal('70')
+    scoring__score_max                         = Decimal('80')
     scoring__maximum_margin                    = 15.0
     # Debate Rules
     debate_rules__reply_scores_enabled         = False
@@ -214,10 +215,10 @@ class NZEastersPreferences(AustralsPreferences):
         "novice statuses.")
 
     # Scoring
-    scoring__score_min                         = 60.0
-    scoring__score_max                         = 80.0
-    scoring__reply_score_min                   = 30.0
-    scoring__reply_score_max                   = 40.0
+    scoring__score_min                         = Decimal('60')
+    scoring__score_max                         = Decimal('80')
+    scoring__reply_score_min                   = Decimal('30.0')
+    scoring__reply_score_max                   = Decimal('40.0')
     # Debate Rules
     debate_rules__reply_scores_enabled         = True
     motions__motion_vetoes_enabled             = True
@@ -241,10 +242,10 @@ class JoyntPreferences(AustralsPreferences):
         "and motions, and novice statuses.")
 
     # Scoring
-    scoring__score_min                         = 60.0
-    scoring__score_max                         = 80.0
-    scoring__reply_score_min                   = 30.0
-    scoring__reply_score_max                   = 40.0
+    scoring__score_min                         = Decimal('60')
+    scoring__score_max                         = Decimal('80')
+    scoring__reply_score_min                   = Decimal('30.0')
+    scoring__reply_score_max                   = Decimal('40.0')
     # Debate Rules
     debate_rules__reply_scores_enabled         = True
     motions__motion_vetoes_enabled             = False
@@ -271,12 +272,12 @@ class UADCPreferences(AustralsPreferences):
 
     # Rules source = https://docs.google.com/document/d/10AVKBhev_OFRtorWsu2VB9B5V1a2f20425HYkC5ztMM/edit
     # Scoring
-    scoring__score_min                         = 69.0  # From Rules Book
-    scoring__score_max                         = 81.0  # From Rules Book
-    scoring__score_step                        = 1.0
-    scoring__reply_score_min                   = 34.5  # Not specified; assuming half of substantive
-    scoring__reply_score_max                   = 42.0  # Not specified; assuming  half of substantive
-    scoring__reply_score_step                  = 0.5
+    scoring__score_min                         = Decimal('69')  # From Rules Book
+    scoring__score_max                         = Decimal('81')  # From Rules Book
+    scoring__score_step                        = Decimal('1')
+    scoring__reply_score_min                   = Decimal('34.5')  # Not specified; assuming half of substantive
+    scoring__reply_score_max                   = Decimal('42.0')  # Not specified; assuming half of substantive
+    scoring__reply_score_step                  = Decimal('0.5')
     scoring__maximum_margin                    = 0.0   # TODO= check this
     scoring__margin_includes_dissenters        = False  # From Rules 20.3.2
     # Draws
@@ -310,12 +311,12 @@ class WSDCPreferences(AustralsPreferences):
 
     # Rules source = http://mkf2v40tlr04cjqkt2dtlqbr.wpengine.netdna-cdn.com/wp-content/uploads/2014/05/WSDC-Debate-Rules-U-2015.pdf
     # Score (strictly specified in the rules)
-    scoring__score_min                         = 60.0
-    scoring__score_max                         = 80.0
-    scoring__score_step                        = 1.0
-    scoring__reply_score_min                   = 30.0
-    scoring__reply_score_max                   = 40.0
-    scoring__reply_score_step                  = 0.5
+    scoring__score_min                         = Decimal('60')
+    scoring__score_max                         = Decimal('80')
+    scoring__score_step                        = Decimal('1')
+    scoring__reply_score_min                   = Decimal('30.0')
+    scoring__reply_score_max                   = Decimal('40.0')
+    scoring__reply_score_step                  = Decimal('0.5')
     # Debates
     motions__motion_vetoes_enabled             = False # Single motions per round
     motions__enable_motions                    = False
@@ -335,8 +336,8 @@ class APDAPreferences(PreferencesPreset):
     show_in_list = True
     description = _("2 vs 2 with speech rankings and byes")
 
-    scoring__score_min                         = 15
-    scoring__score_max                         = 40
+    scoring__score_min                         = Decimal('15')
+    scoring__score_max                         = Decimal('40')
     motions__motion_vetoes_enabled             = False # Single motions per round
     motions__enable_motions                    = False
     draw_rules__draw_odd_bracket               = 'pullup_bottom'

--- a/tabbycat/options/tests/management/commands/test_applypreset.py
+++ b/tabbycat/options/tests/management/commands/test_applypreset.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 from unittest.mock import patch
 
 from django.core.management import call_command
@@ -15,8 +16,8 @@ class TestPreset(PreferencesPreset):
     show_in_list = False
 
     # Scoring
-    scoring__score_min = 70
-    scoring__score_max = 80
+    scoring__score_min = Decimal('70')
+    scoring__score_max = Decimal('80')
 
 
 class ApplyPresetTests(TestCase):
@@ -37,9 +38,9 @@ class ApplyPresetTests(TestCase):
     @patch('options.management.commands.applypreset.all_presets', return_value=[TestPreset])
     def test_set_valid_preset(self, mock_all_presets):
         tournament = Tournament.objects.create(slug="command", name="Command Testing")
-        tournament.preferences['scoring__score_min'] = 0
-        tournament.preferences['scoring__score_max'] = 100
+        tournament.preferences['scoring__score_min'] = Decimal('0')
+        tournament.preferences['scoring__score_max'] = Decimal('100')
 
         call_command('applypreset', ['-t', 'command', 'testpreset'])
-        for pref, val in [('scoring__score_min', 70), ('scoring__score_max', 80)]:
+        for pref, val in [('scoring__score_min', Decimal('70')), ('scoring__score_max', Decimal('80'))]:
             self.assertEqual(tournament.preferences[pref], val)

--- a/tabbycat/options/tests/test_forms.py
+++ b/tabbycat/options/tests/test_forms.py
@@ -1,4 +1,5 @@
 import unittest
+from decimal import Decimal
 from unittest.mock import patch
 
 from django.core.exceptions import ValidationError
@@ -36,8 +37,8 @@ class TournamentPreferenceFormTests(TestCase):
 
     def test_validation_between_prefs(self):
         tests = [
-            ('scoring', (('score_min', 100), ('score_max', 0))),
-            ('scoring', (('reply_score_min', 100), ('reply_score_max', 0))),
+            ('scoring', (('score_min', Decimal('100')), ('score_max', Decimal('0')))),
+            ('scoring', (('reply_score_min', Decimal('100')), ('reply_score_max', Decimal('0')))),
             ('feedback', (('adj_min_score', 100), ('adj_max_score', 0))),
             ('draw_rules', (('draw_side_allocations', 'balance'), ('draw_odd_bracket', 'intermediate1'))),
             ('debate_rules', (('ballots_per_debate_prelim', 'per-adj'), ('teams_in_debate', 'bp'))),

--- a/tabbycat/options/tests/test_presets.py
+++ b/tabbycat/options/tests/test_presets.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 from unittest.mock import patch
 
 from django.test import TestCase
@@ -12,15 +13,15 @@ class TestPreset(PreferencesPreset):
     show_in_list = False
 
     # Scoring
-    scoring__score_min = 70
-    scoring__score_max = 80
+    scoring__score_min = Decimal('70')
+    scoring__score_max = Decimal('80')
 
 
 class TestPresets(TestCase):
     def set_up_tournament(self):
         tournament = Tournament.objects.create(slug="preset", name="Preset Testing")
-        tournament.preferences['scoring__score_min'] = 0
-        tournament.preferences['scoring__score_max'] = 100
+        tournament.preferences['scoring__score_min'] = Decimal('0')
+        tournament.preferences['scoring__score_max'] = Decimal('100')
         return tournament
 
     @patch('options.presets.all_presets', return_value=[TestPreset])
@@ -48,7 +49,7 @@ class TestPresets(TestCase):
         tournament = self.set_up_tournament()
         TestPreset.save(tournament)
 
-        for pref, new_val in [('scoring__score_min', 70), ('scoring__score_max', 80)]:
+        for pref, new_val in [('scoring__score_min', Decimal('70')), ('scoring__score_max', Decimal('80'))]:
             self.assertEqual(tournament.preferences[pref], new_val)
 
         tournament.delete()
@@ -58,7 +59,7 @@ class TestPresets(TestCase):
 
         form = TestPreset.get_form(tournament)
 
-        for pref, new_val in [('scoring__score_min', 70), ('scoring__score_max', 80)]:
+        for pref, new_val in [('scoring__score_min', Decimal('70')), ('scoring__score_max', Decimal('80'))]:
             self.assertTrue(pref in form.fields)
             self.assertEqual(form[pref].initial, new_val)
             self.assertEqual(form[pref].changed, True)
@@ -68,11 +69,11 @@ class TestPresets(TestCase):
     def test_can_save_preset_form(self):
         tournament = self.set_up_tournament()
 
-        form = TestPreset.get_form(tournament, data={'scoring__score_min': 70, 'scoring__score_max': 80})
+        form = TestPreset.get_form(tournament, data={'scoring__score_min': Decimal('70'), 'scoring__score_max': Decimal('80')})
         form.is_valid()
         form.update_preferences()
 
-        for pref, new_val in [('scoring__score_min', 70), ('scoring__score_max', 80)]:
+        for pref, new_val in [('scoring__score_min', Decimal('70')), ('scoring__score_max', Decimal('80'))]:
             self.assertEqual(tournament.preferences[pref], new_val)
 
         tournament.delete()

--- a/tabbycat/options/tests/test_views.py
+++ b/tabbycat/options/tests/test_views.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
@@ -17,8 +18,8 @@ class TestPreset(PreferencesPreset):
     show_in_list = False
 
     # Scoring
-    scoring__score_min = 70
-    scoring__score_max = 80
+    scoring__score_min = Decimal('70')
+    scoring__score_max = Decimal('80')
 
 
 class TournamentConfigIndexViewTests(TestCase):
@@ -67,7 +68,7 @@ class TournamentPreferenceFormViewTests(TestCase):
         view.setup(request, tournament_slug=tournament.slug, section='scoring')
         view.section = scoring
 
-        form = TestPreset.get_form(tournament, data={'scoring__score_min': 70, 'scoring__score_max': 80})
+        form = TestPreset.get_form(tournament, data={'scoring__score_min': Decimal('70'), 'scoring__score_max': Decimal('80')})
         form.is_valid()
         view.form_valid(form)
         mock_success.assert_called()
@@ -79,8 +80,8 @@ class TournamentPreferenceFormViewTests(TestCase):
 class TestSetPresetPreferencesView(TestCase):
     def set_up_tournament(self):
         tournament = Tournament.objects.create(slug="preset", name="Preset Testing")
-        tournament.preferences['scoring__score_min'] = 0
-        tournament.preferences['scoring__score_max'] = 100
+        tournament.preferences['scoring__score_min'] = Decimal('0')
+        tournament.preferences['scoring__score_max'] = Decimal('100')
         return tournament
 
     @patch('options.presets.all_presets', return_value=[TestPreset])
@@ -113,7 +114,7 @@ class TestSetPresetPreferencesView(TestCase):
         view = SetPresetPreferencesView()
         view.setup(request, tournament_slug=tournament.slug, preset_name='testpreset')
 
-        form = TestPreset.get_form(tournament, data={'scoring__score_min': 70, 'scoring__score_max': 80})
+        form = TestPreset.get_form(tournament, data={'scoring__score_min': Decimal('70'), 'scoring__score_max': Decimal('80')})
         form.is_valid()
         view.form_valid(form)
         mock_redirect.assert_called_with(reverse_tournament('options-tournament-index', tournament))

--- a/tabbycat/standings/views.py
+++ b/tabbycat/standings/views.py
@@ -279,7 +279,7 @@ class BaseSpeakerStandingsView(BaseStandingsView):
     def cast_round_results(self, standings, rounds, step_preference):
         """For use by subclasses. Casts round results to integers if appropriate
         according to tournament preferences."""
-        if self.tournament.pref(step_preference).is_integer():
+        if self.tournament.pref(step_preference) % 1 == 0:
             is_consensus_by_round = [self.tournament.ballots_per_debate(r.stage) == 'per-debate' for r in rounds]
             for info in standings:
                 for i, is_consensus in enumerate(is_consensus_by_round):


### PR DESCRIPTION
Rather than use more advanced math to determine whether a given score is within the correct steps, which can become incorrect, use a float epsilon!