### PR TITLE
Update default adj score range from 0-5 to 1-10

### DIFF
--- a/tabbycat/options/preferences.py
+++ b/tabbycat/options/preferences.py
@@ -466,7 +466,7 @@ class MinimumAdjScore(FloatPreference):
     verbose_name = _("Minimum adjudicator score")
     section = feedback
     name = 'adj_min_score'
-    default = 0.0
+    default = 1.0
 
 
 @tournament_preferences_registry.register

--- a/tabbycat/options/preferences.py
+++ b/tabbycat/options/preferences.py
@@ -475,7 +475,7 @@ class MaximumAdjScore(FloatPreference):
     verbose_name = _("Maximum adjudicator score")
     section = feedback
     name = 'adj_max_score'
-    default = 5.0
+    default = 10
 
 
 @tournament_preferences_registry.register


### PR DESCRIPTION
In most competitions, including [WUDC](https://drive.google.com/file/d/1HNAHw1fcuobidsVSF7C_jbSI65ETz6nT/view), the judge range is 1-10, not 0-5.