### PR TITLE
docs: Document Redis requirement for local installs

### DIFF
--- a/docs/features/adjudicator-allocation.rst
+++ b/docs/features/adjudicator-allocation.rst
@@ -41,6 +41,8 @@ To begin this process, click the *Allocate* button in the top-left. If you have 
 
 Once you click *Auto-Allocate Adjudicators* the modal should disappear and your panels should appear. At large tournaments, and in the later rounds, it is not unheard of for this process to take a minute or longer.
 
+.. note:: If you are running a local installation and the allocator modal appears to hang on "Loading...", ensure that you have configured a :ref:`local Redis instance and are running a background worker <install-local>`.
+
 .. note:: You can re-run the automatic allocation process on top of an existing allocation. Thus it is worth tweaking your priorities or allocation settings if the allocation does not seem optimal to you. Also note that the allocation process is not deterministic — if you rerun it the panels will be different.
 
 Once your adjudicators have been allocated you can drag and drop them on to different panels. You can also drag and drop them to the 'unused area' (the gray bar at the bottom of the page) if you wish to store them temporarily or remove them from the draw. Dropping an adjudicator into the chair position will 'swap' that adjudicator into the previous position of the new chair.

--- a/docs/install/linux.rst
+++ b/docs/install/linux.rst
@@ -28,7 +28,7 @@ Short version
 ::
 
   curl -sL https://deb.nodesource.com/setup_16.x | sudo -E bash -    # add Node.js source repository
-  sudo apt install python3.11 python3-distutils pipenv postgresql libpq-dev nodejs gcc g++ make
+  sudo apt install python3.11 python3-distutils pipenv postgresql libpq-dev nodejs gcc g++ make redis-server
   git clone https://github.com/TabbycatDebate/tabbycat.git
   cd tabbycat
   git checkout master
@@ -111,6 +111,15 @@ Tabbycat requires Node and its package manager to compile front-end dependencies
 Some of the Python packages require GCC, G++ and Make in order to install::
 
     $ sudo apt install gcc g++ make
+
+1(e). Redis
+-----------
+  *Redis is an in-memory data structure store, used as a message broker.*
+
+Tabbycat requires Redis to handle asynchronous background tasks (like adjudicator allocation) and real-time updates. Install and start Redis using::
+
+    $ sudo apt install redis-server
+    $ sudo systemctl enable --now redis-server
 
 .. _install-linux-source-code:
 

--- a/docs/install/osx.rst
+++ b/docs/install/osx.rst
@@ -59,6 +59,14 @@ You'll need to use the PostgreSQL command-line tools, so run the command that th
 
 Download and run the `node.js 8 macOS Installer (.pkg) <https://nodejs.org/dist/v12.18.1/node-v12.18.1.pkg>`_
 
+1(d). Redis
+--------------------------------------------------------------------------------
+
+Tabbycat requires `Redis <https://redis.io/>`_ to handle asynchronous background tasks (like adjudicator allocation) and real-time updates. You can install it using `Homebrew <https://brew.sh/>`_::
+
+  $ brew install redis
+  $ brew services start redis
+
 2. Get the source code
 ================================================================================
 

--- a/docs/install/osx.rst
+++ b/docs/install/osx.rst
@@ -60,10 +60,15 @@ You'll need to use the PostgreSQL command-line tools, so run the command that th
 Download and run the `node.js 8 macOS Installer (.pkg) <https://nodejs.org/dist/v12.18.1/node-v12.18.1.pkg>`_
 
 1(d). Redis
---------------------------------------------------------------------------------
-
-Tabbycat requires `Redis <https://redis.io/>`_ to handle asynchronous background tasks (like adjudicator allocation) and real-time updates. You can install it using `Homebrew <https://brew.sh/>`_::
-
+-----------
+  *Redis is an in-memory data structure store, used as a message broker and cache.*
+ 
+Tabbycat requires Redis for two critical functions:
+ 
+  1. Asynchronous Background Tasks: Redis serves as a message broker for Django Channels, handling real-time features like live adjudicator allocation, check-ins updates, and round results display.
+ 
+  2. Page Caching: Redis caches frequently accessed public pages (draws, standings, results) to improve performance during high-traffic periods, especially during tournament events.
+ 
   $ brew install redis
   $ brew services start redis
 

--- a/tabbycat/settings/local.example
+++ b/tabbycat/settings/local.example
@@ -57,3 +57,12 @@ CACHES = { # Use a dummy cache in development
 
 # Use the cache with database write through for local sessions
 SESSION_ENGINE = 'django.contrib.sessions.backends.cached_db'
+
+CHANNEL_LAYERS = {
+    "default": {
+        "BACKEND": "channels_redis.core.RedisChannelLayer",
+        "CONFIG": {
+            "hosts": [("localhost", 6379)],
+        },
+    },
+}

--- a/tabbycat/settings/local.example
+++ b/tabbycat/settings/local.example
@@ -66,3 +66,13 @@ CHANNEL_LAYERS = {
         },
     },
 }
+
+CACHES = {
+    "default": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": "redis://127.0.0.1:6379/1",
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            "IGNORE_EXCEPTIONS": True, # Don't crash on say ConnectionError due to limits
+        }
+    }


### PR DESCRIPTION
- Automatic adjudicator allocation was stalling on “Loading…” whenever a local developer hadn’t configured Redis and a background worker. Channels-based allocation tasks rely on Redis as the broker, so without it the modal never receives a response
- Updated the Linux install guide to include Redis in the short dependency list and added a dedicated subsection with install/start commands 
- Added a Redis installation subsection to the macOS guide with Homebrew instructions 
- Added a Redis prerequisite note to the adjudicator allocation guide so local users know to run Redis and a worker when the modal appears to hang 
- Extended the local settings example with a default CHANNEL_LAYERS config pointing to the local Redis instance 