### PR TITLE
Fixes from my first local docker installation in ages

### DIFF
--- a/bin/osx_docker_start.command
+++ b/bin/osx_docker_start.command
@@ -9,4 +9,4 @@ cd "${DIR}"
 cd ..
 
 # Do docker stuff
-docker-compose -f docker-compose.yml up
+docker compose -f docker-compose.yml up

--- a/bin/windows_docker_start.bat
+++ b/bin/windows_docker_start.bat
@@ -6,7 +6,7 @@ cd ..
 SET COMPOSE_CONVERT_WINDOWS_PATHS=1
 
 :: Run docker
-docker-compose -f docker-compose.yml up
+docker compose -f docker-compose.yml up
 
 :: Don't just vanish after doing it
 cmd /k

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -4,15 +4,14 @@
 # Note that this file extends and overrides what is specified in docker-compose.yml
 
 # Initial setup with
-# $ docker-compose -f docker-compose.yml -f docker-compose.prod.yml build
+# $ docker compose -f docker-compose.yml -f docker-compose.prod.yml build
 
 # Can run management commands with
-# $ docker-compose run web /code/manage.py whatever
+# $ docker compose run web /code/manage.py whatever
 
-version: '3'
+version: "3"
 
 services:
-
   web:
     environment:
       - DEBUG=0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,12 +3,10 @@
 # Reference: https://docs.docker.com/compose/compose-file/
 
 # Initial setup with
-# $ docker-compose -f docker-compose.yml up
+# $ docker compose -f docker-compose.yml up
 
 # Can run management commands with
-# $ docker-compose run web /code/manage.py whatever
-
-version: '3'
+# $ docker compose run web /code/manage.py whatever
 
 services:
   db:
@@ -18,17 +16,24 @@ services:
       - POSTGRES_USER=tabbycat
       - POSTGRES_DB=tabbycat
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - pgdata:/var/lib/postgresql
 
   redis:
     image: redis:6
     volumes:
-     - redis_data:/data
+      - redis_data:/data
 
   web:
     build: .
     # Hack to wait until Postgres is up before running things
-    command: ["./bin/docker-wait.sh", "--timeout=0", "db:5432", "--", "./bin/docker-run-honcho.sh"]
+    command:
+      [
+        "./bin/docker-wait.sh",
+        "--timeout=0",
+        "db:5432",
+        "--",
+        "./bin/docker-run-honcho.sh",
+      ]
     depends_on:
       - db
       - redis
@@ -47,7 +52,14 @@ services:
   worker:
     build: .
     # Hack to wait until migration is done before running things
-    command: ["./bin/docker-wait.sh", "--timeout=0", "web:8000", "--", "./bin/docker-run-worker.sh"]
+    command:
+      [
+        "./bin/docker-wait.sh",
+        "--timeout=0",
+        "web:8000",
+        "--",
+        "./bin/docker-run-worker.sh",
+      ]
     depends_on:
       - db
       - redis

--- a/docs/install/docker.rst
+++ b/docs/install/docker.rst
@@ -45,7 +45,7 @@ Notes for specific operating systems:
 
     - If you're on macOS, press the Control key, click the icon for **osx_docker_start.command**, then choose Open from the shortcut menu.
     - If you're on Windows, open **windows_docker_start.bat**.
-    - If you're on Linux, open up a terminal in the Tabbycat folder (*i.e.* the folder containing ``README.md``) and run ``docker-compose up``.
+    - If you're on Linux, open up a terminal in the Tabbycat folder (*i.e.* the folder containing ``README.md``) and run ``docker compose up``.
 
 3. A terminal window should pop up and lots of text should scroll by. If this is your first time running Docker, it may take a while (30 minutes or more) to download the virtual machine. The last few lines will say something like:
 


### PR DESCRIPTION
To get things running I needed to:

- Use `docker compose ...` rather than `docker-compose ...` (this change had been made already in other places)
- Change the path for postgres data storage [this would probably break existing local docker installs?]

I also removed the version because that it is a deprecated property.

The warning for postgres was: 

```
Error: in 18+, these Docker images are configured to store database data in a

       format which is compatible with "pg_ctlcluster" (specifically, using

       major-version-specific directory names).  This better reflects how

       PostgreSQL itself works, and how upgrades are to be performed.


       See also https://github.com/docker-library/postgres/pull/1259⁠


       Counter to that, there appears to be PostgreSQL data in:

         /var/lib/postgresql/data


       This is usually the result of upgrading the Docker image without

       upgrading the underlying database using "pg_upgrade" (which requires both

       versions).


       The suggested container configuration for 18+ is to place a single mount

       at /var/lib/postgresql which will then place PostgreSQL data in a

       subdirectory, allowing usage of "pg_upgrade --link" without mount point

       boundary issues.


       See https://github.com/docker-library/postgres/issues/37⁠ for a (long)

       discussion around this process, and suggestions for how to do so.
```