### PR TITLE
API: Use last round as default for generating standings

### DIFF
--- a/tabbycat/api/views.py
+++ b/tabbycat/api/views.py
@@ -765,7 +765,7 @@ class BaseStandingsView(TournamentAPIMixin, TournamentPublicAPIMixin, GenericAPI
     def get_max_round(self):
         if self.request.query_params.get('round'):
             return Round.objects.get(tournament=self.tournament, seq=int(self.request.query_params.get('round')))
-        return None
+        return Round.objects.filter(tournament=self.tournament).order_by('seq').last()
 
     @extend_schema(tags=['standings'], parameters=[
         tournament_parameter,


### PR DESCRIPTION
The speaker standings require a round in order to get the tournament for speaker positions.

Fixes #2488.