### PR TITLE
Create draw flags for graph draw generator

### DIFF
--- a/tabbycat/draw/generator/__init__.py
+++ b/tabbycat/draw/generator/__init__.py
@@ -25,6 +25,11 @@ DRAW_FLAG_DESCRIPTIONS = (
     ("bub_dn_accom", _("Bubble down (to accommodate)")),
     ("no_bub_updn", _("Can't bubble up/down")),
     ("pullup", _("Pull-up team")),
+    ("side_imb", _("Side imbalance")),
+    ("seen_pullup", _("Team previously saw pullup")),
+    ("deviation", _("Pairing deviation")),
+    ("history", _("History conflict")),
+    ("inst", _("Institution conflict")),
 )
 
 def get_two_team_generator(draw_type, avoid_conflicts='australs', side_allocations=None, **kwargs):

--- a/tabbycat/draw/tests/test_generator.py
+++ b/tabbycat/draw/tests/test_generator.py
@@ -451,18 +451,18 @@ class TestPowerPairedDrawGenerator(unittest.TestCase):
             pairing_penalty=1,
         ),
         [(12,  2, [], [], ['pullup'], True),
-         (3,  14, [], [], [], True),
-         (17, 11, [], [], [], True),  # Prefers a 2-pairing deviation
+         (3,  14, ['deviation|1'], [], [], True),
+         (17, 11, ['deviation|2'], [], [], True),  # Prefers a 2-pairing deviation
          (8,   6, [], [], [], True),
-         (4,   7, [], [], ['pullup'], True),
-         (9,  24, [], [], [], False),
-         (15, 23, [], [], [], True),
+         (4,   7, ['deviation|1'], [], ['pullup'], True),
+         (9,  24, ['deviation|1'], [], [], False),
+         (15, 23, ['deviation|1'], [], [], True),
          (18, 25, [], [], [], False),
          (22,  1, [], [], ['pullup'], True),
          (5,  21, [], [], [], True),
-         (10, 20, [], [], [], False),
+         (10, 20, ['deviation|2'], [], [], False),
          (16, 26, [], [], [], True),
-         (19, 13, [], [], ['pullup'], True)]]
+         (19, 13, ['deviation|2'], [], ['pullup'], True)]]
 
     expected[6] = [  # Should be identical to [5]
         dict(
@@ -478,19 +478,19 @@ class TestPowerPairedDrawGenerator(unittest.TestCase):
             pairing_penalty=1,
             pullup_penalty=10,
         ),
-        [(12,  2, [], [], ['pullup'], True),
-         (3,  14, [], [], [], True),
-         (17, 11, [], [], [], True),
+        [(12,  2, [], [], ['pullup|1'], True),
+         (3,  14, ['deviation|1'], [], [], True),
+         (17, 11, ['deviation|2'], [], [], True),
          (8,   6, [], [], [], True),
-         (4,   7, [], [], ['pullup'], True),
-         (9,  24, [], [], [], False),
-         (15, 23, [], [], [], True),
+         (4,   7, ['deviation|1'], [], ['pullup|1'], True),
+         (9,  24, ['deviation|1'], [], [], False),
+         (15, 23, ['deviation|1'], [], [], True),
          (18, 25, [], [], [], False),
-         (22,  1, [], [], ['pullup'], True),
+         (22,  1, [], [], ['pullup|1'], True),
          (5,  21, [], [], [], True),
-         (10, 20, [], [], [], False),
+         (10, 20, ['deviation|2'], [], [], False),
          (16, 26, [], [], [], True),
-         (19, 13, [], [], ['pullup'], True)]]
+         (19, 13, ['deviation|2'], [], ['pullup|1'], True)]]
 
     combinations = [(1, 1), (1, 2), (1, 3), (1, 4), (1, 5), (1, 6)]
 
