### PR TITLE
Add a tooltip to show precise score

### DIFF
--- a/tabbycat/utils/tables.py
+++ b/tabbycat/utils/tables.py
@@ -833,7 +833,10 @@ class TabbycatTableBuilder(BaseTableBuilder):
                     sort = float(metric)
                 except (TypeError, ValueError):
                     sort = 99999
-                row.append({'text': metricformat(metric), 'sort': sort})
+                cell = {'text': metricformat(metric), 'sort': sort}
+                if isinstance(metric, float):
+                    cell['tooltip'] = str(metric)
+                row.append(cell)
             data.append(row)
         self.add_columns(headers, data)
 


### PR DESCRIPTION
This adds a tooltip for displaying the full value of decimal scores in standing metrics.

![Screenshot from 2025-06-21 17-48-58](https://github.com/user-attachments/assets/2c79adfb-1042-445d-9cf9-457e897589d1)

During the [national championship](https://pidc2025.calicotab.com/pidc2025/) I tabbed last week, there were questions around why some scores appeared to tie despite the tab ranking them differently. Some margins exceeded the floating-point precision that Excel and most basic calculators can handle. This feature clarifies these cases.