### PR TITLE
Improve error handling for pullup options

### DIFF
--- a/tabbycat/draw/generator/powerpair.py
+++ b/tabbycat/draw/generator/powerpair.py
@@ -618,6 +618,7 @@ class PowerPairedWithAllocatedSidesDrawGenerator(BasePowerPairedDrawGenerator):
         "pairing_method"        : "fold",
         "avoid_conflicts"       : None,
         "pullup_restriction"    : "none",
+        "pullup_penalty"        : 0,
     }
 
     def __init__(self, *args, **kwargs):

--- a/tabbycat/draw/generator/powerpair.py
+++ b/tabbycat/draw/generator/powerpair.py
@@ -358,6 +358,11 @@ class GraphCostMixin:
 
 class AustralsPairingMixin:
 
+    def resolve_odd_brackets(self, brackets):
+        if self.options['odd_bracket'] in ('pullup_lowest_ds_rank', 'pullup_lowest_ds_rank_npulls'):
+            raise DrawUserError(_("Draw strength pullups require 'Minimum cost matching (including pullups)' as the conflict avoidance method"))
+        return super().resolve_odd_brackets(brackets)
+
     def generate_pairings(self, brackets):
         """Returns a function taking an OrderedDict as returned by
         resolve_odd_brackets(), and returning a list of Debates."""
@@ -571,7 +576,7 @@ class SingleGraphPowerPairedDrawGenerator(GraphCostMixin, GraphGeneratorMixin, B
 
     @staticmethod
     def _pullup_lowest_ds_rank(team, size=None):
-        return -team.draw_strength_rank
+        return -getattr(team, 'draw_strength_rank', 0)
 
     @staticmethod
     def _pullup_lowest_ds_rank_npulls(team, size=None):

--- a/tabbycat/options/forms.py
+++ b/tabbycat/options/forms.py
@@ -16,7 +16,7 @@ class TournamentPreferenceForm(PreferenceForm):
         def get_pref(name, section=section):
             return self.cleaned_data.get(section + "__" + name) if (section + "__" + name) in self.cleaned_data else t.pref(name)
 
-        score_range_msg = _("Mininum score must be less than maximum score")
+        score_range_msg = _("Minimum score must be less than maximum score")
 
         if section == 'scoring':
             if get_pref('score_min') > get_pref('score_max'):
@@ -28,6 +28,9 @@ class TournamentPreferenceForm(PreferenceForm):
         elif section == 'draw_rules':
             if get_pref('draw_side_allocations') != 'preallocated' and get_pref('draw_odd_bracket') in ['intermediate1', 'intermediate2']:
                 raise ValidationError({'draw_rules__draw_odd_bracket': _("Intermediate 1 or 2 require preallocated sides")})
+
+            if get_pref('draw_avoid_conflicts') != 'graph_one' and get_pref('draw_odd_bracket') in ['pullup_lowest_ds_rank', 'pullup_lowest_ds_rank_npulls']:
+                raise ValidationError({'draw_rules__draw_odd_bracket': _("Draw strength pullups require 'Minimum cost matching (including pullups)' as the conflict avoidance method")})
 
         elif section == 'debate_rules':
             if get_pref('teams_in_debate') == 4 and (get_pref('ballots_per_debate_prelim') == 'per-adj' or get_pref('ballots_per_debate_elim') == 'per-adj'):

--- a/tabbycat/options/presets.py
+++ b/tabbycat/options/presets.py
@@ -334,7 +334,7 @@ class WSDCPreferences(AustralsPreferences):
     # Hence, this below setting is the closest that we can manage to achive.
     # TODO: Update when Tabbycat can support WSDC pull-up.
     draw_rules__draw_side_allocations          = 'balance'
-    draw_rules__draw_avoid_conflicts           = 'one_up_one_down'
+    draw_rules__draw_avoid_conflicts           = 'graph_one'
     draw_rules__draw_pullup_restriction        = 'lowest_ds_wins'
     # Standings
     standings__team_standings_precedence       = ['wins', 'num_adjs', 'speaks_avg'] # Rule 3.2 (2023 version)


### PR DESCRIPTION
This PR will do a few things:
* Use `getattr` for draw strength, similarly to `_pullup_lowest_ds_rank_npulls`
* Add error states when creating draw with bad options (both when creating the draw and in options)
* Update WSDC preset
* Allow pullup_penalty for preallocated sides