### PR TITLE
Making the ballot view responsive/phone-friendly

### DIFF
--- a/tabbycat/results/templates/ballot/ballot_scoresheet.html
+++ b/tabbycat/results/templates/ballot/ballot_scoresheet.html
@@ -22,7 +22,7 @@
     <div class="list-group-item">
       <div class="row">
 
-        <div class="col-6 mr-0 col-mr-auto pl-md-2 pl-1 btn-group">
+        <div class="col-6 flex-column flex-md-row mr-0 col-mr-auto pl-md-2 pl-1 btn-group">
 
           <button class="btn btn-outline-secondary btn-no-hover" readonly>
             {% if pref.teams_in_debate != 4 %}{% trans "Result" %}{% else %}{% trans "Rank" %}{% endif %}
@@ -38,9 +38,9 @@
           </button>
         </div>
 
-        <div class="col"></div>
+        <div class="col d-none d-md-block"></div>
 
-        <div class="col-4 btn-group pr-md-2 pr-1">
+        <div class="col-6 col-md-4 btn-group pr-md-2 pr-1">
           <button name="{{ team.side_code }}_total"
                   class="btn btn-block btn-secondary btn-no-hover {{ team.side_code }}_total" readonly>00</button>
         </div>

--- a/tabbycat/results/templates/ballot/ballot_speaks.html
+++ b/tabbycat/results/templates/ballot/ballot_speaks.html
@@ -1,12 +1,12 @@
 {% load add_field_css debate_tags i18n %}
 
 <div class="list-group-item js-team-speakers side-{{ team.side_code }} s{{ position.pos }}">
-  <div class="row">
-    <div class="col-2 pt-2 p-lg-2 pr-0 p-1 speaker-position-label">
+  <div class="row flex-column flex-md-row">
+    <div class="col-4 col-md-2 pt-2 p-lg-2 pr-0 p-md-1 speaker-position-label">
       {{ position.name }}
     </div>
 
-    <div class="col mb-0 pr-md-2 pr-1 form-group {{ position.speaker.errors|yesno:'error,' }}">
+    <div class="col mb-0 mb-3 pr-md-2 pr-1 form-group {{ position.speaker.errors|yesno:'error,' }}">
 
       {% if forloop.parentloop.parentloop.first %}
 
@@ -39,16 +39,19 @@
       </div>
     {% endif %}
 
-    <div class="col-4 form-group side-{{ team.side_code }} pr-md-2 pr-1 score {{ position.score_errors|yesno:'error,' }}">
+    <div class="col col-md-4 form-group side-{{ team.side_code }} pr-md-2 pr-1 score {{ position.score_errors|yesno:'error,' }}">
       {% for criterion, field in position.criteria %}
-      <div class="criterion">
+      <div class="criterion mb-3 w-auto">
         {{ criterion.name }}
         {{ field|addcss:"form-control" }}
         {{ field.errors }}
       </div>
       {% endfor %}
-      {{ position.score|addcss:"form-control total" }}
-      {{ position.score.errors }}
+      <div>
+        {{ position.score|addcss:"form-control total" }}
+        {{ position.score.errors }}
+      </div>
+
     </div>
 
   </div>


### PR DESCRIPTION
Not all the judges have laptops available all the time for ballots; thus, they submit their ballots through not-so-responsive ballot view on their phones. Given the score criteria release, the layout got messier. This PR is for fixing that problem. 

Here is the view of ballots:
https://drive.google.com/drive/folders/1e0ZhBXCnEYHp7yD6DD9cMDXIHkOcrsSc?usp=sharing