### PR TITLE
Add tournament filtering to standing generators

### DIFF
--- a/tabbycat/breakqual/base.py
+++ b/tabbycat/breakqual/base.py
@@ -122,7 +122,7 @@ class BaseBreakGenerator:
         self.check_required_metrics(metrics)
 
         generator = TeamStandingsGenerator(metrics, self.rankings)
-        generated = generator.generate(self.team_queryset)
+        generated = generator.generate(self.team_queryset, tournament=self.category.tournament)
         self.standings = list(generated)
 
     def filter_eligible_teams(self):

--- a/tabbycat/breakqual/utils.py
+++ b/tabbycat/breakqual/utils.py
@@ -23,7 +23,7 @@ def get_breaking_teams(category, prefetch=(), rankings=('rank',)):
     teams = category.breaking_teams.all().prefetch_related(*prefetch)
     metrics = category.tournament.pref('team_standings_precedence')
     generator = TeamStandingsGenerator(metrics, rankings)
-    standings = generator.generate(teams)
+    standings = generator.generate(teams, tournament=category.tournament)
 
     breakingteams_by_team_id = {bt.team_id: bt for bt in category.breakingteam_set.all()}
 

--- a/tabbycat/standings/speakers.py
+++ b/tabbycat/standings/speakers.py
@@ -304,3 +304,5 @@ class SpeakerStandingsGenerator(BaseStandingsGenerator):
     ranking_annotator_classes = {
         "rank"     : BasicRankAnnotator,
     }
+
+    tournament_field = 'team__tournament'

--- a/tabbycat/standings/teams.py
+++ b/tabbycat/standings/teams.py
@@ -457,3 +457,5 @@ class TeamStandingsGenerator(BaseStandingsGenerator):
         "subrank"         : SubrankAnnotator,
         "institution_rank": RankFromInstitutionAnnotator,
     }
+
+    tournament_field = 'tournament'

--- a/tabbycat/standings/tests/test_standings.py
+++ b/tabbycat/standings/tests/test_standings.py
@@ -45,7 +45,7 @@ class TestTrivialStandings(TestCase):
 
     def get_standings(self, generator):
         with suppress_logs('standings.metrics', logging.INFO):
-            standings = generator.generate(self.tournament.team_set.all())
+            standings = generator.generate(self.tournament.team_set.all(), tournament=self.tournament)
         return standings
 
     def set_up_speaker_scores(self, position):
@@ -75,7 +75,7 @@ class TestTrivialStandings(TestCase):
     def test_nothing(self):
         # just test that it does not crash
         generator = TeamStandingsGenerator((), ())
-        generator.generate(self.tournament.team_set.all())
+        generator.generate(self.tournament.team_set.all(), tournament=self.tournament)
 
     def test_no_metrics(self):
         generator = TeamStandingsGenerator((), ('rank', 'subrank'))
@@ -348,7 +348,7 @@ class TestBasicStandings(TestCase):
                     generator = TeamStandingsGenerator(metrics, self.rankings)
                     with suppress_logs('standings.teams', logging.INFO), \
                             suppress_logs('standings.metrics', logging.INFO):
-                        standings = generator.generate(tournament.team_set.all())
+                        standings = generator.generate(tournament.team_set.all(), tournament=tournament)
 
                     self.assertEqual(len(standings), len(testdata["standings"]))
                     self.assertEqual(standings.metric_keys, list(metrics))
@@ -379,7 +379,7 @@ class TestMissingStandings(TestCase):
 
     def get_standings(self, generator):
         with suppress_logs('standings.metrics', logging.INFO):
-            return generator.generate(self.tournament.team_set.all())
+            return generator.generate(self.tournament.team_set.all(), tournament=self.tournament)
 
     def test_num_adjs_missing(self):
         generator = TeamStandingsGenerator(('num_adjs',), ())


### PR DESCRIPTION
This commit adds an optional `tournament` parameter to standing generators, which will add filtering to the queryset used for aggregations. In large databases, this improves the execution of the queries by allowing the use of the foreign key index, which can't be done when merely including IDs.

