### PR TITLE
Add missing edit_permission to UpdateEligibilityEditView

### DIFF
--- a/tabbycat/participants/views.py
+++ b/tabbycat/participants/views.py
@@ -424,6 +424,7 @@ class UpdateEligibilityEditView(LogActionMixin, AdministratorMixin, TournamentMi
     action_log_type = ActionLogEntry.ActionType.SPEAKER_ELIGIBILITY_EDIT
     participant_model = Speaker
     many_to_many_field = 'categories'
+    edit_permission = Permission.EDIT_SPEAKER_ELIGIBILITY
 
     def set_category_eligibility(self, participant, sent_status):
         category_id = sent_status['type']


### PR DESCRIPTION
Adds the missing edit_permission field to UpdateEligibilityEditView which means that someone with the correct EDIT_SPEAKER_ELIGIBILITY permission can actually edit speaker eligibilities from the page, rather than only being able to access the page but not make any changes due to errors when clicking the tickboxes.