### PR TITLE
Add check for is_voting on merging ballots

### DIFF
--- a/tabbycat/results/forms.py
+++ b/tabbycat/results/forms.py
@@ -520,7 +520,7 @@ class ScoresMixin:
         debate. Making this its own function allows subclasses to extend this so
         that it can use the same DebateResult as the super class."""
         initial = {}
-        if all(result.teamscore_field_score(side) is None for side in self.sides) and result.get_winner():
+        if not result.is_voting and all(result.teamscore_field_score(side) is None for side in self.sides) and result.get_winner():
             forfeiter = next(iter(set(self.sides) - result.get_winner()))
             initial[self._fieldname_forfeit(forfeiter)] = True
             return initial


### PR DESCRIPTION
This missing check made merging ballots fail for per-adj debates, as the winner method requires an adjudicator, which per-adj ballots wouldn't have.