### PR TITLE
Create default room rank for graph draw generator

### DIFF
--- a/tabbycat/draw/generator/graph.py
+++ b/tabbycat/draw/generator/graph.py
@@ -83,7 +83,7 @@ class GraphGeneratorMixin:
         return pairings
 
     def room_rank_ordering(self, p):
-        return min([t.subrank for t in p if t.subrank is not None], default=0)
+        return 0
 
 
 class GraphAllocatedSidesMixin(GraphGeneratorMixin):

--- a/tabbycat/draw/generator/powerpair.py
+++ b/tabbycat/draw/generator/powerpair.py
@@ -352,6 +352,9 @@ class GraphCostMixin:
                     else:
                         team.subrank = i
 
+    def room_rank_ordering(self, p):
+        return min([t.subrank for t in p if t.subrank is not None], default=0)
+
 
 class AustralsPairingMixin:
 


### PR DESCRIPTION
As random draws would not have a subrank for teams (nor even a rank), we cannot assign a room rank for those debates. As such, we can default to 0 and override in the graph generators for power-paired rounds.