### PR TITLE
Create "draw strength by rank" metric annotator

### DIFF
--- a/tabbycat/options/preferences.py
+++ b/tabbycat/options/preferences.py
@@ -666,7 +666,7 @@ class TeamStandingsExtraMetrics(MultiValueChoicePreference):
     verbose_name = _("Team standings extra metrics")
     section = standings
     name = 'team_standings_extra_metrics'
-    choices = TeamStandingsGenerator.get_metric_choices(ranked_only=False)
+    choices = TeamStandingsGenerator.get_metric_choices(ranked_only=False, for_extra=True)
     nfields = 5
     allow_empty = True
     default = []
@@ -694,7 +694,7 @@ class SpeakerStandingsExtraMetrics(MultiValueChoicePreference):
     verbose_name = _("Speaker standings extra metrics")
     section = standings
     name = 'speaker_standings_extra_metrics'
-    choices = SpeakerStandingsGenerator.get_metric_choices(ranked_only=False)
+    choices = SpeakerStandingsGenerator.get_metric_choices(ranked_only=False, for_extra=True)
     nfields = 5
     allow_empty = True
     default = ['stdev', 'count']

--- a/tabbycat/standings/base.py
+++ b/tabbycat/standings/base.py
@@ -216,7 +216,6 @@ class Standings:
         self._ranking_specs.append((key, name, abbr, icon))
 
     def add_metric(self, instance, key, value):
-        assert not self.ranked, "Can't add metrics once standings object is sorted"
         self.get_standing(instance).add_metric(key, value)
 
     def add_ranking(self, instance, key, value):
@@ -347,7 +346,8 @@ class BaseStandingsGenerator:
             return self.generate_from_queryset(queryset_for_metrics, standings, round)
 
         # Otherwise (not all precedence metrics are SQL-based), need to sort Standings
-        self._annotate_metrics(queryset_for_metrics, self.non_queryset_annotators, standings, round)
+        non_qs_ranked_annotators = [annotator for annotator in self.non_queryset_annotators if annotator.key in self.precedence]
+        self._annotate_metrics(queryset_for_metrics, non_qs_ranked_annotators, standings, round)
 
         standings.sort(self.precedence, self._tiebreak_func)
 
@@ -355,6 +355,10 @@ class BaseStandingsGenerator:
             logger.debug("Running ranking annotator: %s", annotator.name)
             annotator.run(standings)
         logger.debug("Ranking annotators done.")
+
+        # Do Draw Strength by Rank annotator after ranking standings
+        non_qs_extra_annotators = [annotator for annotator in self.non_queryset_annotators if annotator.key not in self.precedence]
+        self._annotate_metrics(queryset_for_metrics, non_qs_extra_annotators, standings, round)
 
         return standings
 
@@ -364,8 +368,6 @@ class BaseStandingsGenerator:
 
         for annotator in self.ranking_annotators:
             queryset = annotator.get_annotated_queryset(queryset, self.queryset_metric_annotators, *self.options["rank_filter"])
-
-        self._annotate_metrics(queryset, self.non_queryset_annotators, standings, round)
 
         # Can use window functions to rank standings if all are from queryset
         for annotator in self.ranking_annotators:
@@ -384,6 +386,10 @@ class BaseStandingsGenerator:
         queryset = queryset.order_by(*ordering_keys)
 
         standings.sort_from_rankings(tiebreak_func)
+
+        # Add metrics that aren't used for ranking (done afterwards for "draw strength by rank")
+        self._annotate_metrics(queryset, self.non_queryset_annotators, standings, round)
+
         return standings
 
     @staticmethod
@@ -465,17 +471,13 @@ class BaseStandingsGenerator:
         return self.TIEBREAK_FUNCTIONS[self.options["tiebreak"]]
 
     @classmethod
-    def get_metric_choices(cls, ranked_only=True):
+    def get_metric_choices(cls, ranked_only=True, for_extra=False):
         choices = []
         for key, annotator in cls.metric_annotator_classes.items():
-            if not ranked_only and annotator.ranked_only:
+            if (not ranked_only and annotator.ranked_only) or not annotator.listed or (not for_extra and annotator.extra_only):
                 continue
