### PR TITLE
Use nowrap on allocation hover panel

### DIFF
--- a/tabbycat/templates/scss/modules/interaction.scss
+++ b/tabbycat/templates/scss/modules/interaction.scss
@@ -134,6 +134,14 @@
   .list-group-item:first-child {
     border-top: 0;
   }
+
+  // Text truncation for hover panel buttons to prevent wrapping
+  .btn-group .btn {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 150px;
+  }
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
This will fix the hover panel getting so tall that it covers the top line, preventing modifications to that panel.