### PR TITLE
Created All preferences Page

### DIFF
--- a/tabbycat/options/forms.py
+++ b/tabbycat/options/forms.py
@@ -49,6 +49,14 @@ class TournamentPreferenceForm(PreferenceForm):
 
 
 def tournament_preference_form_builder(instance, preferences=[], **kwargs):
+    if kwargs.get('section') == 'all_sections':
+
+        return preference_form_builder(
+            TournamentPreferenceForm,
+            preferences=[],
+            model={'instance': instance},
+        )
+
     if kwargs.get('section') in [str(s) for s in global_preferences_registry.sections()]:
         # Check for global preferences
         return preference_form_builder(GlobalPreferenceForm, preferences, **kwargs)

--- a/tabbycat/options/forms.py
+++ b/tabbycat/options/forms.py
@@ -51,13 +51,9 @@ class TournamentPreferenceForm(PreferenceForm):
 def tournament_preference_form_builder(instance, preferences=[], **kwargs):
     if kwargs.get('section') == 'all_sections':
 
-        return preference_form_builder(
-            TournamentPreferenceForm,
-            preferences=[],
-            model={'instance': instance},
-        )
+        return preference_form_builder(TournamentPreferenceForm, preferences=[], model={'instance': instance})
 
-    if kwargs.get('section') in [str(s) for s in global_preferences_registry.sections()]:
+    elif kwargs.get('section') in [str(s) for s in global_preferences_registry.sections()]:
         # Check for global preferences
         return preference_form_builder(GlobalPreferenceForm, preferences, **kwargs)
 

--- a/tabbycat/options/preferences.py
+++ b/tabbycat/options/preferences.py
@@ -1,5 +1,6 @@
 from decimal import Decimal
 
+from django import forms
 from django.core.validators import EmailValidator, MinValueValidator, validate_slug
 from django.forms import SelectMultiple
 from django.utils.translation import gettext_lazy as _
@@ -16,6 +17,25 @@ from tournaments.utils import get_side_name_choices
 from .models import tournament_preferences_registry
 from .types import MultiValueChoicePreference
 from .utils import validate_metric_duplicates
+
+
+# ==============================================================================
+all_sections = Section('all_sections', verbose_name=_("All Preferances"))
+# ==============================================================================
+
+
+@tournament_preferences_registry.register
+class DummyAllSectionsPreference(StringPreference):
+    section = all_sections
+    name = 'dummy_all_sections'
+    default = ''
+    verbose_name = 'All Sections Placeholder'
+
+    def get_field_kwargs(self):
+        kwargs = super().get_field_kwargs()
+        kwargs['widget'] = forms.HiddenInput
+        return kwargs
+
 
 # ==============================================================================
 scoring = Section('scoring', verbose_name=_("Score Rules"))

--- a/tabbycat/options/preferences.py
+++ b/tabbycat/options/preferences.py
@@ -20,7 +20,7 @@ from .utils import validate_metric_duplicates
 
 
 # ==============================================================================
-all_sections = Section('all_sections', verbose_name=_("All Preferances"))
+all_sections = Section('all_sections', verbose_name=_("All Preferences"))
 # ==============================================================================
 
 

--- a/tabbycat/options/templates/preferences_index.html
+++ b/tabbycat/options/templates/preferences_index.html
@@ -82,6 +82,12 @@
       {% trans "Settings which can affect all tournaments on the site" as description %}
       {% include "components/item-action.html" with type="primary" emoji="🌏" text=title extra=description %}
 
+      {% tournamenturl 'options-tournament-section' section='all_sections' as url %}
+      {% trans "Preferance List" as title %}
+      {% trans "All preferance options in one place" as description %}
+      {% include "components/item-action.html" with type="primary" emoji="📋" text=title extra=description %}
+
+
     </ul>
   </div>
 

--- a/tabbycat/options/templates/preferences_index.html
+++ b/tabbycat/options/templates/preferences_index.html
@@ -83,8 +83,8 @@
       {% include "components/item-action.html" with type="primary" emoji="🌏" text=title extra=description %}
 
       {% tournamenturl 'options-tournament-section' section='all_sections' as url %}
-      {% trans "Preferance List" as title %}
-      {% trans "All preferance options in one place" as description %}
+      {% trans "Preference List" as title %}
+      {% trans "All preference options in one place" as description %}
       {% include "components/item-action.html" with type="primary" emoji="📋" text=title extra=description %}
 
 


### PR DESCRIPTION
I saw Issue #2586 requesting a page that had all preferences listed. This Page Has all preferences listed grouped by the section they appear. Under the assumption this page will be used with ctrl/cmd+f there are no section headers. Adding section headers requires more substantial code changes especially to templates and such, I also didn't think they would be necessary with the current seperate pages for each section.