### PR TITLE
API: Fix adjudicator feedback creation

### DIFF
--- a/tabbycat/api/serializers.py
+++ b/tabbycat/api/serializers.py
@@ -1136,7 +1136,7 @@ class FeedbackSerializer(serializers.ModelSerializer):
     url = fields.AdjudicatorFeedbackIdentityField(view_name='api-feedback-detail')
     adjudicator = fields.TournamentHyperlinkedRelatedField(view_name='api-adjudicator-detail', queryset=Adjudicator.objects.all())
     source = SubmitterSourceField(source='*')
-    participant_submitter = fields.ParticipantSourceField(allow_null=True)
+    participant_submitter = fields.ParticipantSourceField(allow_null=True, required=False)
     debate = DebateHyperlinkedRelatedField(view_name='api-pairing-detail', queryset=Debate.objects.all(), lookup_url_kwarg='debate_pk')
     answers = FeedbackAnswerSerializer(many=True, source='get_answers', required=False)
 
@@ -1158,7 +1158,7 @@ class FeedbackSerializer(serializers.ModelSerializer):
         debate = data.pop('debate')
 
         source_type = 'from_team' if isinstance(source, Team) else 'from_adj'
-        required_questions = self.context['tournament'].adjudicatorfeedbackquestion_set.filter(required=True, **{source_type: True})
+        required_questions = AdjudicatorFeedbackQuestion.objects.filter(tournament=self.context['tournament'], required=True, **{source_type: True})
         answers = data.get('get_answers', [])
 
         if len(set(required_questions) - set(a['question'] for a in answers)) > 0:

--- a/tabbycat/api/views.py
+++ b/tabbycat/api/views.py
@@ -669,10 +669,10 @@ class BaseCheckinsView(AdministratorAPIMixin, TournamentAPIMixin, APIView):
 class PersonCheckinMixin:
     class CustomPermission(BasePermission):
         def has_permission(self, request, view):
-            return request.user is None or view.tournament.pref('participant_ballots') == 'private-urls' and view.participant_requester and request.method != 'POST'
+            return (view.tournament.pref('public_checkins_submit') == 'private-urls' and view.participant_requester) or request.method != 'POST'
 
     authentication_classes = [TokenAuthentication, SessionAuthentication, URLKeyAuthentication]
-    permission_classes = [APIEnabledPermission, PerTournamentPermissionRequired, CustomPermission]
+    permission_classes = [APIEnabledPermission, PerTournamentPermissionRequired | CustomPermission]
 
     @property
     def participant_requester(self):
@@ -1009,7 +1009,7 @@ class BallotViewSet(RoundAPIMixin, TournamentPublicAPIMixin, ModelViewSet):
 
     class CustomPermission(BasePermission):
         def has_permission(self, request, view):
-            return request.user is None or (
+            return (
                 (view.action in ['list', 'retrieve', 'create'] and view.tournament.pref('participant_ballots') == 'private-urls' and view.participant_requester) or
                 (view.action == 'create' and view.tournament.pref('participant_ballots') == 'public') or
                 (view.action in ['list', 'retrieve'] and view.tournament.pref('private_ballots_released') is True)
@@ -1022,7 +1022,7 @@ class BallotViewSet(RoundAPIMixin, TournamentPublicAPIMixin, ModelViewSet):
     round_field = 'debate__round'
 
     authentication_classes = [TokenAuthentication, SessionAuthentication, URLKeyAuthentication]
-    permission_classes = [APIEnabledPermission, PerTournamentPermissionRequired, PublicPreferencePermission | CustomPermission]
+    permission_classes = [APIEnabledPermission, PerTournamentPermissionRequired | PublicPreferencePermission | CustomPermission]
 
     list_permission = Permission.VIEW_BALLOTSUBMISSIONS
     create_permission = Permission.ADD_BALLOTSUBMISSIONS
@@ -1136,7 +1136,7 @@ class FeedbackViewSet(TournamentAPIMixin, AdministratorAPIMixin, ModelViewSet):
 
     class CustomPermission(BasePermission):
         def has_permission(self, request, view):
-            return request.user is None or (
+            return (
                 (view.action in ['list', 'retrieve', 'create'] and view.tournament.pref('participant_feedback') == 'private-urls' and view.participant_requester) or
                 (view.action == 'create' and view.tournament.pref('participant_feedback') == 'public')
             )
@@ -1147,7 +1147,7 @@ class FeedbackViewSet(TournamentAPIMixin, AdministratorAPIMixin, ModelViewSet):
     action_log_type_updated = ActionLogEntry.ActionType.FEEDBACK_SAVE
 
     authentication_classes = [TokenAuthentication, SessionAuthentication, URLKeyAuthentication]
-    permission_classes = [APIEnabledPermission, PerTournamentPermissionRequired, CustomPermission]
+    permission_classes = [APIEnabledPermission, PerTournamentPermissionRequired | CustomPermission]
 
     list_permission = Permission.VIEW_FEEDBACK
     create_permission = Permission.ADD_FEEDBACK


### PR DESCRIPTION
Due to the split between Question and AdjudicatorFeedbackQuestion, the related manager no longer exists and broke creation.

This commit also adds tests and fixes permissions.