-            if not annotator.listed:
-                continue
-            if hasattr(annotator, 'choice_name'):
-                choice_name = annotator.choice_name.capitalize()
-            else:
-                choice_name = annotator.name.capitalize()
+
+            choice_name = annotator.choice_name.capitalize() if hasattr(annotator, 'choice_name') else annotator.name.capitalize()
             choices.append((key, choice_name))
         choices.sort(key=lambda x: x[1])
         return choices

--- a/tabbycat/standings/metrics.py
+++ b/tabbycat/standings/metrics.py
@@ -57,6 +57,7 @@ class BaseMetricAnnotator:
     abbr = None  # must be set by subclasses
     icon = None
     ranked_only = False
+    extra_only = False
     repeatable = False
     listed = True
     ascending = False  # if True, this metric is sorted in ascending order, not descending

--- a/tabbycat/standings/teams.py
+++ b/tabbycat/standings/teams.py
@@ -205,6 +205,38 @@ class BaseDrawStrengthMetricAnnotator(BaseMetricAnnotator):
             standings.add_metric(team, self.key, draw_strength)
 
 
+class DrawStrengthByRankMetricAnnotator(BaseMetricAnnotator):
+    key = "draw_strength_rank"
+    name = _("draw strength by rank")
+    abbr = _("DSR")
+
+    ascending = True
+    extra_only = True  # Cannot rank based on ranking
+
+    def annotate(self, queryset, standings, round=None):
+        if not queryset.exists():
+            return
+
+        logger.info("Running opponents query for rank draw strength:")
+
+        # Make a copy of teams queryset and annotate with opponents
+        opponents_filter = ~Q(debateteam__debate__debateteam__team_id=F('id'))
+        opponents_filter &= Q(debateteam__debate__round__stage=Round.Stage.PRELIMINARY)
+        if round is not None:
+            opponents_filter &= Q(debateteam__debate__round__seq__lte=round.seq)
+        opponents_annotation = ArrayAgg('debateteam__debate__debateteam__team_id',
+                filter=opponents_filter)
+        logger.info("Opponents annotation: %s", str(opponents_annotation))
+        teams_with_opponents = queryset.model.objects.annotate(opponent_ids=opponents_annotation)
+        opponents_by_team = {team.id: team.opponent_ids or [] for team in teams_with_opponents}
+        teams_by_id = {team.id: team for team in teams_with_opponents}
+
+        for team in queryset:
+            ranks = [standings.infos[teams_by_id[opponent_id]].rankings['rank'][0] for opponent_id in opponents_by_team[team.id]]
+            ranks_without_none = [rank for rank in ranks if rank is not None]
+            standings.add_metric(team, self.key, sum(ranks_without_none))
+
+
 class DrawStrengthByWinsMetricAnnotator(BaseDrawStrengthMetricAnnotator):
     """Metric annotator for draw strength."""
     key = "draw_strength"  # keep this key for backwards compatibility
@@ -407,6 +439,7 @@ class TeamStandingsGenerator(BaseStandingsGenerator):
         "speaks_stddev"       : SpeakerScoreStandardDeviationMetricAnnotator,
         "draw_strength"       : DrawStrengthByWinsMetricAnnotator,
         "draw_strength_speaks": DrawStrengthBySpeakerScoreMetricAnnotator,
+        "draw_strength_rank"  : DrawStrengthByRankMetricAnnotator,
         "margin_sum"          : SumMarginMetricAnnotator,
         "margin_avg"          : AverageMarginMetricAnnotator,
         "npullups"            : TeamPullupsMetricAnnotator,


### PR DESCRIPTION
This commit adds a new team metric that takes the opponent teams' ranks as a sum, for use in WSDC draw pull-up rules.

As the metric relies on the rankings, this metric must be run after having sorted the precedence metrics, and cannot be used itself for ranking. To solve these, now, metrics can be excluded from the options ranking metrics lists, and the check for adding metrics after sorting is removed. The other option would be to only sort based on metrics specified before DSR.