### PR TITLE
Fixed deployment issue for heroku

### DIFF
--- a/app.json
+++ b/app.json
@@ -8,7 +8,7 @@
   "addons": [
     "papertrail",
     "rediscloud:30",
-    "heroku-postgresql:mini",
+    "heroku-postgresql:essential-0",
     {
       "plan": "heroku-redis:mini",
       "options": {

--- a/deploy_heroku.py
+++ b/deploy_heroku.py
@@ -39,8 +39,8 @@ parser.add_argument(
     help="Git branch to push (defaults to current branch)")
 
 parser.add_argument(
-    "--pg-plan", "--postgresql-plan", type=str, default="mini",
-    help="Heroku Postgres plan (default mini)")
+    "--pg-plan", "--postgresql-plan", type=str, default="essential-0",
+    help="Heroku Postgres plan (default essential-0)")
 
 parser.add_argument(
     "--web-dynos", type=str, default="1",

--- a/docs/install/heroku.rst
+++ b/docs/install/heroku.rst
@@ -49,7 +49,7 @@ In order to use a user-friendly '1-click deployment button', you will need to ma
 
   ::
 
-   https://heroku.com/deploy?template=https://github.com/YOUR_GITHUB_NAME/YOUR_FORK_NAME/tree/master
+   dashboard.heroku.com/new-app?template=https://github.com/YOUR_GITHUB_NAME/YOUR_FORK_NAME/tree/master”
 
 6. In the URL address, replace ``YOUR_GITHUB_NAME`` with your GitHub username (e.g. **JaneSmith**) and replace ``YOUR_FORK_NAME`` with the name of your fork (e.g. **tabbycat**)
 7. Hit enter and fill out the details required. After the deployment process completes, you should have a new Tabbycat deployment

--- a/docs/install/heroku.rst
+++ b/docs/install/heroku.rst
@@ -49,7 +49,7 @@ In order to use a user-friendly '1-click deployment button', you will need to ma
 
   ::
 
-   dashboard.heroku.com/new-app?template=https://github.com/YOUR_GITHUB_NAME/YOUR_FORK_NAME/tree/master”
+   https://dashboard.heroku.com/new-app?template=https://github.com/YOUR_GITHUB_NAME/YOUR_FORK_NAME/tree/master
 
 6. In the URL address, replace ``YOUR_GITHUB_NAME`` with your GitHub username (e.g. **JaneSmith**) and replace ``YOUR_FORK_NAME`` with the name of your fork (e.g. **tabbycat**)
 7. Hit enter and fill out the details required. After the deployment process completes, you should have a new Tabbycat deployment


### PR DESCRIPTION
New updates to heroku removed the postgresql mini plan and added an essential-0 plan. The link to deploy via the fork was also changed. This PR addresses those issues. #2439 