@@ -510,19 +510,20 @@ class TestPowerPairedDrawGenerator(unittest.TestCase):
                     actual_teams = tuple([t.id for t in actual.teams])
                     expected_teams = (exp_aff, exp_neg)
 
-                    if same_affs:
-                        self.assertEqual(set(actual_teams), set(expected_teams))
-                    else:
-                        self.assertEqual(actual_teams, expected_teams)
+                    with self.subTest(aff=exp_aff, neg=exp_neg):
+                        if same_affs:
+                            self.assertEqual(set(actual_teams), set(expected_teams))
+                        else:
+                            self.assertEqual(actual_teams, expected_teams)
 
-                    self.assertEqual(actual.flags, exp_flags)
+                        self.assertEqual(actual.flags, exp_flags)
 
-                    if exp_aff == actual.teams[0].id:
-                        self.assertEqual(actual.get_team_flags(actual.teams[0]), exp_aff_flags)
-                        self.assertEqual(actual.get_team_flags(actual.teams[1]), exp_neg_flags)
-                    else:
-                        self.assertEqual(actual.get_team_flags(actual.teams[1]), exp_aff_flags)
-                        self.assertEqual(actual.get_team_flags(actual.teams[0]), exp_neg_flags)
+                        if exp_aff == actual.teams[0].id:
+                            self.assertEqual(actual.get_team_flags(actual.teams[0]), exp_aff_flags)
+                            self.assertEqual(actual.get_team_flags(actual.teams[1]), exp_neg_flags)
+                        else:
+                            self.assertEqual(actual.get_team_flags(actual.teams[1]), exp_aff_flags)
+                            self.assertEqual(actual.get_team_flags(actual.teams[0]), exp_neg_flags)
 
 
 class TestPowerPairedWithAllocatedSidesDrawGeneratorPartOddBrackets(unittest.TestCase):

--- a/tabbycat/draw/tests/test_graph_allocations.py
+++ b/tabbycat/draw/tests/test_graph_allocations.py
@@ -1,7 +1,7 @@
 import unittest
 
 from .utils import TestTeam
-from ..generator.powerpair import GraphCostMixin, GraphPowerPairedDrawGenerator
+from ..generator.powerpair import GraphPowerPairedDrawGenerator, PowerPairedGraphCostMixin
 from ..types import DebateSide
 
 DUMMY_TEAMS = [TestTeam(1, 'A', allocated_side=DebateSide.AFF), TestTeam(2, 'B', allocated_side=DebateSide.NEG)]
@@ -23,7 +23,7 @@ class TestPowerPairedDrawGeneratorParts(unittest.TestCase):
             A - G: 2
             A - H: 3"""
             with self.subTest(i=i):
-                self.assertEqual(GraphCostMixin._pairings_slide([teams[0].subrank, team.subrank], 8), abs(i - 4))
+                self.assertEqual(PowerPairedGraphCostMixin._pairings_slide([teams[0].subrank, team.subrank], 8), abs(i - 4))
 
     def test_pairings_slide_deviation(self):
         teams = [TestTeam(i+1, chr(ord('A') + i), subrank=i+1) for i in range(8)]
@@ -39,7 +39,7 @@ class TestPowerPairedDrawGeneratorParts(unittest.TestCase):
             D - G: 1
             D - H: 0"""
             with self.subTest(i=i):
-                self.assertEqual(GraphCostMixin._pairings_slide([teams[3].subrank, team.subrank], 8), 4 - abs(i - 3))
+                self.assertEqual(PowerPairedGraphCostMixin._pairings_slide([teams[3].subrank, team.subrank], 8), 4 - abs(i - 3))
 
     def test_pairings_fold_deviation_top(self):
         teams = [TestTeam(i+1, chr(ord('A') + i), subrank=i+1) for i in range(8)]
