### PR TITLE
Add success message to Invite User form

### DIFF
--- a/tabbycat/users/forms.py
+++ b/tabbycat/users/forms.py
@@ -2,6 +2,7 @@ from django import forms
 from django.contrib.auth import get_user_model
 from django.contrib.auth.forms import PasswordResetForm, SetPasswordForm, UserCreationForm, UsernameField
 from django.utils.translation import gettext_lazy as _
+from users.models import Membership # added 14/5/25 to allow for group membership in the InviteUserForm
 
 
 class SuperuserCreationForm(UserCreationForm):
@@ -34,12 +35,21 @@ class InviteUserForm(PasswordResetForm):
                 'username': email.split("@")[0],
             },
         )
-        user.membership_set.add(group=self.cleaned_data['role'])
+        Membership.objects.get_or_create(
+            user=user,
+            group=self.cleaned_data['role'],
+        )
+
         return [user]
 
+
     def save(self, *args, **kwargs):
-        kwargs['extra_email_context'] = {**(kwargs['extra_email_context'] or {}), 'tournament': self.tournament}
+        kwargs['extra_email_context'] = {
+            **(kwargs.get('extra_email_context') or {}),
+            'tournament': self.tournament,
+        }
         return super().save(*args, **kwargs)
+
 
 
 class AcceptInvitationForm(SetPasswordForm):

--- a/tabbycat/users/views.py
+++ b/tabbycat/users/views.py
@@ -79,6 +79,16 @@ class InviteUserView(LogActionMixin, AdministratorMixin, TournamentMixin, Passwo
     def get_success_url(self):
         return reverse_tournament('options-tournament-index', self.tournament)
 
+    def form_valid(self, form):
+        form.save(
+            domain_override=self.request.get_host(),
+            use_https=self.request.is_secure(),
+            request=self.request,
+        )
+        messages.success(self.request, "Successfully invited user to create an account for the tournament.")
+        return super().form_valid(form)
+
+
 
 class AcceptInvitationView(TournamentMixin, PasswordResetConfirmView):
     form_class = AcceptInvitationForm


### PR DESCRIPTION
This PR adds a success message to the Invite User flow and made amendments in response to two issues that arose during local testing, one of which required a small adjustment to the form logic.

### Summary of changes

1. In tabbycat/users/views.py > InviteUserView, added a form_valid method to display a success message when a new user is invited, using Django's messages framework.

2. When testing locally, two errors were encountered:

**a) TypeError when attempting to use .add(group=...)**

The original get_users method in tabbycat/users/forms.py > InviteUserForm included the line:

`user.membership_set.add(group=self.cleaned_data['role'])`

However, Django's RelatedManager.add() method expects one or more instances of the related model (Membership), not keyword arguments. Attempting to pass group= raised a TypeError.

To resolve this, I replaced that line with:

```
Membership.objects.get_or_create(
    user=user,
    group=self.cleaned_data['role'],
)
```

This change ensures the user's group membership is correctly created (or reused if it already exists), without changing the intended behaviour. 

**b) KeyError: 'extra_email_context'**

This occurred when calling form.save() within the new form_valid() method. The original save() in InviteUserForm attempted to access:

`kwargs['extra_email_context']`

without checking whether this key was present in kwargs, which led to the KeyError.

We resolved this by updating that line to safely retrieve the context using kwargs.get():

```
kwargs['extra_email_context'] = {
    **(kwargs.get('extra_email_context') or {}),
    'tournament': self.tournament,
}
```

This ensures that even if extra_email_context wasn't passed in, the assignment still works with a fallback empty dictionary.

No other parts of the system were affected or altered.

Let me know if anything needs adjusting — happy to tweak based on reviewer feedback.