### PR TITLE
Remove redundant permissions

### DIFF
--- a/tabbycat/adjfeedback/views.py
+++ b/tabbycat/adjfeedback/views.py
@@ -795,7 +795,7 @@ class IgnoreFeedbackView(BaseFeedbackToggleView):
 class UpdateAdjudicatorScoresView(AdministratorMixin, LogActionMixin, TournamentMixin, FormView):
     template_name = 'update_adjudicator_scores.html'
     form_class = UpdateAdjudicatorScoresForm
-    edit_permission = Permission.EDIT_JUDGESCORES_BULK
+    edit_permission = Permission.EDIT_BASEJUDGESCORES_IND
     action_log_type = ActionLogEntry.ActionType.UPDATE_ADJUDICATOR_SCORES
 
     def get_context_data(self, **kwargs):

--- a/tabbycat/api/views.py
+++ b/tabbycat/api/views.py
@@ -136,8 +136,8 @@ class TournamentPreferenceViewSet(TournamentFromUrlMixin, AdministratorAPIMixin,
     queryset = TournamentPreferenceModel.objects.all()
     serializer_class = PreferenceSerializer
 
-    list_permission = Permission.VIEW_TOURNAMENTPREFERENCEMODEL
-    update_permission = Permission.EDIT_TOURNAMENTPREFERENCEMODEL
+    list_permission = Permission.VIEW_SETTINGS
+    update_permission = Permission.EDIT_SETTINGS
 
     action_log_content_object_attr = 'obj'
     action_log_type_updated = ActionLogEntry.ActionType.OPTIONS_EDIT
@@ -967,7 +967,7 @@ class TeamRoundStandingsRoundsView(TournamentAPIMixin, TournamentPublicAPIMixin,
 )
 class PairingViewSet(RoundAPIMixin, ModelViewSet):
 
-    class Permission(PublicPreferencePermission):
+    class CustomPermission(PublicPreferencePermission):
         def get_tournament_preference(self, view, op):
             t = view.tournament
             r = view.round
@@ -992,12 +992,12 @@ class PairingViewSet(RoundAPIMixin, ModelViewSet):
     round_released_field = 'draw_status'
     round_released_value = Round.Status.RELEASED
 
-    """list_permission = Permission.VIEW_DEBATE
+    list_permission = Permission.VIEW_DEBATE
     create_permission = Permission.GENERATE_DEBATE
-    update_permission = Permission.GENERATE_DEBATE
-    destroy_permission = Permission.GENERATE_DEBATE"""
+    # update_permission = Permission.EDIT_DEBATETEAMS
+    destroy_permission = Permission.DELETE_DEBATE
 
-    permission_classes = [APIEnabledPermission, Permission | PerTournamentPermissionRequired]
+    permission_classes = [APIEnabledPermission, CustomPermission | PerTournamentPermissionRequired]
 
     action_log_type_created = ActionLogEntry.ActionType.DEBATE_CREATE
     action_log_type_updated = ActionLogEntry.ActionType.DEBATE_EDIT

--- a/tabbycat/privateurls/views.py
+++ b/tabbycat/privateurls/views.py
@@ -152,8 +152,6 @@ class GenerateRandomisedUrlsView(AdministratorMixin, TournamentMixin, PostOnlyRe
 
 class EmailRandomisedUrlsView(RoleColumnMixin, TournamentTemplateEmailCreateView):
     page_subtitle = _("Private URLs")
-    view_permission = Permission.VIEW_PRIVATE_URLS_EMAIL_LIST
-    edit_permission = Permission.SEND_PRIVATE_URLS
     event = BulkNotification.EventType.URL
     subject_template = 'url_email_subject'
     message_template = 'url_email_message'

--- a/tabbycat/users/groups.py
+++ b/tabbycat/users/groups.py
@@ -45,7 +45,6 @@ class AdjudicationCore(BaseGroup):
         Permission.EDIT_DEBATEADJUDICATORS,
         Permission.EDIT_FEEDBACK_CONFIRM,
         Permission.EDIT_FEEDBACK_IGNORE,
-        Permission.EDIT_JUDGESCORES_BULK,
         Permission.EDIT_BASEJUDGESCORES_IND,
         Permission.EDIT_MOTION,
         Permission.EDIT_STARTTIME,

--- a/tabbycat/users/permissions.py
+++ b/tabbycat/users/permissions.py
@@ -86,13 +86,9 @@ class Permission(TextChoices):
     UNRELEASE_DRAW = 'unrelease.draw', _("unrelease draw to public")
     UNRELEASE_MOTION = 'unrelease.motion', _("unrelease motion to public")
     EDIT_STARTTIME = 'edit.starttime', _("add debate start time")
-    VIEW_DRAW = 'view.draw', _("view draws")
 
     VIEW_BRIEFING_DRAW = 'view.briefingdraw', _("view draws (for the briefing room)")
     DISPLAY_MOTION = 'display.motion', _("display motion (for the briefing room)")
-
-    VIEW_TOURNAMENTPREFERENCEMODEL = 'view.tournamentpreferencemodel', _("view tournament configuration")
-    EDIT_TOURNAMENTPREFERENCEMODEL = 'edit.tournamentpreferencemodel', _("edit tournament configuration")
 
     VIEW_PREFORMEDPANELS = 'view.preformedpanels', _("view existing preformed panels")
     EDIT_PREFORMEDPANELS = 'edit.preformedpanels', _("edit preformed panels")
@@ -107,7 +103,6 @@ class Permission(TextChoices):
 
     # Feedback tab
     VIEW_FEEDBACK_OVERVIEW = 'view.feedbackoverview', _("view overview of judge feedback")
-    EDIT_JUDGESCORES_BULK = 'edit.judgescoresbulk', _("bulk update judge scores")
     EDIT_BASEJUDGESCORES_IND = 'edit.judgescoresind', _("edit base scores of judges")
     VIEW_FEEDBACK = 'view.feedback', _("view feedback")
     EDIT_FEEDBACK_IGNORE = 'edit.feedbackignore', _("toggle ignore feedback")
@@ -116,8 +111,6 @@ class Permission(TextChoices):
     ADD_FEEDBACK = 'add.feedback', _("add feedback")
     VIEW_ADJ_BREAK = 'view.adj.break', _("view adjudicator break")
     EDIT_ADJ_BREAK = 'edit.adj.break', _("edit adjudicator break")
-    # idk if its possible for them to add feedback everywhere, considering there is add feedback on multiple pages
-
     EDIT_FEEDBACKQUESTION = 'edit.feedbackquestion', _("edit feedback questions")
 
     # breaks
@@ -134,10 +127,7 @@ class Permission(TextChoices):
     GENERATE_BREAK = 'generate.break', _("generate all breaks")
 
     VIEW_PRIVATE_URLS = 'view.privateurls', _("view private urls")
-    VIEW_PRIVATE_URLS_EMAIL_LIST = 'view.privateurls.emaillist', _("view private urls email list")
     GENERATE_PRIVATE_URLS = 'generate.privateurls', _("generate private URLs")
-    # need to get rid of generate private urls soons
-    SEND_PRIVATE_URLS = 'send.privateurls', _("send private URLs")
 
     VIEW_CHECKIN = 'view.checkin', _("view checkins")
     EDIT_PARTICIPANT_CHECKIN = 'edit.participantcheckin', _("edit participant check-in")


### PR DESCRIPTION
This commit removes some permissions in order to streamline some capabilities, and fixes the permissions checks for API pairings.