@@ -55,7 +55,7 @@ class TestPowerPairedDrawGeneratorParts(unittest.TestCase):
             A - G: 1
             A - H: 0"""
             with self.subTest(i=i):
-                self.assertEqual(GraphCostMixin._pairings_fold([teams[0].subrank, team.subrank], 8), 7-i)
+                self.assertEqual(PowerPairedGraphCostMixin._pairings_fold([teams[0].subrank, team.subrank], 8), 7-i)
 
     def test_pairings_fold_deviation(self):
         teams = [TestTeam(i+1, chr(ord('A') + i), subrank=i+1) for i in range(8)]
@@ -71,13 +71,13 @@ class TestPowerPairedDrawGeneratorParts(unittest.TestCase):
             D - G: 2
             D - H: 3"""
             with self.subTest(i=i):
-                self.assertEqual(GraphCostMixin._pairings_fold([teams[3].subrank, team.subrank], 8), abs(4-i))
+                self.assertEqual(PowerPairedGraphCostMixin._pairings_fold([teams[3].subrank, team.subrank], 8), abs(4-i))
         return [abs(4-i) for i in range(8)]
 
     def test_pairings_random_deviation_zero(self):
         teams = [TestTeam(i+1, chr(ord('A') + i), subrank=i+1) for i in range(8)]
         # Always 0
-        self.assertEqual(GraphCostMixin._pairings_random([teams[0].subrank, teams[1].subrank], 8), 0)
+        self.assertEqual(PowerPairedGraphCostMixin._pairings_random([teams[0].subrank, teams[1].subrank], 8), 0)
 
     def test_pairings_adjacent_deviation_top(self):
         teams = [TestTeam(i+1, chr(ord('A') + i), subrank=i+1) for i in range(8)]
@@ -93,7 +93,7 @@ class TestPowerPairedDrawGeneratorParts(unittest.TestCase):
             A - G: 5
             A - H: 6"""
             with self.subTest(i=i):
-                self.assertEqual(GraphCostMixin._pairings_adjacent([teams[0].subrank, team.subrank], 8), i-1)
+                self.assertEqual(PowerPairedGraphCostMixin._pairings_adjacent([teams[0].subrank, team.subrank], 8), i-1)
 
     def test_pairings_adjacent_deviation(self):
         teams = [TestTeam(i+1, chr(ord('A') + i), subrank=i+1) for i in range(8)]
@@ -109,7 +109,7 @@ class TestPowerPairedDrawGeneratorParts(unittest.TestCase):
             D - G: 2
             D - H: 3"""
             with self.subTest(i=i):
-                self.assertEqual(GraphCostMixin._pairings_adjacent([teams[3].subrank, team.subrank], 8), abs(i - 3) - 1)
+                self.assertEqual(PowerPairedGraphCostMixin._pairings_adjacent([teams[3].subrank, team.subrank], 8), abs(i - 3) - 1)
         return [abs(i - 3) - 1 for i in range(8)]
 
     def test_pairings_fold_adj_deviation(self):
@@ -117,31 +117,31 @@ class TestPowerPairedDrawGeneratorParts(unittest.TestCase):
         methods = [self.test_pairings_fold_deviation, self.test_pairings_adjacent_deviation]
         for i, method in enumerate(methods):
             for j, (team, expected) in enumerate(zip(teams, method())):
-                self.assertEqual(GraphCostMixin._pairings_fold_top_adjacent_rest([teams[3].subrank, team.subrank], 8, bracket=i), expected)
+                self.assertEqual(PowerPairedGraphCostMixin._pairings_fold_top_adjacent_rest([teams[3].subrank, team.subrank], 8, bracket=i), expected)
 
     def test_add_pullup_penalty(self):
         teams = [TestTeam(i+1, chr(ord('A') + i), points=i, subrank=i+1, pullup_debates=i+1) for i in range(2)]
         gcm = GraphPowerPairedDrawGenerator(teams)
         gcm.options = {'pullup_debates_penalty': 1, 'pairing_method': 'random', 'avoid_history': False, 'avoid_institution': False, 'side_allocations': False}
         gcm.team_flags = {teams[0]: ['pullup']}
