### PR TITLE
Emails: Include <a tag within URL variables

### DIFF
--- a/tabbycat/notifications/forms.py
+++ b/tabbycat/notifications/forms.py
@@ -1,3 +1,5 @@
+import re
+
 from django import forms
 from django.conf import settings
 from django.core.mail import send_mail
@@ -42,4 +44,10 @@ class BasicEmailForm(forms.Form):
         return self.clean_as_template('subject_line')
 
     def clean_message_body(self) -> str:
-        return self.clean_as_template('message_body')
+        message = self.clean_as_template('message_body')
+
+        # Check if {{ URL }} is used within an <a> tag, sorry Zalgo
+        if re.search(r'<a\s[^>]*{{\s*URL\s*}}[^>]*>', message, re.IGNORECASE | re.DOTALL):
+            raise forms.ValidationError(_("The {{ URL }} variable must be unlinked for it to work"))
+
+        return message

--- a/tabbycat/notifications/utils.py
+++ b/tabbycat/notifications/utils.py
@@ -60,6 +60,10 @@ def _check_in_to(pk: int, to_ids: Set[int]) -> bool:
     return True
 
 
+def _create_url(url: str) -> str:
+    return mark_safe('<a href="%s">%s</a>' % (url, url)) if url else ''
+
+
 class NotificationContextGenerator:
     context_class = EmailContextData
 
@@ -102,7 +106,7 @@ class AdjudicatorAssignmentEmailGenerator(NotificationContextGenerator):
                     continue
 
                 context_user = cls.context_class(**context, POSITION=adj_position_names[pos],
-                    URL=url + adj.url_key + '/' if adj.url_key else '')
+                    URL=_create_url(url + adj.url_key + '/'))
                 emails.append((context_user, adj))
 
         return emails
@@ -120,7 +124,7 @@ class RandomizedUrlEmailGenerator(NotificationContextGenerator):
 
     @classmethod
     def generate(cls, to: 'QuerySet[Person]', url: str, tournament: 'Tournament') -> List[Tuple[EmailContextData, 'Person']]:
-        return [(cls.context_class(URL=url + p.url_key + '/', KEY=p.url_key, TOURN=str(tournament)), p) for p in to]
+        return [(cls.context_class(URL=_create_url(url + p.url_key + '/'), KEY=p.url_key, TOURN=str(tournament)), p) for p in to]
 
 
 class BallotsEmailGenerator(NotificationContextGenerator):
@@ -217,7 +221,7 @@ class StandingsEmailGenerator(NotificationContextGenerator):
         context = {
             'TOURN': str(round.tournament),
             'ROUND': round.name,
-            'URL': url,
+            'URL': _create_url(url),
         }
 
         for team in teams:

--- a/tabbycat/options/preferences.py
+++ b/tabbycat/options/preferences.py
@@ -1425,7 +1425,7 @@ class PointsEmailMessageBody(LongStringPreference):
     name = 'team_points_email_message'
     default = ("<p>Hi {{ USER }},</p>"
         "After {{ ROUND }}, your team ({{ TEAM }}) currently has <strong>{{ POINTS }}</strong> wins in the {{ TOURN }}.</p>"
-        "<p>Current Standings: <a href='{{ URL }}'>{{ URL }}</a></p>")
+        "<p>Current Standings: {{ URL }}</p>")
 
 
 @tournament_preferences_registry.register
@@ -1483,7 +1483,7 @@ class PrivateUrlEmailMessage(LongStringPreference):
         "anyone, as anyone who knows it can submit forms on your behalf. This URL "
         "will not change throughout this tournament, so we suggest bookmarking it.</p>"
         "<p>Your personal private URL is:<br />"
-        "<a href='{{ URL }}'>{{ URL }}</a></p>")
+        "{{ URL }}</p>")
 
 
 @tournament_preferences_registry.register


### PR DESCRIPTION
To avoid problems with bad URLs like with Summernote adding stuff to the `<a` tag:
* Include the HTML within the variable, and
* Add a Regex search to make sure the variable isn't used incorrectly (which is likely for tournaments with the old default preference)