### PR TITLE
Minor bug fix for displaying result cell

### DIFF
--- a/tabbycat/utils/tables.py
+++ b/tabbycat/utils/tables.py
@@ -422,7 +422,7 @@ class TabbycatTableBuilder(BaseTableBuilder):
             return {'text': self.BLANK_TEXT}
 
         other_teams = {dt.side: self._team_short_name(dt.team) for dt in ts.debate_team.debate.debateteam_set.all()}
-        n_teams = max(other_teams.keys())
+        n_teams = max(other_teams.keys()) + 1
         other_team_strs = [_("Teams in debate:")]
         for side in range(n_teams):
             if ts.debate_team.debate.sides_confirmed:


### PR DESCRIPTION
After the newest patch, the result cell doesn't show the last team (CO) for the BP format. This is a quick fix for it.