### PR TITLE
Docker: Avoid overwriting collectstatic

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,8 +42,6 @@ services:
       - USING_NGINX=1
     ports:
       - "8000:8000"
-    volumes:
-      - .:/tcd
     working_dir: /tcd
 
   worker:
@@ -59,8 +57,6 @@ services:
       - DISABLE_SENTRY=1
       - DOCKER_REDIS=1
       - USING_NGINX=1
-    volumes:
-      - .:/tcd
     working_dir: /tcd
 
 volumes:


### PR DESCRIPTION
Adding the volumes made the `npm run build` and `dj collectstatic` commands ineffective as we were looking outside the container for the styling.

Closes #2436.