### PR TITLE
Fix DraggableAdjudicator objects disappearing

### DIFF
--- a/tabbycat/adjallocation/templates/EditDebateAdjudicatorsContainer.vue
+++ b/tabbycat/adjallocation/templates/EditDebateAdjudicatorsContainer.vue
@@ -106,7 +106,7 @@ export default {
   }),
   computed: {
     maxTeams: function () {
-      return Math.max(...this.sortedDebatesOrPanels.map(d => d.teams.length))
+      return Math.max(...this.sortedDebatesOrPanels.map(d => d.teams ? d.teams.length : 0), 2)
     },
     groupedDebatesByRound: function () {
       // Group already-sorted debates by their round for visual separation

--- a/tabbycat/templates/allocations/ConflictableMixin.vue
+++ b/tabbycat/templates/allocations/ConflictableMixin.vue
@@ -60,7 +60,7 @@ export default {
     isTeamInDebateTeams: function (idToFind, debateTeams) {
       let found = false
       Object.keys(debateTeams).forEach(teamPosition => {
-        if (debateTeams[teamPosition].id === idToFind) {
+        if (debateTeams[teamPosition]?.id === idToFind) {
           found = true
         }
       })

--- a/tabbycat/templates/allocations/DragAndDropDebate.vue
+++ b/tabbycat/templates/allocations/DragAndDropDebate.vue
@@ -47,7 +47,7 @@
     </slot>
     <slot name="teams">
       <div class="teams-list" :style="{ flex: (maxTeams + maxTeams % 2) * 3, 'flex-direction': 'row !important', 'flex-wrap': 'wrap' }" v-if="debateOrPanel.teams">
-        <div :class="['d-flex flex-fill flex-truncate align-items-center']" v-for="team in debateOrPanel.teams">
+        <div :class="['d-flex flex-fill flex-truncate align-items-center']" v-for="team in debateOrPanel.teams" :key="team ? team.id : 'empty-' + $index">
           <inline-team :debate-id="debateOrPanel.id" :is-elimination="isElimination" :team="team" :key="team.id" v-if="team !== null"/>
         </div>
       </div>

--- a/tabbycat/venues/templates/EditDebateVenuesContainer.vue
+++ b/tabbycat/venues/templates/EditDebateVenuesContainer.vue
@@ -77,7 +77,7 @@ export default {
       return this.$store.getters.allocatableItems
     },
     maxTeams: function () {
-      return Math.max(...this.sortedDebatesOrPanels.map(d => d.teams.length))
+      return Math.max(...this.sortedDebatesOrPanels.map(d => d.teams ? d.teams.length : 0), 2)
     },
     groupedDebatesByRound: function () {
       const groups = {}


### PR DESCRIPTION
In Public Speaking, as there aren't always the same number of teams in a debate, sometimes the history checker would error and make the DraggableAdjudicator component disappear.