### PR TITLE
Add info-slide button for motions in 'In this Round'

### DIFF
--- a/tabbycat/participants/templates/current_round/common.html
+++ b/tabbycat/participants/templates/current_round/common.html
@@ -54,16 +54,33 @@
         <em>{% trans "Motions are not released to public." %}</em><br />
       {% endif %}
       {% if debate.round.motion_set.all|length == 1 %}
-        <strong>{% trans "Motion:" %}</strong> {{ debate.round.motion_set.first.text }}
+        {% with motion=debate.round.motion_set.first %}
+        <strong>{% trans "Motion:" %}</strong> {{ motion.text }}
+            {% if motion.info_slide %}
+              <span class="h6 badge badge-light text-secondary mx-auto mb-3 mt-0 hover-target"
+                    data-toggle="modal" data-target="#info_{{ motion.id }}">
+                {% trans "View Info Slide" %}
+              </span>
+              {% include 'motions_info.html' %}
+            {% endif %}
+        {% endwith %}
       {% else %}
+        <h6>Motions</h6>
+        <ol>
         {% for rm in debate.round.roundmotion_set.all %}
-          <strong>
-            {% blocktrans trimmed with seq=rm.seq %}
-              Motion {{ seq }}:
-            {% endblocktrans %}
-          </strong>
-          {{ rm.motion.text }}<br />
+          <li value="{{ rm.seq }}">
+            {{ rm.motion.text }}
+
+            {% if rm.motion.info_slide %}
+              <span class="h6 badge badge-light text-secondary mx-auto mb-3 mt-0 hover-target"
+                    data-toggle="modal" data-target="#info_{{ rm.motion.id }}">
+                {% trans "View Info Slide" %}
+              </span>
+              {% include 'motions_info.html' with motion=rm.motion %}
+            {% endif %}
+          </li>
         {% endfor %}
+      </ol>
       {% endif %}
     {% else %} {# elif not (current_round.motions_released or admin_page) #}
       <em>{% trans "The motion(s) for this round haven't yet been released." %}</em>


### PR DESCRIPTION
This commit adds buttons to activate the info-slide model for motions in private URLs, for ease of access. In addition, we use the a numbered list if there are many motions, rather than using line-breaks.