### PR TITLE
Set X-CSRFToken header for ajax requests.

### DIFF
--- a/tabbycat/templates/ajax/AjaxMixin.vue
+++ b/tabbycat/templates/ajax/AjaxMixin.vue
@@ -10,9 +10,27 @@ export default {
     ) {
       const self = this
       const dataPayload = JSON.stringify(payload)
+      function getCookie (name) {
+        let cookieValue = null
+        if (document.cookie && document.cookie !== '') {
+          const cookies = document.cookie.split(';')
+          for (let i = 0; i < cookies.length; i++) {
+            const cookie = cookies[i].trim()
+            // Does this cookie string begin with the name we want?
+            if (cookie.substring(0, name.length + 1) === (name + '=')) {
+              cookieValue = decodeURIComponent(cookie.substring(name.length + 1))
+              break
+            }
+          }
+        }
+        return cookieValue
+      }
+      const csrftoken = getCookie('csrftoken')
       $.ajax({
         type: 'POST',
         url: url,
+        headers: { 'X-CSRFToken': csrftoken },
+        mode: 'same-origin',
         data: dataPayload,
         contentType: 'application/json',
         dataType: 'json',


### PR DESCRIPTION
Currently HTTP requests made from Javascript code fail because they do not contain the CSRF token.

This uses the approach recommended in the Django documentation (https://docs.djangoproject.com/en/5.1/howto/csrf/).