### PR TITLE
Add ability to re-send account creation emails.

### DIFF
--- a/tabbycat/users/forms.py
+++ b/tabbycat/users/forms.py
@@ -34,7 +34,8 @@ class InviteUserForm(PasswordResetForm):
                 'username': email.split("@")[0],
             },
         )
-        user.membership_set.create(group=self.cleaned_data['role'])
+        if created is True:
+            user.membership_set.create(group=self.cleaned_data['role'])
         return [user]
 
     def save(self, *args, **kwargs):

--- a/tabbycat/users/forms.py
+++ b/tabbycat/users/forms.py
@@ -34,7 +34,7 @@ class InviteUserForm(PasswordResetForm):
                 'username': email.split("@")[0],
             },
         )
-        if created is True:
+        if created:
             user.membership_set.create(group=self.cleaned_data['role'])
         return [user]
 

--- a/tabbycat/users/forms.py
+++ b/tabbycat/users/forms.py
@@ -34,8 +34,7 @@ class InviteUserForm(PasswordResetForm):
                 'username': email.split("@")[0],
             },
         )
-        if created:
-            user.membership_set.create(group=self.cleaned_data['role'])
+        user.membership_set.add(group=self.cleaned_data['role'])
         return [user]
 
     def save(self, *args, **kwargs):

--- a/tabbycat/users/templates/invite_user.html
+++ b/tabbycat/users/templates/invite_user.html
@@ -18,6 +18,7 @@
     {% include 'components/form-main.html' %}
 
     {% trans "Invite User" context "button" as title %}
+    {% trans "Note: if you submit this multiple times, multiple invite emails will be sent." as subtitle %}
     {% include "components/form-submit.html" %}
   </div>
 </form>


### PR DESCRIPTION
Submitting the "invite user" form a second time will now send a new email.

Fixes #2582