### PR TITLE
Remove/replace CSS class that doesn't exist

### DIFF
--- a/tabbycat/checkins/templates/checkin_ids.html
+++ b/tabbycat/checkins/templates/checkin_ids.html
@@ -37,7 +37,7 @@
               {% else %}
                 {% trans "Generate all identifiers" as text %}
               {% endif %}
-              <div class="list-item-group">
+              <div class="list-group-item">
                 <form action="{% tournamenturl 'admin-checkin-generate' kind=check_key %}" method="POST">
                   {% csrf_token %}
                   <button type="submit" class="btn btn-primary btn-block">{{ text }}</button>

--- a/tabbycat/templates/components/item-action.html
+++ b/tabbycat/templates/components/item-action.html
@@ -1,4 +1,4 @@
-{% if alone %}<div class="list-item-group">{% endif %}
+{% if alone %}<div class="list-group">{% endif %}
 
   <a href="{{ url }}" {% if blank %}target="_blank"{% endif %} {% if id %}id="{{ id }}"{% endif %}
    class="{% if not child %}list-group-item {% endif %}list-group-item-action


### PR DESCRIPTION
<img width="1086" height="1170" alt="CleanShot 2026-01-23 at 09 08 49@2x" src="https://github.com/user-attachments/assets/f5a1fa87-a824-4321-aa1b-c720d95c9e2f" />

The initial notification has square edges. Looks like `list-item-group` doesn't actually exist and is a typo of `list-group-item` or (more accurately in this context) `list-group`. As I understand it, the `alone` should be ensuring that solitary notifications have the proper wrapper. 

<img width="1256" height="1084" alt="CleanShot 2026-01-23 at 09 08 35@2x" src="https://github.com/user-attachments/assets/a8400c27-5efa-45e0-8b06-b46ae88cf3d1" />