### PR TITLE
Add Schedule Events API endpoints

### DIFF
--- a/tabbycat/actionlog/models.py
+++ b/tabbycat/actionlog/models.py
@@ -116,6 +116,8 @@ class ActionLogEntry(models.Model):
         ADJUDICATOR_REGISTER              = 'aj.reg', _("Registered adjudicator")
         SPEAKER_REGISTER                  = 'sp.reg', _("Registered speaker")
         REGISTRATION_CONFIRM              = 're.conf', _("Confirmed registration")
+        SCHEDULE_EVENT_CREATE             = 'sc.crea', _("Created schedule event")
+        SCHEDULE_EVENT_EDIT               = 'sc.edit', _("Edited schedule event")
 
     class Agent(models.TextChoices):
         API = 'a', _("API")

--- a/tabbycat/api/serializers.py
+++ b/tabbycat/api/serializers.py
@@ -213,6 +213,9 @@ class TournamentSerializer(serializers.ModelSerializer):
         preferences = serializers.HyperlinkedIdentityField(
             view_name='tournamentpreferencemodel-list',
             lookup_field='slug', lookup_url_kwarg='tournament_slug')
+        schedule_events = serializers.HyperlinkedIdentityField(
+            view_name='api-scheduleevent-list',
+            lookup_field='slug', lookup_url_kwarg='tournament_slug')
 
     _links = TournamentLinksSerializer(source='*', read_only=True)
 

--- a/tabbycat/api/serializers.py
+++ b/tabbycat/api/serializers.py
@@ -35,7 +35,7 @@ from results.models import BallotSubmission, ScoreCriterion, SpeakerScore, Submi
 from results.result import DebateResult, ResultError
 from standings.speakers import SpeakerStandingsGenerator
 from standings.teams import TeamStandingsGenerator
-from tournaments.models import Round, Tournament
+from tournaments.models import Round, ScheduleEvent, Tournament
 from users.models import Group, Membership, UserPermission
 from users.permissions import has_permission, Permission
 from utils.misc import get_ip_address
@@ -1060,6 +1060,22 @@ class VenueCategorySerializer(serializers.ModelSerializer):
 
     class Meta:
         model = VenueCategory
+        exclude = ('tournament',)
+
+
+class ScheduleEventSerializer(serializers.ModelSerializer):
+    url = fields.TournamentHyperlinkedIdentityField(view_name='api-scheduleevent-detail')
+    round = fields.TournamentHyperlinkedRelatedField(
+        view_name='api-round-detail',
+        lookup_field='seq',
+        lookup_url_kwarg='round_seq',
+        queryset=Round.objects.all(),
+        allow_null=True,
+        required=False,
+    )
+
+    class Meta:
+        model = ScheduleEvent
         exclude = ('tournament',)
 
 

--- a/tabbycat/api/tests/test_serializers.py
+++ b/tabbycat/api/tests/test_serializers.py
@@ -46,6 +46,7 @@ class TournamentSerializerTests(CompletedTournamentTestMixin, APITestCase):
                 "feedback": tournament_url + "/feedback",
                 "feedback_questions": tournament_url + "/feedback-questions",
                 "preferences": tournament_url + "/preferences",
+                "schedule_events": tournament_url + "/schedule-events",
             },
             "name": self.tournament.name,
             "short_name": self.tournament.short_name,

--- a/tabbycat/api/urls.py
+++ b/tabbycat/api/urls.py
@@ -246,6 +246,15 @@ urlpatterns = [
                         name='api-venuecategory-detail'),
                 ])),
 
+                path('/schedule-events', include([
+                    path('',
+                        views.ScheduleEventViewSet.as_view(list_methods),
+                        name='api-scheduleevent-list'),
+                    path('/<int:pk>',
+                        views.ScheduleEventViewSet.as_view(detail_methods),
+                        name='api-scheduleevent-detail'),
+                ])),
+
                 path('/user-groups', include([
                     path('',
                         views.GroupViewSet.as_view(list_methods),

--- a/tabbycat/api/views.py
+++ b/tabbycat/api/views.py
@@ -598,6 +598,29 @@ class VenueCategoryViewSet(TournamentAPIMixin, PublicAPIMixin, ModelViewSet):
             Prefetch('venues', queryset=Venue.objects.select_related('tournament').filter(tournament__isnull=False)))
 
 
+@extend_schema(tags=['schedule'], parameters=[tournament_parameter])
+@extend_schema_view(
+    list=extend_schema(summary="List tournament schedule events"),
+    create=extend_schema(summary="Create schedule event"),
+    retrieve=extend_schema(summary="Get schedule event", parameters=[id_parameter]),
+    update=extend_schema(summary="Update schedule event", parameters=[id_parameter]),
+    partial_update=extend_schema(summary="Patch schedule event", parameters=[id_parameter]),
+    destroy=extend_schema(summary="Delete schedule event", parameters=[id_parameter]),
+)
+class ScheduleEventViewSet(TournamentAPIMixin, PublicAPIMixin, ModelViewSet):
+    serializer_class = serializers.ScheduleEventSerializer
+    action_log_type_created = ActionLogEntry.ActionType.SCHEDULE_EVENT_CREATE
+    action_log_type_updated = ActionLogEntry.ActionType.SCHEDULE_EVENT_EDIT
+
+    list_permission = Permission.VIEW_EVENTS
+    create_permission = Permission.EDIT_EVENTS
+    update_permission = Permission.EDIT_EVENTS
+    destroy_permission = Permission.EDIT_EVENTS
+
+    def get_queryset(self):
+        return super().get_queryset().select_related('tournament', 'round').order_by('start_time')
+
+
 @extend_schema(tags=['checkins'], parameters=[tournament_parameter, id_parameter])
 class BaseCheckinsView(AdministratorAPIMixin, TournamentAPIMixin, APIView):
     name = "Check-ins"


### PR DESCRIPTION
## Summary
- Add REST API endpoints to read and update schedule events for tournaments
- Supports full CRUD operations: list, create, retrieve, update, partial_update, delete
- Uses existing `VIEW_EVENTS` and `EDIT_EVENTS` permissions
- Includes action logging for create and edit operations

## API Endpoints
| Method | Endpoint | Description |
|--------|----------|-------------|
| GET | `/api/v1/tournaments/<slug>/schedule-events/` | List all schedule events |
| POST | `/api/v1/tournaments/<slug>/schedule-events/` | Create a schedule event |
| GET | `/api/v1/tournaments/<slug>/schedule-events/<pk>/` | Get single event |
| PUT/PATCH | `/api/v1/tournaments/<slug>/schedule-events/<pk>/` | Update event |
| DELETE | `/api/v1/tournaments/<slug>/schedule-events/<pk>/` | Delete event |

## Test plan
- [x] Tested GET (list) endpoint - returns empty array when no events
- [x] Tested POST endpoint - creates event and returns 201
- [x] Tested GET (single) endpoint - returns event details
- [x] Tested PATCH endpoint - updates event and returns 200
- [x] Tested DELETE endpoint - returns 204