### PR TITLE
Auto prep time on motion release

### DIFF
--- a/tabbycat/draw/views.py
+++ b/tabbycat/draw/views.py
@@ -6,6 +6,7 @@ from itertools import product
 from django.contrib import messages
 from django.db.models import OuterRef, Subquery
 from django.http import HttpResponseRedirect
+from django.utils import timezone
 from django.utils.functional import cached_property
 from django.utils.html import escape, format_html
 from django.utils.safestring import mark_safe
@@ -792,11 +793,10 @@ class SetRoundStartTimeView(DrawStatusEdit):
     def post(self, request, *args, **kwargs):
         time_text = request.POST["start_time"]
         try:
-            time = datetime.datetime.strptime(time_text, "%H:%M").time()
+            time = timezone.make_aware(datetime.datetime.strptime(time_text, "%Y-%m-%dT%H:%M"))
         except ValueError:
             messages.error(request, _("Sorry, \"%(input)s\" isn't a valid time. It must "
-                           "be in 24-hour format, with a colon, for "
-                           "example: \"13:57\".") % {'input': time_text})
+                           "be in ISO format, for example: \"2024-06-07T13:57\".") % {'input': time_text})
             return super().post(request, *args, **kwargs)
 
         self.round.starts_at = time

--- a/tabbycat/draw/views.py
+++ b/tabbycat/draw/views.py
@@ -796,7 +796,8 @@ class SetRoundStartTimeView(DrawStatusEdit):
             time = timezone.make_aware(datetime.datetime.strptime(time_text, "%Y-%m-%dT%H:%M"))
         except ValueError:
             messages.error(request, _("Sorry, \"%(input)s\" isn't a valid time. It must "
-                           "be in ISO format, for example: \"2024-06-07T13:57\".") % {'input': time_text})
+                           "be in 24-hour format, with a colon, for "
+                           "example: \"13:57\".") % {'input': time_text})
             return super().post(request, *args, **kwargs)
 
         self.round.starts_at = time

--- a/tabbycat/motions/views.py
+++ b/tabbycat/motions/views.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.contrib import messages
 from django.db.models import OuterRef, Prefetch, Q, Subquery
+from django.utils import timezone
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy, ngettext
 from django.views.generic.base import TemplateView
@@ -177,6 +178,15 @@ class ReleaseMotionsView(BaseReleaseMotionsView):
     @property
     def message_text(self):
         return ngettext("Released the motion.", "Released the motions.", self.round.motion_set.count())
+
+    def post(self, request, *args, **kwargs):
+        preparation_time = self.tournament.pref('preparation_time')
+
+        if preparation_time > -1:
+            self.round.starts_at = timezone.now() + timezone.timedelta(minutes=preparation_time)
+            self.round.save()
+
+        return super().post(request, *args, **kwargs)
 
 
 class UnreleaseMotionsView(BaseReleaseMotionsView):

--- a/tabbycat/options/preferences.py
+++ b/tabbycat/options/preferences.py
@@ -614,7 +614,13 @@ class UseSpeakerRanks(ChoicePreference):
         ('high-points', 'Require ranking speeches, ranks congruent with speaker scores'),
     )
     default = 'none'
-
+@tournament_preferences_registry.register
+class UseSpeakerRanks(ChoicePreference):
+    help_text = _("How long, in minutes, after motion release does the round start (-1 to deactivate")
+    verbose_name = _("Preparation Time")
+    section = debate_rules
+    name = 'preparation_time'
+    default = -1
 
 # ==============================================================================
 standings = Section('standings', verbose_name=_("Standings"))

--- a/tabbycat/options/preferences.py
+++ b/tabbycat/options/preferences.py
@@ -615,7 +615,7 @@ class UseSpeakerRanks(ChoicePreference):
     )
     default = 'none'
 @tournament_preferences_registry.register
-class UseSpeakerRanks(ChoicePreference):
+class PreparationTime(IntegerPreference):
     help_text = _("How long, in minutes, after motion release does the round start (-1 to deactivate")
     verbose_name = _("Preparation Time")
     section = debate_rules

--- a/tabbycat/options/presets.py
+++ b/tabbycat/options/presets.py
@@ -136,6 +136,7 @@ class BritishParliamentaryPreferences(PreferencesPreset):
     debate_rules__speakers_in_ballots          = 'prelim'
     debate_rules__side_names                   = 'gov-opp'
     debate_rules__reply_scores_enabled         = False
+    debate_rules__preparation_time             = 15
     motions__motion_vetoes_enabled             = False
     motions__enable_motions                    = False
     # Draw Rules


### PR DESCRIPTION
### **Description**
This commit adds a setting to modify prep time in Configuraton>Debate Rules. It also calculates round start time, in minutes, and displays it on triggering the release motions action. The default is set to 0 minutes and users can still modify the start time manually as before. The BP preset is set to 15 minutes.

### **Screenshots**
![Screenshot from 2024-05-21 23-50-52](https://github.com/TabbycatDebate/tabbycat/assets/67259345/56ebfff9-3a17-4453-87c9-d65c8d3909d9)


### **Additional Context**
This PR is related to issue #2435 