### PR TITLE
API: Create /me endpoint

### DIFF
--- a/tabbycat/api/fields.py
+++ b/tabbycat/api/fields.py
@@ -271,6 +271,12 @@ class BaseSourceField(TournamentHyperlinkedRelatedField):
         except self.model.DoesNotExist:
             self.fail('does_not_exist')
 
+    def get_url_options(self, value, format):
+        for view_name, (model, field) in self.models.items():
+            obj = getattr(value, model.__name__.lower(), None)
+            if obj is not None:
+                return self.get_url(obj, view_name, self.context['request'], format)
+
 
 class ParticipantSourceField(BaseSourceField):
     field_source_name = 'participant_submitter'

--- a/tabbycat/api/serializers.py
+++ b/tabbycat/api/serializers.py
@@ -23,7 +23,7 @@ from motions.models import DebateTeamMotionPreference, Motion, RoundMotion
 from options.preferences import (BPAssignmentMethod, BPPositionCost, BPPullupDistribution, DrawAvoidConflicts,
     DrawOddBracket, DrawPairingMethod, DrawPullupRestriction, DrawSideAllocations)
 from participants.emoji import pick_unused_emoji
-from participants.models import Adjudicator, Institution, Region, Speaker, SpeakerCategory, Team
+from participants.models import Adjudicator, Institution, Person, Region, Speaker, SpeakerCategory, Team
 from participants.utils import populate_code_names
 from privateurls.utils import populate_url_keys
 from results.models import BallotSubmission, ScoreCriterion, SpeakerScore, Submission, TeamScore
@@ -1604,3 +1604,18 @@ class ScoreCriterionSerializer(serializers.ModelSerializer):
     class Meta:
         model = ScoreCriterion
         exclude = ('tournament',)
+
+
+class ParticipantIdentificationSerializer(serializers.ModelSerializer):
+    class ParticipantIdField(fields.BaseSourceField):
+        field_source_name = 'pk'
+        models = {
+            'api-speaker-detail': (Speaker, 'pk'),
+            'api-adjudicator-detail': (Adjudicator, 'pk'),
+        }
+
+    url = ParticipantIdField()
+
+    class Meta:
+        model = Person
+        fields = '__all__'

--- a/tabbycat/api/urls.py
+++ b/tabbycat/api/urls.py
@@ -246,6 +246,10 @@ urlpatterns = [
                         name='api-group-detail'),
                 ])),
 
+                path('/me',
+                    views.ParticipantIdentificationView.as_view({'get': 'retrieve'}),
+                    name='api-tournament-detail'),
+
                 path('/', include(pref_router.urls)),  # Preferences
             ])),
         ])),

--- a/tabbycat/api/views.py
+++ b/tabbycat/api/views.py
@@ -1417,3 +1417,11 @@ class GroupViewSet(TournamentAPIMixin, AdministratorAPIMixin, ModelViewSet):
 )
 class ScoreCriterionViewSet(TournamentAPIMixin, PublicAPIMixin, ModelViewSet):
     serializer_class = serializers.ScoreCriterionSerializer
+
+
+class ParticipantIdentificationView(TournamentAPIMixin, ModelViewSet):
+    serializer_class = serializers.ParticipantIdentificationSerializer
+    authentication_classes = [URLKeyAuthentication]
+
+    def get_object(self):
+        return self.request.auth


### PR DESCRIPTION
This new endpoint will allow participants to identify themselves through their private URL key. With this endpoint, API users can ask for private URLs and find data relating to them through subsequent API calls.

This uses the URL key authentication scheme to give the relevant data.