### PR TITLE
Fix team name generation on adding new speakers

### DIFF
--- a/tabbycat/registration/forms.py
+++ b/tabbycat/registration/forms.py
@@ -157,6 +157,9 @@ class SpeakerForm(CustomQuestionsFormMixin, forms.ModelForm):
     class Meta:
         model = Speaker
         fields = ('name', 'last_name', 'email', 'phone', 'gender', 'categories')
+        labels = {
+            'name': _("Full name for tab"),
+        }
 
     def save(self, commit=True):
         self.instance.team = self.team
@@ -190,6 +193,9 @@ class AdjudicatorForm(CustomQuestionsFormMixin, forms.ModelForm):
     class Meta:
         model = Adjudicator
         fields = ('name', 'institution', 'email', 'phone', 'gender')
+        labels = {
+            'name': _("Full name for tab"),
+        }
 
     def save(self):
         self.instance.tournament = self.tournament


### PR DESCRIPTION
This commit makes the team [code] name generators static in order to have them update when a speaker uses the individual speaker form. It also fixes the `key` field as it changes with each step.