### PR TITLE
Add email validator to "Reply-To address" setting

### DIFF
--- a/tabbycat/options/preferences.py
+++ b/tabbycat/options/preferences.py
@@ -1,6 +1,6 @@
 from decimal import Decimal
 
-from django.core.validators import MinValueValidator, validate_slug, EmailValidator
+from django.core.validators import EmailValidator, MinValueValidator, validate_slug
 from django.utils.translation import gettext_lazy as _
 from django_summernote.widgets import SummernoteWidget
 from dynamic_preferences.preferences import Section

--- a/tabbycat/options/preferences.py
+++ b/tabbycat/options/preferences.py
@@ -1,6 +1,6 @@
 from decimal import Decimal
 
-from django.core.validators import MinValueValidator, validate_slug
+from django.core.validators import MinValueValidator, validate_slug, EmailValidator
 from django.utils.translation import gettext_lazy as _
 from django_summernote.widgets import SummernoteWidget
 from dynamic_preferences.preferences import Section
@@ -1272,6 +1272,7 @@ class ReplyToEmailAddress(StringPreference):
     section = email
     name = 'reply_to_address'
     default = ""
+    field_kwargs = {'validators': [EmailValidator()]}
 
 
 @tournament_preferences_registry.register


### PR DESCRIPTION
Imported `EmailValidator` from django validators and added it to "Reply-To address" setting

Fixes #2514