### PR TITLE
Remove uses of is_integer() for Decimal instances

### DIFF
--- a/tabbycat/results/utils.py
+++ b/tabbycat/results/utils.py
@@ -77,15 +77,6 @@ def readable_ballotsub_result(debateresult):
     return result_winner, result
 
 
-def set_float_or_int(number, step_value):
-    """Used to ensure the values sent through to the frontend <input> are
-    either Ints or Floats such that the validation can handle them properly"""
-    if step_value.is_integer():
-        return int(number)
-    else:
-        return number
-
-
 def get_result_status_stats(round):
     """Returns a dict where keys are result statuses of debates; values are the
     number of debates in the round with that status.

--- a/tabbycat/tournaments/models.py
+++ b/tabbycat/tournaments/models.py
@@ -125,10 +125,10 @@ class Tournament(models.Model):
         the value in question is in fact an integer before casting."""
         if self.ballots_per_debate(stage) == 'per-adj':
             return False
-        if not self.pref('score_step').is_integer():
+        if not self.pref('score_step').as_integer_ratio()[1] == 1:
             return False
         if (self.pref('reply_scores_enabled') and
-                not self.pref('reply_score_step').is_integer()):
+                not self.pref('reply_score_step').as_integer_ratio()[1] == 1):
             return False
         return True
 


### PR DESCRIPTION
The equivalent of the float .is_integer() method is to compare the denominator of the Decimal object with "1". This will avoid the crashes due to the former not existing.

It also removes the set_float_or_int() function as it didn't seem to be used anywhere.

Fixes BACKEND-C5D