### PR TITLE
Add preference to control search engine indexing.

### DIFF
--- a/tabbycat/adjfeedback/templates/enter_feedback.html
+++ b/tabbycat/adjfeedback/templates/enter_feedback.html
@@ -13,7 +13,7 @@
     {% trans "Add Feedback" %}
   {% endif %}
 {% endblock %}
-{% block extra-head %}<meta name="robots" content="noindex" />{% endblock %}
+{% block noindex %}<meta name="robots" content="noindex" />{% endblock %}
 
 {% block content %}
 

--- a/tabbycat/options/preferences.py
+++ b/tabbycat/options/preferences.py
@@ -1060,6 +1060,27 @@ public_features = Section('public_features', verbose_name=_("Public Features"))
 
 
 @tournament_preferences_registry.register
+class AllowSearchEngineIndexing(ChoicePreference):
+    help_text = _("Set whether or not search engines can index the tab."
+                  "This is done by adding a <meta name=\"robots\" content=\"noindex\">"
+                  "tag to appropriate pages. Please note that while most search"
+                  "engines (e.g. Google) do respect this, not all search engines"
+                  "will. While this may be useful in preserving participants"
+                  "privacy, you may wish to also consider other techniques"
+                  "(such as disabling public pages or password-protecting your)"
+                  "web server.")
+    verbose_name = _("Search engine indexing configuration")
+    section = public_features
+    name = 'search_engine_indexing'
+    choices = (
+        ('all', _("Allow all pages to be indexed by search engines.")),
+        ('homepage-only', _("Only allow the homepage to be indexed, do not allow any other pages (e.g. tabs, ballots, etc).")),
+        ('none', _("Do not allow any pages to be indexed by search engines.")),
+    )
+    default = 'all'
+
+
+@tournament_preferences_registry.register
 class PublicParticipants(BooleanPreference):
     help_text = _("Enables the public page listing all participants in the tournament")
     verbose_name = _("Enable public view of participants list")

--- a/tabbycat/options/preferences.py
+++ b/tabbycat/options/preferences.py
@@ -1061,15 +1061,9 @@ public_features = Section('public_features', verbose_name=_("Public Features"))
 
 @tournament_preferences_registry.register
 class AllowSearchEngineIndexing(ChoicePreference):