-        self.assertEqual(gcm.assignment_cost(*teams, 2), 2)
+        self.assertEqual(gcm.assignment_cost(*teams, 2, [], {t: [] for t in teams}), 2)
 
     def test_add_subrank_pullup(self):
         teams = [TestTeam(i+1, chr(ord('A') + i), subrank=(None if i else 1)) for i in range(2)]
         gcm = GraphPowerPairedDrawGenerator(teams)
         gcm.options = {'pullup_debates_penalty': 1, 'pairing_method': 'fold', 'avoid_history': False, 'avoid_institution': False, 'side_allocations': False, 'pairing_penalty': 1}
-        self.assertEqual(gcm.assignment_cost(*teams, 2), 0)
+        self.assertEqual(gcm.assignment_cost(*teams, 2, [], {t: [] for t in teams}), 0)
 
     def test_none_self_penalty(self):
         team = TestTeam(1, 'A')
         gcm = GraphPowerPairedDrawGenerator([team, team])
         gcm.options = {'pullup_debates_penalty': 1, 'pairing_method': 'fold', 'avoid_history': False, 'avoid_institution': False, 'side_allocations': False, 'pairing_penalty': 1}
-        self.assertEqual(gcm.assignment_cost(team, team, 2), None)
+        self.assertEqual(gcm.assignment_cost(team, team, 2, [], {t: [] for t in [team]}), None)
 
     def test_none_max_side_balance_penalty(self):
         teams = [TestTeam(1, 'A', side_history=(2, 0), subrank=1), TestTeam(2, 'B', side_history=(1, 1), subrank=2)]
         gcm = GraphPowerPairedDrawGenerator(teams)
         gcm.options = {'side_allocations': 'balance', 'max_times_on_one_side': 1,
                        'avoid_history': False, 'avoid_institution': False, 'side_penalty': 1, 'pairing_method': 'fold', 'pairing_penalty': 1, 'pullup_debates_penalty': 1}
-        cost = gcm.assignment_cost(*teams, 2)
+        cost = gcm.assignment_cost(*teams, 2, [], {t: [] for t in teams})
         self.assertEqual(cost, None)

--- a/tabbycat/utils/tables.py
+++ b/tabbycat/utils/tables.py
@@ -29,6 +29,11 @@ logger = logging.getLogger(__name__)
 _draw_flags_dict = dict(DRAW_FLAG_DESCRIPTIONS)
 
 
+def get_flag_description(flag):
+    flag_parts = flag.split('|')
+    return _draw_flags_dict.get(flag_parts[0], flag_parts[0]) + (_(' × %s') % flag_parts[1] if len(flag_parts) == 2 and int(flag_parts[1]) > 1 else '')
+
+
 def escape_if_unsafe(s):
     return s if type(s) is SafeString else escape(s)
 
@@ -759,11 +764,11 @@ class TabbycatTableBuilder(BaseTableBuilder):
         conflicts_by_debate = []
         for debate in debates:
             # conflicts is a list of (level, message) tuples
-            conflicts = [("secondary", _draw_flags_dict.get(flag, flag)) for flag in debate.flags]
+            conflicts = [("secondary", get_flag_description(flag)) for flag in debate.flags]
             if not debate.is_bye:
                 conflicts += [("secondary", "%(team)s: %(flag)s" % {
                             'team': self._team_short_name(dt.team),
-                            'flag': _draw_flags_dict.get(flag, flag),
+                            'flag': get_flag_description(flag),
                         }) for dt in debate.debateteams for flag in dt.flags]
 
             if self.tournament.pref('avoid_team_history'):


### PR DESCRIPTION
In order to give more observability to what the graph draw generators are doing, we can show the flags that are created that relate to penalties being added. To show the magnitude, we can then append a number to the flag which will show as "× x".

These flags are passed as a list by reference.