### PR TITLE
Add badge for API operations in action log

### DIFF
--- a/tabbycat/actionlog/models.py
+++ b/tabbycat/actionlog/models.py
@@ -191,6 +191,7 @@ class ActionLogEntry(models.Model):
         return {
             'id': self.id,
             'user': self.user.username if self.user else self.ip_address or _("anonymous"),
+            'agent': self.agent,
             'type': self.get_type_display(),
             # As the team names are passed in the content of the message for all users,
             # must assume they don't have permission for real names

--- a/tabbycat/templates/graphs/UpdatesList.vue
+++ b/tabbycat/templates/graphs/UpdatesList.vue
@@ -3,6 +3,7 @@
   <li class='list-group-item text-info d-flex justify-content-between align-items-center'>
     <div>
       <strong v-html="item.user" class="pr-1"></strong>
+      <span v-if="item.agent == 'a'" class="badge badge-light mr-1">API</span>
       <span v-html="item.type" class="pr-1"></span>
       <em v-html="item.param"></em>
     </div>


### PR DESCRIPTION
Expose the agent property of the action log in `ActionLogEntry#serialize`, and add an 'API' badge in the Vue `UpdatesList` component if the agent was the API in order to differentiate from manual actions.