-    help_text = _("Set whether or not search engines can index the tab."
-                  "This is done by adding a <meta name=\"robots\" content=\"noindex\">"
-                  "tag to appropriate pages. Please note that while most search"
-                  "engines (e.g. Google) do respect this, not all search engines"
-                  "will. While this may be useful in preserving participants"
-                  "privacy, you may wish to also consider other techniques"
-                  "(such as disabling public pages or password-protecting your)"
-                  "web server.")
-    verbose_name = _("Search engine indexing configuration")
+    help_text = _("Adds a flag signaling search engines to not include tournament pages in search results."
+                  "Note that it may get ignored, and the other available settings will provide greater privacy.")
+    verbose_name = _("Include site in search engines")
     section = public_features
     name = 'search_engine_indexing'
     choices = (

--- a/tabbycat/privateurls/templates/private_url_landing.html
+++ b/tabbycat/privateurls/templates/private_url_landing.html
@@ -4,8 +4,7 @@
 {% block page-title %}{% trans "Private URL" %}{% endblock %}
 {% block head-title %}{% trans "Private URL" %}{% endblock %}
 
-{% block extra-head %}<meta name="robots" content="noindex" />{% endblock %}
-
+{% block noindex %}<meta name="robots" content="noindex" />{% endblock %}
 {% block sub-title %}
   {% blocktrans trimmed with name=object.name %}for {{ name }}{% endblocktrans %}
   {% if object.speaker %}

--- a/tabbycat/registration/templates/coach_private_url.html
+++ b/tabbycat/registration/templates/coach_private_url.html
@@ -4,8 +4,7 @@
 {% block page-title %}{% trans "Private URL" %}{% endblock %}
 {% block head-title %}{% trans "Private URL" %}{% endblock %}
 
-{% block extra-head %}<meta name="robots" content="noindex" />{% endblock %}
-
+{% block noindex %}<meta name="robots" content="noindex" />{% endblock %}
 {% block sub-title %}
   {% blocktrans trimmed with name=coach.name institution=institution.name %}for {{ name }} ({{ institution }}){% endblocktrans %}
 {% endblock %}

--- a/tabbycat/results/templates/ballot_entry_base.html
+++ b/tabbycat/results/templates/ballot_entry_base.html
@@ -1,8 +1,7 @@
 {% extends "base.html" %}
 {% load add_field_css debate_tags static i18n team_name_for_data_entry %}
 
-{% block extra-head %}<meta name="robots" content="noindex" />{% endblock %}
-
+{% block noindex %}<meta name="robots" content="noindex" />{% endblock %}
 {% block page-subnav-sections %}
   {% if for_admin %}
     <a class="btn btn-outline-primary" href="{% roundurl 'results-round-list' debate.round %}">

--- a/tabbycat/results/templates/privateurl_ballot_set.html
+++ b/tabbycat/results/templates/privateurl_ballot_set.html
@@ -1,8 +1,7 @@
 {% extends "public_ballot_set.html" %}
 {% load debate_tags i18n %}
 
-{% block extra-head %}<meta name="robots" content="noindex" />{% endblock %}
-
+{% block noindex %}<meta name="robots" content="noindex" />{% endblock %}
 {% block page-alerts %}
   {% blocktrans trimmed with name=adjudicator.name asvar p1 %}
     The page is provided to allow you, <strong>{{ name }}</strong>, to verify

--- a/tabbycat/results/templates/privateurl_ballot_set_error.html
+++ b/tabbycat/results/templates/privateurl_ballot_set_error.html
@@ -6,8 +6,7 @@
   <h2><span class="emoji">😾</span> {% trans "Ballot Not Available" %}</h2>
 {% endblock %}
 
-{% block extra-head %}<meta name="robots" content="noindex" />{% endblock %}
-
+{% block noindex %}<meta name="robots" content="noindex" />{% endblock %}
 {% block page-alerts %}
   {% blocktrans trimmed with name=adjudicator.name asvar p1 %}
     The page is provided to allow you, <strong>{{ name }}</strong>, to verify

--- a/tabbycat/results/templates/public_enter_results.html
+++ b/tabbycat/results/templates/public_enter_results.html
@@ -1,8 +1,7 @@
 {% extends "base.html" %}
 {% load debate_tags add_field_css humanize static i18n %}
 
-{% block extra-head %}<meta name="robots" content="noindex" />{% endblock %}
-
+{% block noindex %}<meta name="robots" content="noindex" />{% endblock %}
 {% block page-alerts %}
 
   {% if form.scoresheets|length > 1 %}

--- a/tabbycat/results/templates/public_enter_results_error.html
+++ b/tabbycat/results/templates/public_enter_results_error.html
@@ -7,8 +7,7 @@
   No Result to Enter ({{ adjudicator }})
 {% endblocktrans %}{% endblock %}
 {% block page-title %}{% trans "No Result to Enter" %}{% endblock %}
-{% block extra-head %}<meta name="robots" content="noindex" />{% endblock %}
-
+{% block noindex %}<meta name="robots" content="noindex" />{% endblock %}
 {% block content %}
 
   {% include "includes/public_enter_results_info.html" %}

--- a/tabbycat/templates/base.html
+++ b/tabbycat/templates/base.html
@@ -22,19 +22,14 @@
   <meta property="og:description" content="{{ meta_description }}" />
   <meta property="og:image" content="{% static 'logo-social.png' %}" />
 
-  {# Set noindex property if configured. #}
-  {% if tournament %}
-    {% if pref.search_engine_indexing == "all" %}
-    {% elif pref.search_engine_indexing == "homepage-only" %}
-        {% tournamenturl 'tournament-public-index' as tournament_homepage_url %}
-        {% if request.path == tournament_homepage_url %}
-        {% else %}
-            <meta name="robots" content="noindex">
-        {% endif %}
-    {% else %}
-        <meta name="robots" content="noindex">
+  {% block noindex %}
+    {% if tournament %}
+            {% if pref.search_engine_indexing != "all" %}
+                <meta name="robots" content="noindex">
+            {% endif %}
     {% endif %}
-  {% endif %}
+  {% endblock %}
+
 
   <link rel="preload" href="{% static 'fonts/Inter-Regular.woff2' %}" as="font" type="font/woff2">
   <link rel="icon" type="image/png" href="{% static 'logo-32x32.png' %}" sizes="32x32" />

--- a/tabbycat/templates/base.html
+++ b/tabbycat/templates/base.html
@@ -22,6 +22,20 @@
   <meta property="og:description" content="{{ meta_description }}" />
   <meta property="og:image" content="{% static 'logo-social.png' %}" />
 
+  {# Set noindex property if configured. #}
+  {% if tournament %}
+    {% if pref.search_engine_indexing == "all" %}
+    {% elif pref.search_engine_indexing == "homepage-only" %}
+        {% tournamenturl 'tournament-public-index' as tournament_homepage_url %}
+        {% if request.path == tournament_homepage_url %}
+        {% else %}
+            <meta name="robots" content="noindex">
+        {% endif %}
+    {% else %}
+        <meta name="robots" content="noindex">
+    {% endif %}
+  {% endif %}
+
   <link rel="preload" href="{% static 'fonts/Inter-Regular.woff2' %}" as="font" type="font/woff2">
   <link rel="icon" type="image/png" href="{% static 'logo-32x32.png' %}" sizes="32x32" />
   <link rel="icon" type="image/png" href="{% static 'logo-16x16.png' %}" sizes="16x16" />

--- a/tabbycat/tournaments/templates/public_tournament_index.html
+++ b/tabbycat/tournaments/templates/public_tournament_index.html
@@ -1,7 +1,14 @@
 {% extends "base.html" %}
 {% load debate_tags i18n static %}
 
+{% block noindex %}
+  {% if pref.search_engine_indexing == "none" %}
+    <meta name="robots" content="noindex">
+  {% endif %}
+{% endblock %}
+
 {% block head-title %}<span class="emoji">👋</span>
+
 {% blocktrans trimmed with tournament=tournament.name %}
     Welcome to {{ tournament }}
 {% endblocktrans %}{% endblock %}

--- a/tabbycat/users/templates/signup.html
+++ b/tabbycat/users/templates/signup.html
@@ -1,8 +1,7 @@
 {% extends 'base.html' %}
 {% load i18n %}
 
-{% block extra-head %}<meta name="robots" content="noindex" />{% endblock %}
-
+{% block noindex %}<meta name="robots" content="noindex" />{% endblock %}
 {% block content %}
 
   <form id="signupForm" method="POST">


### PR DESCRIPTION
Fixes #1724 

In the fullest implementation, I think we should also handle non-tournament pages (should users be able to disable indexing of these pages) as well as sites with multiple tournaments.

I think either of:
- add a global preference "disable_indexing" which disables indexing for the whole domain (overriding per-tournament preferences)
- add a preference to disable indexing for global pages (e.g. lists of tournaments) such that the disjoint sum of {global setting preference} + union of all the individual per-tournament settings covers every possible page.

could work?