### PR TITLE
Add schedule to public page

### DIFF
--- a/tabbycat/options/preferences.py
+++ b/tabbycat/options/preferences.py
@@ -17,7 +17,6 @@ from .models import tournament_preferences_registry
 from .types import MultiValueChoicePreference
 from .utils import validate_metric_duplicates
 
-
 # ==============================================================================
 scoring = Section('scoring', verbose_name=_("Score Rules"))
 # ==============================================================================
@@ -1179,6 +1178,15 @@ class FeedbackProgress(BooleanPreference):
     verbose_name = _("Enable public view of unsubmitted feedback")
     section = public_features
     name = 'feedback_progress'
+    default = False
+
+
+@tournament_preferences_registry.register
+class PublicSchedule(BooleanPreference):
+    help_text = _("Enables the public page showing the schedule")
+    verbose_name = _("Enable public view of shedule")
+    section = public_features
+    name = 'public_schedule'
     default = False
 
 

--- a/tabbycat/templates/nav/admin_nav.html
+++ b/tabbycat/templates/nav/admin_nav.html
@@ -84,6 +84,10 @@
          class="list-group-item" data-parent="#setuph}">
         <span class="circle-icon small-circle"></span><i data-feather="link"></i>{% trans "Private URLs" %}
       </a>
+      <a href="{% tournamenturl 'tournament-set-schedule' %}"
+         class="list-group-item" data-parent="#setuph">
+        <span class="circle-icon small-circle"></span><i data-feather="clock"></i>{% trans "Schedule" %}
+      </a>
       <a href="{% tournamenturl 'notifications-status' %}"
          class="list-group-item" data-parent="#setuph">
         <span class="circle-icon small-circle"></span><i data-feather="mail"></i>{% trans "Emails" %}

--- a/tabbycat/templates/nav/public_nav.html
+++ b/tabbycat/templates/nav/public_nav.html
@@ -185,6 +185,11 @@
     <a class="nav-link" href="{% tournamenturl 'public_feedback_progress' %}">{% trans "Feedback Progress" %}</a>
   </li>
 {% endif %}
+{% if pref.public_schedule %}
+<li class="nav-item {% if schedule_nav %}active{% endif %}">
+  <a class="nav-link" href="{% tournamenturl 'tournament-public-schedule' %}">{% trans "Schedule" %}</a>
+</li>
+{% endif %}
 {% if pref.participant_ballots == 'public' %}
   {% if tournament.current_rounds|length == 1 %}
     <li class="nav-item {% if enter_ballots_nav %}active{% endif %}">

--- a/tabbycat/tournaments/forms.py
+++ b/tabbycat/tournaments/forms.py
@@ -1,6 +1,6 @@
 from django.contrib.contenttypes.models import ContentType
 from django.core.cache import cache
-from django.forms import CharField, ChoiceField, Form, ModelChoiceField, ModelForm
+from django.forms import CharField, ChoiceField, DateTimeInput, Form, HiddenInput, ModelChoiceField, ModelForm
 from django.forms.fields import IntegerField, NumberInput
 from django.forms.models import ModelChoiceIterator
 from django.utils.html import escape
@@ -16,7 +16,7 @@ from options.presets import all_presets, data_entry_presets_for_form, presets_fo
 from users.groups import all_groups
 from users.models import Group
 
-from .models import Round, Tournament
+from .models import Round, ScheduleEvent, Tournament
 from .signals import update_tournament_cache
 from .utils import auto_make_rounds
 
@@ -295,3 +295,20 @@ class RoundWeightForm(Form):
         Round.objects.bulk_update(rounds, ['weight'])
 
         return rounds
