### PR TITLE
Set sides for bye debates when prefetching

### DIFF
--- a/tabbycat/results/dbutils.py
+++ b/tabbycat/results/dbutils.py
@@ -21,6 +21,8 @@ User = get_user_model()
 def add_results_to_round(round, **kwargs):
     """Calls add_result() for every debate in the given round."""
     for debate in round.debate_set.all():
+        if debate.is_bye:
+            continue
         add_result(debate, **kwargs)
 
 

--- a/tabbycat/results/prefetch.py
+++ b/tabbycat/results/prefetch.py
@@ -103,7 +103,8 @@ def populate_results(ballotsubs, tournament=None):
 
     # Create the DebateResults
     for ballotsub in ballotsubs:
-        result = DebateResult(ballotsub, load=False, sides=range(nsides_per_debate.get(ballotsub.debate_id, tournament.pref('teams_in_debate'))), criteria=criteria)
+        sides = [-1] if ballotsub.debate.is_bye else range(nsides_per_debate.get(ballotsub.debate_id, tournament.pref('teams_in_debate')))
+        result = DebateResult(ballotsub, load=False, sides=sides, criteria=criteria)
         result.init_blank_buffer()
 
         ballotsub._result = result


### PR DESCRIPTION
If a debate is a bye, the team would only get a "Win" as a team score, and no speaker scores. However, an error would be raised as "-1" would not be found.

Fixes BACKEND-DQ0