<details>
<summary>EXPLAIN without filter (speakers)</summary>

```
WindowAgg  (cost=1490.53..1513.99 rows=1173 width=110) (actual time=27.548..27.641 rows=171 loops=1)
  ->  Sort  (cost=1490.53..1493.46 rows=1173 width=102) (actual time=27.544..27.551 rows=171 loops=1)
        Sort Key: (CASE WHEN (count(results_speakerscore.score) FILTER (WHERE (results_ballotsubmission.confirmed AND (tournaments_round.seq <= 14) AND ((tournaments_round.stage)::text = 'P'::text) AND (NOT results_speakerscore.ghost) AND (results_speakerscore."position" <= 3))) >= 6) THEN avg(results_speakerscore.score) FILTER (WHERE (results_ballotsubmission.confirmed AND (tournaments_round.seq <= 14) AND ((tournaments_round.stage)::text = 'P'::text) AND (NOT results_speakerscore.ghost) AND (results_speakerscore."position" <= 3))) ELSE NULL::double precision END)
        Sort Method: quicksort  Memory: 61kB
        ->  WindowAgg  (cost=1407.27..1430.73 rows=1173 width=102) (actual time=27.382..27.463 rows=171 loops=1)
              ->  Sort  (cost=1407.27..1410.20 rows=1173 width=94) (actual time=27.368..27.375 rows=171 loops=1)
                    Sort Key: (CASE WHEN (count(results_speakerscore.score) FILTER (WHERE (results_ballotsubmission.confirmed AND (tournaments_round.seq <= 14) AND ((tournaments_round.stage)::text = 'P'::text) AND (NOT results_speakerscore.ghost) AND (results_speakerscore."position" <= 3))) >= 6) THEN avg(results_speakerscore.score) FILTER (WHERE (results_ballotsubmission.confirmed AND (tournaments_round.seq <= 14) AND ((tournaments_round.stage)::text = 'P'::text) AND (NOT results_speakerscore.ghost) AND (results_speakerscore."position" <= 3))) ELSE NULL::double precision END) DESC NULLS LAST
                    Sort Method: quicksort  Memory: 57kB
                    ->  HashAggregate  (cost=1326.94..1347.47 rows=1173 width=94) (actual time=27.215..27.259 rows=171 loops=1)
                          Group Key: participants_person.id, participants_speaker.person_ptr_id
                          Batches: 1  Memory Usage: 129kB
                          ->  Hash Semi Join  (cost=522.79..1297.62 rows=1173 width=82) (actual time=4.357..25.939 rows=5483 loops=1)
                                Hash Cond: (participants_speaker.person_ptr_id = u0.person_ptr_id)
                                ->  Hash Left Join  (cost=471.10..1181.35 rows=19632 width=82) (actual time=3.923..23.728 rows=20095 loops=1)
                                      Hash Cond: (draw_debate.round_id = tournaments_round.id)
                                      ->  Hash Left Join  (cost=464.25..1121.69 rows=19632 width=80) (actual time=3.866..20.880 rows=20095 loops=1)
                                            Hash Cond: (draw_debateteam.debate_id = draw_debate.id)
                                            ->  Hash Left Join  (cost=406.60..1012.37 rows=19632 width=80) (actual time=3.448..17.341 rows=20095 loops=1)
                                                  Hash Cond: (results_speakerscore.debate_team_id = draw_debateteam.id)
                                                  ->  Hash Left Join  (cost=256.43..810.62 rows=19632 width=80) (actual time=2.463..13.523 rows=20095 loops=1)
                                                        Hash Cond: (results_speakerscore.ballot_submission_id = results_ballotsubmission.id)
                                                        ->  Hash Join  (cost=165.07..667.63 rows=19632 width=83) (actual time=1.791..10.039 rows=20095 loops=1)
                                                              Hash Cond: (participants_speaker.person_ptr_id = participants_person.id)
                                                              ->  Hash Right Join  (cost=60.32..511.27 rows=19632 width=29) (actual time=0.348..4.359 rows=20095 loops=1)
                                                                    Hash Cond: (results_speakerscore.speaker_id = participants_speaker.person_ptr_id)
                                                                    ->  Seq Scan on results_speakerscore  (cost=0.00..399.32 rows=19632 width=25) (actual time=0.009..0.919 rows=19636 loops=1)
                                                                    ->  Hash  (cost=32.92..32.92 rows=2192 width=8) (actual time=0.323..0.324 rows=2192 loops=1)
                                                                          Buckets: 4096  Batches: 1  Memory Usage: 118kB
                                                                          ->  Seq Scan on participants_speaker  (cost=0.00..32.92 rows=2192 width=8) (actual time=0.003..0.125 rows=2192 loops=1)
                                                              ->  Hash  (cost=68.22..68.22 rows=2922 width=54) (actual time=1.428..1.428 rows=2922 loops=1)
                                                                    Buckets: 4096  Batches: 1  Memory Usage: 277kB
                                                                    ->  Seq Scan on participants_person  (cost=0.00..68.22 rows=2922 width=54) (actual time=0.006..0.586 rows=2922 loops=1)
                                                        ->  Hash  (cost=58.94..58.94 rows=2594 width=5) (actual time=0.659..0.659 rows=2595 loops=1)
                                                              Buckets: 4096  Batches: 1  Memory Usage: 134kB
                                                              ->  Seq Scan on results_ballotsubmission  (cost=0.00..58.94 rows=2594 width=5) (actual time=0.007..0.352 rows=2595 loops=1)
                                                  ->  Hash  (cost=93.41..93.41 rows=4541 width=8) (actual time=0.963..0.963 rows=4446 loops=1)
                                                        Buckets: 8192  Batches: 1  Memory Usage: 238kB
                                                        ->  Seq Scan on draw_debateteam  (cost=0.00..93.41 rows=4541 width=8) (actual time=0.005..0.517 rows=4446 loops=1)
                                            ->  Hash  (cost=38.40..38.40 rows=1540 width=8) (actual time=0.408..0.408 rows=1540 loops=1)
                                                  Buckets: 2048  Batches: 1  Memory Usage: 77kB
                                                  ->  Seq Scan on draw_debate  (cost=0.00..38.40 rows=1540 width=8) (actual time=0.006..0.257 rows=1540 loops=1)
                                      ->  Hash  (cost=4.71..4.71 rows=171 width=10) (actual time=0.052..0.052 rows=171 loops=1)
                                            Buckets: 1024  Batches: 1  Memory Usage: 16kB
                                            ->  Seq Scan on tournaments_round  (cost=0.00..4.71 rows=171 width=10) (actual time=0.004..0.029 rows=171 loops=1)
                                ->  Hash  (cost=50.05..50.05 rows=131 width=4) (actual time=0.424..0.424 rows=171 loops=1)
                                      Buckets: 1024  Batches: 1  Memory Usage: 15kB
                                      ->  Hash Join  (cost=11.35..50.05 rows=131 width=4) (actual time=0.054..0.406 rows=171 loops=1)
                                            Hash Cond: (u0.team_id = u1.id)
                                            ->  Seq Scan on participants_speaker u0  (cost=0.00..32.92 rows=2192 width=8) (actual time=0.008..0.141 rows=2192 loops=1)
                                            ->  Hash  (cost=10.64..10.64 rows=57 width=4) (actual time=0.036..0.037 rows=57 loops=1)
                                                  Buckets: 1024  Batches: 1  Memory Usage: 11kB
                                                  ->  Index Scan using participants_team_tournament_id_013c7939 on participants_team u1  (cost=0.15..10.64 rows=57 width=4) (actual time=0.011..0.026 rows=57 loops=1)
                                                        Index Cond: (tournament_id = 1)
```
</details>
<details>
<summary>EXPLAIN with filter (speakers)</summary>

