### PR TITLE
Feature/schedule separation by day

### DIFF
--- a/tabbycat/utils/tables.py
+++ b/tabbycat/utils/tables.py
@@ -1021,6 +1021,25 @@ class TabbycatTableBuilder(BaseTableBuilder):
             self.add_column(header, results)
 
     def add_schedule_event_columns(self, schedule_events):
+
+        tournament_days_verbose = {}
+        for ev in schedule_events:
+            temp_variable = timezone.localtime(ev.start_time).strftime("%A, %b %d")
+            if temp_variable in tournament_days_verbose.keys():
+                ev.show_day_flag = False
+            else:
+                tournament_days_verbose[temp_variable] = len(tournament_days_verbose.keys()) + 1
+                ev.show_day_flag = True
+
+        tournament_days = []
+        for ev in schedule_events:
+            if ev.show_day_flag:
+                tournament_days.append("Day " + str(tournament_days_verbose[timezone.localtime(ev.start_time).strftime("%A, %b %d")]) + " of tournament")
+            else:
+                tournament_days.append("")
+
+        self.add_column({'title': _("Day of tournamnet"), 'key': _("Day")}, tournament_days)
+
         self.add_column({'title': _("Event"), 'key': _("Event")}, [ev.title for ev in schedule_events])
 
         starts = [

--- a/tabbycat/utils/tables.py
+++ b/tabbycat/utils/tables.py
@@ -1038,7 +1038,7 @@ class TabbycatTableBuilder(BaseTableBuilder):
             else:
                 tournament_days.append("")
 
-        self.add_column({'title': _("Day of tournamnet"), 'key': _("Day")}, tournament_days)
+        self.add_column({'title': _(""), 'key': _("Day")}, tournament_days)
 
         self.add_column({'title': _("Event"), 'key': _("Event")}, [ev.title for ev in schedule_events])
 


### PR DESCRIPTION
Changed the add scheduled events to table function so that it segregates them by day of the tournament. I loaded a fake mini schedule in to see how the visual separation works. Open to feedback to make changes. 
<img width="1276" height="706" alt="Screenshot 2026-01-12 at 9 31 07 pm" src="https://github.com/user-attachments/assets/ed3b66f2-b6d3-4a13-93b9-77b53e436f1e" />



fixes #2758