+
+
+class ScheduleEventForm(ModelForm):
+
+    def __init__(self, tournament, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields['tournament'].initial = tournament
+        self.fields['round'].queryset = tournament.round_set.all()
+
+    class Meta:
+        model = ScheduleEvent
+        fields = ('tournament', 'type', 'title', 'start_time', 'end_time', 'round')
+        widgets = {
+            'tournament': HiddenInput(),
+            'start_time': DateTimeInput(attrs={'type': 'datetime-local'}),
+            'end_time':   DateTimeInput(attrs={'type': 'datetime-local'}),
+        }

--- a/tabbycat/tournaments/templates/public_tournament_index.html
+++ b/tabbycat/tournaments/templates/public_tournament_index.html
@@ -117,6 +117,12 @@
           {% endif %}
         {% endif %}
 
+        {% if pref.public_schedule %}
+          {% trans "Schedule" as text %}
+          {% tournamenturl 'tournament-public-schedule' as url %}
+          {% include "components/item-action.html" with icon="clock" %}
+        {% endif %}
+
         {% if pref.public_checkins %}
           {% trans "Check-Ins" as text %}
           {% tournamenturl 'checkins-public-status' as url %}

--- a/tabbycat/tournaments/templates/public_tournament_schedule.html
+++ b/tabbycat/tournaments/templates/public_tournament_schedule.html
@@ -1,0 +1,12 @@
+{% extends 'tables/base_vue_table.html' %}
+{% load i18n %}
+
+{% block content %}
+{% blocktrans trimmed asvar p1 %}
+Schedule is in time zone: {{ schedule_timezone_label }}
+{% endblocktrans %}
+{% include "components/explainer-card.html" with type="info" %}
+
+
+{{ block.super }}
+{% endblock %}

--- a/tabbycat/tournaments/templates/tournament_schedule_edit.html
+++ b/tabbycat/tournaments/templates/tournament_schedule_edit.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+{% load add_field_css debate_tags i18n %}
+
+{% block head-title %}<span class="emoji">⌛</span> {% trans "Schedule" %}{% endblock %}
+{% block page-title %}⌛{% trans "Schedule" %}{% endblock %}
+
+{% block content %}
+
+{% blocktrans trimmed asvar p1 %}
+This page allows you to set the public schedule for the tournament.
+{% endblocktrans %}
+
+
+
+{% include "components/explainer-card.html" with type="info" %}
+
+{% trans "Save Schedule" as save_text %}
+{% include "components/formset.html" with quadruple=True %}
+
+{% endblock content %}

--- a/tabbycat/tournaments/urls.py
+++ b/tabbycat/tournaments/urls.py
@@ -27,6 +27,9 @@ urlpatterns = [
     path('tab/',                    include('standings.urls_public')),
     path('registration/',           include('registration.urls_public')),
 
+    # Public Schedule
+    path('schedule/',               views.PublicScheduleView.as_view(), name='tournament-public-schedule'),
+
     # Application URLs for admin pages
     path('admin/allocations/',      include('adjallocation.urls')),
     path('admin/availability/',     include('availability.urls')),
@@ -80,4 +83,7 @@ urlpatterns = [
     path('admin/fix-debate-teams/',
         views.FixDebateTeamsView.as_view(),
         name='tournament-fix-debate-teams'),
+    path('admin/schedule/',
+        views.SetTournamentScheduleView.as_view(),
+        name='tournament-set-schedule'),
 ]

--- a/tabbycat/tournaments/views.py
+++ b/tabbycat/tournaments/views.py
@@ -8,6 +8,7 @@ from django.contrib.auth import get_user_model
 from django.db.models import Count, Q
 from django.shortcuts import redirect, resolve_url
 from django.utils.html import format_html_join
+from django.utils.timezone import get_current_timezone_name
 from django.utils.translation import gettext_lazy as _
 from django.views.generic.base import TemplateView
 from django.views.generic.edit import CreateView, FormView, UpdateView
@@ -23,13 +24,14 @@ from users.permissions import has_permission, Permission
 from utils.misc import redirect_round, redirect_tournament, reverse_round, reverse_tournament
 from utils.mixins import (AdministratorMixin, AssistantMixin, CacheMixin, TabbycatPageTitlesMixin,
                           WarnAboutDatabaseUseMixin, WarnAboutLegacySendgridConfigVarsMixin)
-from utils.views import PostOnlyRedirectView
+from utils.tables import TabbycatTableBuilder
+from utils.views import ModelFormSetView, PostOnlyRedirectView, VueTableTemplateView
 
-from .forms import (RoundWeightForm, SetCurrentRoundMultipleBreakCategoriesForm,
+from .forms import (RoundWeightForm, ScheduleEventForm, SetCurrentRoundMultipleBreakCategoriesForm,
                     SetCurrentRoundSingleBreakCategoryForm, TournamentConfigureForm,
                     TournamentStartForm)
-from .mixins import RoundMixin, TournamentMixin
-from .models import Tournament
+from .mixins import PublicTournamentPageMixin, RoundMixin, TournamentMixin
+from .models import ScheduleEvent, Tournament
 from .utils import get_side_name
 
 User = get_user_model()
@@ -369,3 +371,85 @@ class FixDebateTeamsView(AdministratorMixin, TournamentMixin, TemplateView):
 class StyleGuideView(TemplateView, TabbycatPageTitlesMixin):
     template_name = 'admin/style_guide.html'
     page_subtitle = 'Contextual sub title'
+
+
+class SetTournamentScheduleView(AdministratorMixin, TournamentMixin, ModelFormSetView):
+    template_name = 'tournament_schedule_edit.html'
+    formset_model = ScheduleEvent
+    form_class = ScheduleEventForm
+
+    edit_permission = Permission.EDIT_EVENTS
+    view_permission = Permission.VIEW_EVENTS
+
+    def get_formset_factory_kwargs(self):
+        can_edit = has_permission(self.request.user, self.get_edit_permission(), self.tournament)
+        kwargs = super().get_formset_factory_kwargs()
+        kwargs.update({
+            'form': self.form_class,
+            'extra': 3 * int(can_edit),
+            'can_delete': can_edit,
+        })
+        return kwargs
+
+    def get_formset_kwargs(self):
+        kwargs = super().get_formset_kwargs()
+        kwargs.update({
+            'form_kwargs': {'tournament': self.tournament},
+        })
+        return kwargs
+
+    def get_formset(self):
+        formset = super().get_formset()
+        if not has_permission(self.request.user, self.get_edit_permission(), self.tournament):
+            for form in formset:
+                for field in form.fields.values():
+                    field.disabled = True
+        return formset
+
+    def get_formset_queryset(self):
+        return self.tournament.scheduleevent_set.all()
+
+    def formset_valid(self, formset):
+        instances = formset.save(commit=False)
+        for ev in instances:
+            ev.tournament = self.tournament
+            ev.save()
+
+        deleted = formset.deleted_objects
+        for ev in deleted:
+            ev.delete()
+
+        nsaved = len(instances)
+        ndeleted = len(deleted)
+        messages.success(
+            self.request,
+            f"Saved {nsaved} event(s), deleted {ndeleted}.",
+        )
+
+        if "add_more" in self.request.POST:
+            return redirect_tournament(self.same_view, self.tournament)
+
+        return super().formset_valid(formset)
+
+    def get_success_url(self):
+        return reverse_tournament('tournament-set-schedule', self.tournament)
+
+
+class PublicScheduleView(PublicTournamentPageMixin, VueTableTemplateView):
+    template_name = 'public_tournament_schedule.html'
+    cache_timeout = settings.PUBLIC_SLOW_CACHE_TIMEOUT
+    public_page_preference = 'public_schedule'
+    page_title = _("Tournament Schedule")
+    page_emoji = '⏳'
+    cache_timeout = settings.PUBLIC_SLOW_CACHE_TIMEOUT
+
+    def get_table(self):
+        events = self.tournament.scheduleevent_set.all()
+        table = TabbycatTableBuilder(view=self, sort_key='start_time')
+        table.add_schedule_event_columns(events)
+        return table
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['schedule_timezone_label'] = get_current_timezone_name()
+        return context

--- a/tabbycat/users/permissions.py
+++ b/tabbycat/users/permissions.py
@@ -151,6 +151,10 @@ class Permission(TextChoices):
     DELETE_QUESTIONS = 'delete.questions', _("delete general questions")
     VIEW_CUSTOM_ANSWERS = 'view.answers', _("view answers to general questions")
 
+    # Schedule
+    EDIT_EVENTS = 'edit.events', _("edit events")
+    VIEW_EVENTS = 'view.events', _("view events")
+
     VIEW_REGISTRATION = 'view.registration', _("view registration responses")
 
 

--- a/tabbycat/utils/tables.py
+++ b/tabbycat/utils/tables.py
@@ -5,6 +5,7 @@ from django.contrib.auth.models import AnonymousUser
 from django.contrib.humanize.templatetags.humanize import ordinal
 from django.db.models import Exists, OuterRef, Prefetch
 from django.template.loader import render_to_string
+from django.utils import timezone
 from django.utils.encoding import force_str
 from django.utils.html import escape
 from django.utils.safestring import SafeString
@@ -24,7 +25,6 @@ from users.permissions import has_permission, Permission
 from utils.misc import reverse_round, reverse_tournament
 
 from .mixins import AdministratorMixin
-
 logger = logging.getLogger(__name__)
 _draw_flags_dict = dict(DRAW_FLAG_DESCRIPTIONS)
 
@@ -1019,3 +1019,23 @@ class TabbycatTableBuilder(BaseTableBuilder):
                 show_ballots=show_ballots,
             ) for s in standings]
             self.add_column(header, results)
+
+    def add_schedule_event_columns(self, schedule_events):
+        self.add_column({'title': _("Event"), 'key': _("Event")}, [ev.title for ev in schedule_events])
+
+        starts = [
+            timezone.localtime(ev.start_time)
+                    .strftime("%A, %b %d,  %H:%M")
+            for ev in schedule_events
+        ]
+        self.add_column({'title': _("Start Time"), 'key': _("Start Time")}, starts)
+
+        ends = [
+            (
+                timezone.localtime(ev.end_time)
+                        .strftime("%A, %b %d, %H:%M")
+                if ev.end_time else ""
+            )
+            for ev in schedule_events
+        ]
+        self.add_column({'title': _("End Time"), 'key': _("End Time")}, ends)


### PR DESCRIPTION
In place of most tourneys having to write the schedule in the Welcome Page, we can add  a schedule page that displays the schedule. As it's not "timezone-aware", we also have an info card above the table that allows tabs to set the time zone todisplay on the info card.

This is not really an implementation of https://github.com/orgs/TabbycatDebate/projects/5 per-se, but could be a starting point.

![image](https://github.com/user-attachments/assets/a41a591d-2c98-483a-8c20-9295194abc3a)
![image](https://github.com/user-attachments/assets/b288a86c-e104-4ab5-917e-2c75684b0eef)
