### PR TITLE
Turn off redis certificate verification

### DIFF
--- a/tabbycat/settings/heroku.py
+++ b/tabbycat/settings/heroku.py
@@ -87,7 +87,10 @@ CHANNEL_LAYERS = {
     "default": {
         "BACKEND": "channels_redis.core.RedisChannelLayer",
         "CONFIG": {
-            "hosts": [environ.get('REDIS_URL')],
+            "hosts": [{
+                "address": environ.get('REDIS_URL'),
+                "ssl_cert_reqs": None,
+            }],
             # Remove channels from groups after 3 hours
             # This matches websocket_timeout in Daphne
             "group_expiry": 10800,


### PR DESCRIPTION
Hi,

From my current understanding of the problem, Heroku's Key-Value Store uses self-signed certificates, and redis attempt to verify certificate results in an error. This issue was raised previously (#1841). 

It was recommended (both on Heroku and channels_redis pages) to disable redis cert verification.

As I have been facing this error on my heroku installation, I assume the error is happening on any tabbycat heroku installation (at least since commit 0728fc5).

**This PR** resolves the issue by turning off redis cert verification.

Reference:
[Heroku key value store connection issues](https://help.heroku.com/HC0F8CUS/heroku-key-value-store-connection-issues)
[django instruction on channels_redis](https://github.com/django/channels_redis?tab=readme-ov-file#hosts)


PS: Heroku [official help page](https://devcenter.heroku.com/articles/connecting-heroku-redis#using-django-redis) provide solution for `django_redis` module which is either outdated or simply incorrect and must not be used. 