### PR TITLE
Create new answer type for datetime

### DIFF
--- a/tabbycat/api/fields.py
+++ b/tabbycat/api/fields.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from urllib import parse
 
 from django.core.exceptions import ObjectDoesNotExist
@@ -343,10 +344,16 @@ class AnswerSerializer(Serializer):
     def validate(self, data):
         # Convert answer to correct type
         typ = Question.ANSWER_TYPE_TYPES[data['question'].answer_type]
+        if typ is datetime:
+            try:
+                data['answer'] = datetime.fromisoformat(data['answer'])
+            except ValueError:
+                raise ValidationError({'answer': 'The answer must be an ISO 8601 timestamp'})
         if type(data['answer']) != typ:
             raise ValidationError({'answer': 'The answer must be of type %s' % typ.__name__})
 
-        data['answer'] = typ(data['answer'])
+        if typ is not datetime:
+            data['answer'] = typ(data['answer'])
 
         option_error = ValidationError({'answer': 'Answer must be in set of options'})
         if len(data['question'].choices) > 0:

--- a/tabbycat/registration/admin.py
+++ b/tabbycat/registration/admin.py
@@ -2,9 +2,14 @@ from django.contrib import admin
 
 from utils.admin import ModelAdmin
 
-from .models import Answer
+from .models import Answer, Question
 
 
 @admin.register(Answer)
 class AnswerAdmin(ModelAdmin):
     list_display = ('question', 'answer', 'content_object')
+
+
+@admin.register(Question)
+class QuestionAdmin(ModelAdmin):
+    pass

--- a/tabbycat/registration/form_utils.py
+++ b/tabbycat/registration/form_utils.py
@@ -98,6 +98,8 @@ class CustomQuestionsFormMixin:
                 field = OptionalChoiceField(choices=question.choices_for_field)
             case question.AnswerType.MULTIPLE_SELECT:
                 field = forms.MultipleChoiceField(choices=question.choices_for_field, widget=BlockCheckboxWidget())
+            case question.AnswerType.DATETIME:
+                field = forms.DateTimeField(widget=forms.DateTimeInput(attrs={'type': 'datetime-local'}))
         field.label = question.text
         if question.help_text:
             field.help_text = question.help_text
@@ -116,5 +118,7 @@ class CustomQuestionsFormMixin:
             if response is not None:
                 if question.answer_type is question.AnswerType.MULTIPLE_SELECT:
                     response = json.dumps(response)
+                if question.answer_type is question.AnswerType.DATETIME:
+                    response = response.isoformat()
                 if response != "":
                     question.answer_set.create(content_object=obj, answer=response)

--- a/tabbycat/registration/models.py
+++ b/tabbycat/registration/models.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
@@ -56,6 +58,7 @@ class Question(models.Model):
         LONGTEXT = 'tl', _("long text")
         SINGLE_SELECT = 'ss', _("select one")
         MULTIPLE_SELECT = 'ms', _("select multiple")
+        DATETIME = 'dt', _("date + time")
 
     ANSWER_TYPE_TYPES = {
         AnswerType.BOOLEAN_CHECKBOX: bool,
@@ -67,6 +70,7 @@ class Question(models.Model):
         AnswerType.LONGTEXT: str,
         AnswerType.SINGLE_SELECT: str,
         AnswerType.MULTIPLE_SELECT: list,
+        AnswerType.DATETIME: datetime,
     }
 
     tournament = models.ForeignKey('tournaments.Tournament', models.CASCADE,


### PR DESCRIPTION
This commit adds a new answer type for general questions: date + time. Such fields are sometimes used for ascertaining when participants are due to arrive/leave.

These values are serialized as ISO 8601 strings.