### PR TITLE
Create new email status for failure to send

### DIFF
--- a/tabbycat/notifications/models.py
+++ b/tabbycat/notifications/models.py
@@ -96,6 +96,7 @@ class EmailStatus(models.Model):
         SPAM = 'spamreport', _("Marked as spam")
         ASM_UNSUBSCRIBED = 'group_unsubscribe', _("Unsubscribed from group")
         ASM_RESUBSCRIBED = 'group_resubscribe', _("Resubscribed to group")
+        FAILED = 'failed', _("Failed to send")
 
     email = models.ForeignKey('notifications.SentMessage', models.CASCADE,
         verbose_name=_("email message"))

--- a/tabbycat/notifications/views.py
+++ b/tabbycat/notifications/views.py
@@ -111,6 +111,7 @@ class EmailStatusView(AdministratorMixin, TournamentMixin, VueTableTemplateView)
             EmailStatus.EventType.DROPPED: 'text-warning',
             EmailStatus.EventType.SPAM: 'text-warning',
             EmailStatus.EventType.DEFERRED: 'text-warning',
+            EmailStatus.EventType.FAILED: 'text-warning',
             EmailStatus.EventType.PROCESSED: 'text-info',
             EmailStatus.EventType.DELIVERED: 'text-info',
             EmailStatus.EventType.OPENED: 'text-success',


### PR DESCRIPTION
This commit will attempt to add more visibility to the email sending process, where some emails seem to fail and that makes the rest of the batch also fail with no record of the emails created.

To make sure we only fail on specific emails, we can send each email one-at-a-time (keeping the same connection for performance). Then, we can catch failures and create a status object for it with the exception.

Fixes #2662
