### PR TITLE
Fix error when running `simulaterounds` command.

### DIFF
--- a/tabbycat/results/dbutils.py
+++ b/tabbycat/results/dbutils.py
@@ -157,13 +157,13 @@ def add_result(debate, submitter_type, user, discarded=False, confirmed=False, r
         if result.uses_declared_winners:
             logger.info("%(debate)s: %(advancing)s on %(motion)s", {
                 'debate': debate.matchup,
-                'advancing': ", ".join(result.get_winner()),
+                'advancing': ", ".join(map(str, result.get_winner())),
                 'motion': bsub.motion and bsub.motion.reference or "<No motion>",
             })
         else:
             logger.info("%(debate)s: %(ranked)s on %(motion)s", {
                 'debate': debate.matchup,
-                'ranked': ", ".join(result.scoresheet.ranked_sides()),
+                'ranked': ", ".join(map(str, result.scoresheet.ranked_sides())),
                 'motion': bsub.motion and bsub.motion.reference or "<No motion>",
             })
 


### PR DESCRIPTION
Cast the result to a string before calling `logger.info`.