### PR TITLE
Align local dev settings and inline scripts with the Vite workflow

### DIFF
--- a/tabbycat/availability/templates/availability_index.html
+++ b/tabbycat/availability/templates/availability_index.html
@@ -233,7 +233,7 @@
 
 {% block js %}
   {{ block.super }}
-  <script>
+  <script type="module">
     $(document).ready( function() {
       $("#createDraw").click(function(event) {
         $.fn.loadButton(event.target); // Prevent double submission

--- a/tabbycat/draw/templates/draw_display_admin.html
+++ b/tabbycat/draw/templates/draw_display_admin.html
@@ -446,7 +446,7 @@
 
 {% block js %}
   {{ block.super }}
-  <script>
+  <script type="module">
     $(document).ready( function() { // Use the fake submit buttons as real submission
       $("#triggerReleaseDrawForm").click( function() {
         $("#releaseDrawForm").submit();

--- a/tabbycat/draw/templates/draw_display_by.html
+++ b/tabbycat/draw/templates/draw_display_by.html
@@ -69,7 +69,7 @@
 
 {% block js %}
   {{ block.super }}
-  <script>
+  <script type="module">
     function startScrolling() {
       {% if no_popovers %}
       $('.hover-target').css("pointer-events", "none")

--- a/tabbycat/privateurls/templates/private_url_landing.html
+++ b/tabbycat/privateurls/templates/private_url_landing.html
@@ -137,7 +137,7 @@
 
 {% block js %}
   {{ block.super }}
-  <script>
+  <script type="module">
     $(document).ready( function() { // Use the fake submit buttons as real submission
       $("#triggerCheckInForm").click( function() {
         $("#checkInForm").submit();
@@ -147,7 +147,7 @@
   </script>
 
   <!-- WebPush Subscription Logic -->
-  <script>
+  <script type="module">
     // Utility function to convert base64 to Uint8Array
     function urlBase64ToUint8Array(base64String) {
       var padding = '='.repeat((4 - base64String.length % 4) % 4);
@@ -266,7 +266,7 @@
   </script>
   {% if checkins_used %}
     <script src="{% static 'js/vendor/JsBarcode.all.min.js' %}"></script>
-    <script>
+    <script type="module">
       JsBarcode(".barcode-placeholder").init();
       $("#openBarcode").click( function() {
         $("#barcodeModal").modal('show');

--- a/tabbycat/results/templates/assistant_enter_results.html
+++ b/tabbycat/results/templates/assistant_enter_results.html
@@ -63,7 +63,7 @@
 
 {% block js %}
 {{ block.super }}
-<script type="text/javascript">
+<script type="module">
   $(document).ready( function() {
     {% if not new %}
       function preSubmit() {

--- a/tabbycat/results/templates/enter_results.html
+++ b/tabbycat/results/templates/enter_results.html
@@ -64,7 +64,7 @@
 {% block js %}
   {{ block.super }}
   <script src="{% static 'js/vendor/jquery.validate.js' %}"></script>
-  <script>
+  <script type="module">
     $(document).ready( function() {
       {% include "js-bundles/enter_results.js" %}
     });

--- a/tabbycat/results/templates/public_enter_results.html
+++ b/tabbycat/results/templates/public_enter_results.html
@@ -79,7 +79,7 @@
   {{ block.super }}
   <!-- TODO: bundle -->
   <script src="{% static 'js/vendor/jquery.validate.js' %}"></script>
-  <script>
+  <script type="module">
     $(document).ready( function() {
       {% include "js-bundles/enter_results.js" %}
     });

--- a/tabbycat/results/templates/public_enter_results_error.html
+++ b/tabbycat/results/templates/public_enter_results_error.html
@@ -21,7 +21,7 @@
   {{ block.super }}
   <!-- TODO: bundle -->
   <script src="{% static 'js/vendor/jquery.validate.js' %}"></script>
-  <script>
+  <script type="module">
     $(document).ready( function() {
       {% include "js-bundles/enter_results.js" %}
     });

--- a/tabbycat/settings/local.example
+++ b/tabbycat/settings/local.example
@@ -28,7 +28,9 @@ ADMINS              = ()
 MANAGERS            = ADMINS
 DEBUG               = True
 DEBUG_ASSETS        = True
+USE_VITE_SERVER     = True
 SECRET_KEY          = '#2q43u&tp4((4&m3i8v%w-6z6pp7m(v0-6@w@i!j5n)n15epwc'
+
 
 # ==============================================================================
 # Django-specific Modules

--- a/tabbycat/tournaments/templates/set_current_round.html
+++ b/tabbycat/tournaments/templates/set_current_round.html
@@ -69,7 +69,7 @@
 {% block js %}
   {{ block.super }}
 
-  <script>
+  <script type="module">
     $('#id_prelim').change(function () {
       if ($('#id_prelim').val() == 'all-completed') {
         $('select[id^=id_elim_]').prop('disabled', false);

--- a/tabbycat/utils/context_processors.py
+++ b/tabbycat/utils/context_processors.py
@@ -11,7 +11,7 @@ def debate_context(request):
         'all_tournaments': Tournament.objects.filter(active=True),
         'disable_sentry': getattr(settings, 'DISABLE_SENTRY', False),
         'on_local': getattr(settings, 'ON_LOCAL', False),
-        'hmr': getattr(settings, 'USE_WEBPACK_SERVER', False),
+        'hmr': getattr(settings, 'USE_VITE_SERVER', False),
     }
 
     if hasattr(request, 'tournament'):

--- a/tabbycat/venues/templates/venue_constraints_edit.html
+++ b/tabbycat/venues/templates/venue_constraints_edit.html
@@ -26,7 +26,7 @@
 
   {{ block.super }}
 
-  <script>
+  <script type="module">
     $(document).ready( function() {
 
       function filterContentIDs(filteredList, filterToType) {


### PR DESCRIPTION
- Added the USE_VITE_SERVER flag and set it to be on by default in settings/local.example. This was done after renaming the old USE_WEBPACK_SERVER flag to the new USE_VITE_SERVER, so the hmr context flag now reflects the dev server introduced in the recent “Migrate Templates to local Vite HMR Setup” PR. Without adding this flag, participant lists and standings pages silently failed to load because the templates never received an active HMR signal.

- Updated all inline script blocks to declare type="module" (availability, draw admin/by, private URLs, results, tournaments, venues, etc.), keeping them consistent with Vite’s module graph. Previously these scripts were treated as classic scripts, causing buttons like “Generate Draw” (and other inline-script actions) to hang because Vite couldn’t process the inline code; marking them as modules resolves those interactions