```
WindowAgg  (cost=620.13..621.53 rows=70 width=110) (actual time=14.656..14.756 rows=171 loops=1)
  ->  Sort  (cost=620.13..620.30 rows=70 width=102) (actual time=14.652..14.661 rows=171 loops=1)
        Sort Key: (CASE WHEN (count(results_speakerscore.score) FILTER (WHERE (results_ballotsubmission.confirmed AND (tournaments_round.seq <= 14) AND ((tournaments_round.stage)::text = 'P'::text) AND (NOT results_speakerscore.ghost) AND (results_speakerscore."position" <= 3))) >= 6) THEN avg(results_speakerscore.score) FILTER (WHERE (results_ballotsubmission.confirmed AND (tournaments_round.seq <= 14) AND ((tournaments_round.stage)::text = 'P'::text) AND (NOT results_speakerscore.ghost) AND (results_speakerscore."position" <= 3))) ELSE NULL::double precision END)
        Sort Method: quicksort  Memory: 61kB
        ->  WindowAgg  (cost=616.58..617.98 rows=70 width=102) (actual time=14.455..14.564 rows=171 loops=1)
              ->  Sort  (cost=616.58..616.76 rows=70 width=94) (actual time=14.441..14.450 rows=171 loops=1)
                    Sort Key: (CASE WHEN (count(results_speakerscore.score) FILTER (WHERE (results_ballotsubmission.confirmed AND (tournaments_round.seq <= 14) AND ((tournaments_round.stage)::text = 'P'::text) AND (NOT results_speakerscore.ghost) AND (results_speakerscore."position" <= 3))) >= 6) THEN avg(results_speakerscore.score) FILTER (WHERE (results_ballotsubmission.confirmed AND (tournaments_round.seq <= 14) AND ((tournaments_round.stage)::text = 'P'::text) AND (NOT results_speakerscore.ghost) AND (results_speakerscore."position" <= 3))) ELSE NULL::double precision END) DESC NULLS LAST
                    Sort Method: quicksort  Memory: 57kB
                    ->  GroupAggregate  (cost=611.29..614.44 rows=70 width=94) (actual time=12.743..14.355 rows=171 loops=1)
                          Group Key: participants_person.id, participants_speaker.person_ptr_id
                          ->  Sort  (cost=611.29..611.46 rows=70 width=82) (actual time=12.699..12.886 rows=5483 loops=1)
                                Sort Key: participants_person.id
                                Sort Method: quicksort  Memory: 1081kB
                                ->  Hash Semi Join  (cost=369.64..609.14 rows=70 width=82) (actual time=3.014..10.631 rows=5483 loops=1)
                                      Hash Cond: (participants_speaker.person_ptr_id = u0.person_ptr_id)
                                      ->  Hash Left Join  (cost=317.95..553.60 rows=1173 width=82) (actual time=2.504..9.170 rows=5483 loops=1)
                                            Hash Cond: (draw_debate.round_id = tournaments_round.id)
                                            ->  Hash Left Join  (cost=311.11..543.59 rows=1173 width=80) (actual time=2.437..8.134 rows=5483 loops=1)
                                                  Hash Cond: (draw_debateteam.debate_id = draw_debate.id)
                                                  ->  Hash Left Join  (cost=253.46..482.85 rows=1173 width=80) (actual time=1.943..6.488 rows=5483 loops=1)
                                                        Hash Cond: (results_speakerscore.debate_team_id = draw_debateteam.id)
                                                        ->  Hash Left Join  (cost=103.28..329.60 rows=1173 width=80) (actual time=0.800..4.258 rows=5483 loops=1)
                                                              Hash Cond: (results_speakerscore.ballot_submission_id = results_ballotsubmission.id)
                                                              ->  Nested Loop Left Join  (cost=11.92..235.16 rows=1173 width=83) (actual time=0.071..2.466 rows=5483 loops=1)
                                                                    ->  Nested Loop  (cost=11.63..101.45 rows=131 width=62) (actual time=0.060..0.725 rows=171 loops=1)
                                                                          ->  Hash Join  (cost=11.35..50.05 rows=131 width=8) (actual time=0.035..0.374 rows=171 loops=1)
                                                                                Hash Cond: (participants_speaker.team_id = participants_team.id)
                                                                                ->  Seq Scan on participants_speaker  (cost=0.00..32.92 rows=2192 width=8) (actual time=0.004..0.127 rows=2192 loops=1)
                                                                                ->  Hash  (cost=10.64..10.64 rows=57 width=4) (actual time=0.023..0.023 rows=57 loops=1)
                                                                                      Buckets: 1024  Batches: 1  Memory Usage: 11kB
                                                                                      ->  Index Scan using participants_team_tournament_id_013c7939 on participants_team  (cost=0.15..10.64 rows=57 width=4) (actual time=0.005..0.013 rows=57 loops=1)
                                                                                            Index Cond: (tournament_id = 1)
                                                                          ->  Index Scan using participants_person_pkey on participants_person  (cost=0.28..0.39 rows=1 width=54) (actual time=0.002..0.002 rows=1 loops=171)
                                                                                Index Cond: (id = participants_speaker.person_ptr_id)
                                                                    ->  Index Scan using results_speakerscore_speaker_id_f2627efc on results_speakerscore  (cost=0.29..0.91 rows=11 width=25) (actual time=0.001..0.006 rows=32 loops=171)
                                                                          Index Cond: (speaker_id = participants_speaker.person_ptr_id)
                                                              ->  Hash  (cost=58.94..58.94 rows=2594 width=5) (actual time=0.715..0.715 rows=2595 loops=1)
                                                                    Buckets: 4096  Batches: 1  Memory Usage: 134kB
                                                                    ->  Seq Scan on results_ballotsubmission  (cost=0.00..58.94 rows=2594 width=5) (actual time=0.007..0.404 rows=2595 loops=1)
                                                        ->  Hash  (cost=93.41..93.41 rows=4541 width=8) (actual time=1.131..1.131 rows=4446 loops=1)
                                                              Buckets: 8192  Batches: 1  Memory Usage: 238kB
                                                              ->  Seq Scan on draw_debateteam  (cost=0.00..93.41 rows=4541 width=8) (actual time=0.004..0.609 rows=4446 loops=1)
                                                  ->  Hash  (cost=38.40..38.40 rows=1540 width=8) (actual time=0.482..0.482 rows=1540 loops=1)
                                                        Buckets: 2048  Batches: 1  Memory Usage: 77kB
                                                        ->  Seq Scan on draw_debate  (cost=0.00..38.40 rows=1540 width=8) (actual time=0.007..0.303 rows=1540 loops=1)
                                            ->  Hash  (cost=4.71..4.71 rows=171 width=10) (actual time=0.061..0.061 rows=171 loops=1)
                                                  Buckets: 1024  Batches: 1  Memory Usage: 16kB
                                                  ->  Seq Scan on tournaments_round  (cost=0.00..4.71 rows=171 width=10) (actual time=0.005..0.033 rows=171 loops=1)
                                      ->  Hash  (cost=50.05..50.05 rows=131 width=4) (actual time=0.499..0.499 rows=171 loops=1)
                                            Buckets: 1024  Batches: 1  Memory Usage: 15kB
                                            ->  Hash Join  (cost=11.35..50.05 rows=131 width=4) (actual time=0.063..0.478 rows=171 loops=1)
                                                  Hash Cond: (u0.team_id = u1.id)
                                                  ->  Seq Scan on participants_speaker u0  (cost=0.00..32.92 rows=2192 width=8) (actual time=0.009..0.170 rows=2192 loops=1)
                                                  ->  Hash  (cost=10.64..10.64 rows=57 width=4) (actual time=0.042..0.042 rows=57 loops=1)
                                                        Buckets: 1024  Batches: 1  Memory Usage: 11kB
                                                        ->  Index Scan using participants_team_tournament_id_013c7939 on participants_team u1  (cost=0.15..10.64 rows=57 width=4) (actual time=0.012..0.030 rows=57 loops=1)
                                                              Index Cond: (tournament_id = 1)
```
</details>
