### PR TITLE
Redact names in team results page.

### DIFF
--- a/tabbycat/participants/models.py
+++ b/tabbycat/participants/models.py
@@ -134,6 +134,8 @@ class Person(models.Model):
         return str(self.name)
 
     def get_public_name(self, tournament):
+        if self.anonymous:
+            return "Redacted"
         if tournament.pref('participant_code_names') == 'off':
             return self.name
         return self.code_name

--- a/tabbycat/participants/tables.py
+++ b/tabbycat/participants/tables.py
@@ -1,3 +1,5 @@
+from typing import Iterable
+
 from django.db.models import Max, Prefetch
 from django.db.models.functions import Coalesce
 from django.utils.html import escape
@@ -15,7 +17,7 @@ from utils.tables import TabbycatTableBuilder
 
 class TeamResultTableBuilder(TabbycatTableBuilder):
 
-    def add_cumulative_team_points_column(self, teamscores):
+    def add_cumulative_team_points_column(self, teamscores: Iterable[TeamScore]):
         """It is assumed that `teamscores` is ordered by round number; the
         caller must ensure that this is the case."""
         cumul = 0
@@ -34,10 +36,10 @@ class TeamResultTableBuilder(TabbycatTableBuilder):
         header = {'key': 'cumulative', 'tooltip': tooltip, 'icon': 'trending-up'}
         self.add_column(header, data)
 
-    def add_speaker_scores_column(self, teamscores):
+    def add_speaker_scores_column(self, teamscores: Iterable[TeamScore]):
         data = [{
             'text': ", ".join([metricformat(ss.score) for ss in ts.debate_team.speaker_scores]) or "—",
-            'tooltip': "<br>".join(["%s for %s" % (metricformat(ss.score), escape(ss.speaker)) for ss in ts.debate_team.speaker_scores]),
+            'tooltip': "<br>".join(["%s for %s" % (metricformat(ss.score), escape(ss.speaker.get_public_name(self.tournament))) for ss in ts.debate_team.speaker_scores]),
         } for ts in teamscores]
         header = {'key': 'speaks', 'tooltip': _("Speaker scores<br>(in speaking order)"), 'text': _("Speaks")}
         self.add_column(header, data)

--- a/tabbycat/results/models.py
+++ b/tabbycat/results/models.py
@@ -371,7 +371,7 @@ class SpeakerScore(models.Model):
 
     def __str__(self):
         return ("[{0.ballot_submission_id}/{0.id}] {0.score} at {0.position} for "
-            "{0.speaker.name} in {0.debate_team!s}").format(self)
+            "{0.speaker.get_public_name()} in {0.debate_team!s}").format(self)
 
     def clean(self):
         super().clean()


### PR DESCRIPTION
Should fix https://github.com/TabbycatDebate/tabbycat/issues/2497.

I'm not sure if we want to redact names in the admin section of the site (as admins can view the names in the database anyway) but I guess it doesn't hurt.

~I imagine it would also be sensible to redact speakers from the API.~ (Apologies, I checked against the API of a Tabbycat instance but forgot I was logged in as an admin so could see the speaker details).