### PR TITLE
Add more protections for deleting draws

### DIFF
--- a/tabbycat/draw/forms.py
+++ b/tabbycat/draw/forms.py
@@ -1,0 +1,14 @@
+from django import forms
+from django.utils.translation import gettext as _
+
+
+class ConfirmDrawDeletionForm(forms.Form):
+    round_name = forms.CharField(label=_("Full round name"), required=True)
+
+    def __init__(self, round, **kwargs):
+        self.round = round
+        super().__init__(**kwargs)
+
+    def clean_round_name(self):
+        if self.cleaned_data['round_name'] != self.round.name:
+            raise forms.ValidationError(_("You must type '%s' to confirm draw and results deletion.") % self.round.name)

--- a/tabbycat/draw/templates/draw_base.html
+++ b/tabbycat/draw/templates/draw_base.html
@@ -12,7 +12,7 @@
     </a>
   </div>
   <div class="btn-group flex-wrap" role="group">
-    <a href="{% roundurl 'draw-confirm-regenerate' %}" class="btn btn-outline-primary">
+    <a href="{% roundurl 'draw-regenerate' %}" class="btn btn-outline-primary">
       {% trans "Redo Draw" %}
     </a>
     <a href="{% roundurl 'draw-details' %}" class="btn btn-outline-primary">

--- a/tabbycat/draw/templates/draw_confirm_regeneration.html
+++ b/tabbycat/draw/templates/draw_confirm_regeneration.html
@@ -29,11 +29,12 @@
 
   <form method="POST" action="{% roundurl 'draw-regenerate' %}">
     {% csrf_token %}
-    <button class="btn btn-block btn-danger " type="submit">
-      {% blocktrans trimmed with round=round.name %}
-      Yes, I want to delete the current draw for {{ round }}
-      {% endblocktrans %}
-    </button>
+    {% include "components/form-main.html" %}
+
+    {% blocktrans trimmed with round=round.name asvar title %}
+    Yes, I want to delete the current draw for {{ round }}
+    {% endblocktrans %}
+    {% include "components/form-submit.html" with type='danger' %}
   </form>
 
 {% endblock %}

--- a/tabbycat/draw/templates/draw_status_draft.html
+++ b/tabbycat/draw/templates/draw_status_draft.html
@@ -2,7 +2,7 @@
 {% load debate_tags i18n standingsformat %}
 
 {% block page-subnav-sections %}
-  <a href="{% roundurl 'draw-confirm-regenerate' %}" class="btn btn-outline-danger">
+  <a href="{% roundurl 'draw-regenerate' %}" class="btn btn-outline-danger">
     <i data-feather="chevron-left"></i> {% trans "Delete Draw" %}
   </a>
   <a href="{% roundurl 'edit-debate-teams' round %}" class="btn btn-outline-primary">

--- a/tabbycat/draw/urls_admin.py
+++ b/tabbycat/draw/urls_admin.py
@@ -21,11 +21,8 @@ urlpatterns = [
         path('confirm/',
             views.ConfirmDrawCreationView.as_view(),
             name='draw-confirm'),
-        path('regenerate/confirm/',
-            views.ConfirmDrawRegenerationView.as_view(),
-            name='draw-confirm-regenerate'),
         path('regenerate/',
-            views.DrawRegenerateView.as_view(),
+            views.ConfirmDrawRegenerationView.as_view(),
             name='draw-regenerate'),
 
         # Email

--- a/tabbycat/draw/views.py
+++ b/tabbycat/draw/views.py
@@ -15,6 +15,7 @@ from django.utils.timezone import get_current_timezone_name
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy, ngettext
 from django.views.generic.base import TemplateView
+from django.views.generic.edit import FormView
 
 from actionlog.mixins import LogActionMixin
 from actionlog.models import ActionLogEntry
@@ -46,6 +47,7 @@ from venues.models import VenueConstraint
 from venues.utils import venue_conflicts_display
 
 from .dbutils import delete_round_draw
+from .forms import ConfirmDrawDeletionForm
 from .generator import DrawFatalError, DrawUserError
 from .manager import DrawManager
 from .models import Debate, TeamSideAllocation
@@ -732,20 +734,26 @@ class ConfirmDrawCreationView(DrawStatusEdit):
         return super().post(request, *args, **kwargs)
 
 
-class DrawRegenerateView(DrawStatusEdit):
+class ConfirmDrawRegenerationView(LogActionMixin, AdministratorMixin, RoundMixin, FormView):
+    template_name = "draw_confirm_regeneration.html"
+    view_permission = Permission.DELETE_DEBATE
+    form_class = ConfirmDrawDeletionForm
+
     action_log_type = ActionLogEntry.ActionType.DRAW_REGENERATE
     round_redirect_pattern_name = 'availability-index'
 
-    def post(self, request, *args, **kwargs):
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs['round'] = self.round
+        return kwargs
+
+    def form_valid(self, form):
         delete_round_draw(self.round)
-        self.log_action()
-        messages.success(request, _("Deleted the draw. You can now recreate it as normal."))
-        return super().post(request, *args, **kwargs)
+        messages.success(self.request, _("Deleted the draw. You can now recreate it as normal."))
+        return super().form_valid(form)
 
-
-class ConfirmDrawRegenerationView(AdministratorMixin, TemplateView):
-    template_name = "draw_confirm_regeneration.html"
-    view_permission = Permission.GENERATE_DEBATE
+    def get_success_url(self):
+        return self.get_redirect_url()
 
 
 class DrawReleaseView(DrawStatusEdit):

--- a/tabbycat/templates/components/form-submit.html
+++ b/tabbycat/templates/components/form-submit.html
@@ -1,6 +1,6 @@
 <div class="list-group-item pt-4 pb-2">
 
-  <button type="submit" name="continue" class="btn btn-block btn-success mb-3">
+  <button type="submit" name="continue" class="btn btn-block btn-{% if type %}{{ type }}{% else %}success{% endif %} mb-3">
     {{ title }}
   </button>
 

--- a/tabbycat/users/permissions.py
+++ b/tabbycat/users/permissions.py
@@ -58,6 +58,7 @@ class Permission(TextChoices):
     VIEW_DEBATE = 'view.debate', _("view debates (draw)")
     VIEW_ADMIN_DRAW = 'view.debate.admin', _("view debates (detailed draw)")
     GENERATE_DEBATE = 'generate.debate', _("generate debates (draw)")
+    DELETE_DEBATE = 'delete.debate', _("delete debates (draw)")
     EDIT_DEBATETEAMS = 'edit.debateteam', _("edit debate teams (pairings)")
     VIEW_DEBATEADJUDICATORS = 'view.debateadjudicator', _("view debate adjudicators (allocations)")
     EDIT_DEBATEADJUDICATORS = 'edit.debateadjudicator', _("edit debate adjudicators (allocations)")


### PR DESCRIPTION
As deleting draws can have a huge and irreversible effect, we should guard better against accidental or negligent use. To that end, we add these layers:
* A new user permission for deleting the draw
* A confirmation text box which requires typing the name of the round in order to delete it.

With the page becoming a form, we can merge the confirmation view (as a GET) with the POST action.