### PR TITLE
Add option to hide metrics on public break page

### DIFF
--- a/tabbycat/breakqual/views.py
+++ b/tabbycat/breakqual/views.py
@@ -85,6 +85,23 @@ class PublicBreakingTeamsView(PublicTournamentPageMixin, BaseBreakingTeamsView):
     public_page_preference = 'public_breaking_teams'
     cache_timeout = settings.PUBLIC_SLOW_CACHE_TIMEOUT
 
+    def get_table(self):
+        metrics_to_show = self.tournament.pref('public_break_metrics_to_show')
+        self.standings = self.get_standings()
+
+        if metrics_to_show != -1:
+            n = max(0, metrics_to_show)
+            self.standings.metric_keys = self.standings.metric_keys[:n]
+            self.standings._metric_specs = self.standings._metric_specs[:n]
+
+        table = TabbycatTableBuilder(view=self, title=escape(self.object.name), sort_key='Rk')
+        table.add_ranking_columns(self.standings)
+        table.add_column({'title': _("Break"), 'key': 'break'},
+                         [tsi.break_rank for tsi in self.standings])
+        table.add_team_columns([tsi.team for tsi in self.standings])
+        table.add_metric_columns(self.standings)
+        return table
+
 
 class GenerateBreakMixin:
 

--- a/tabbycat/options/preferences.py
+++ b/tabbycat/options/preferences.py
@@ -1190,6 +1190,17 @@ class PublicBreakingTeams(BooleanPreference):
 
 
 @tournament_preferences_registry.register
+class PublicBreakMetricsToShow(IntegerPreference):
+    help_text = _("How many metrics from the team standings precedence to show on the public break page. "
+                  "For example, 2 shows only the first two metrics set in Standings. "
+                  "Use 0 to hide all metrics, or -1 to show all of them.")
+    verbose_name = _("Number of metrics to show on public break page")
+    section = public_features
+    name = 'public_break_metrics_to_show'
+    default = -1
+
+
+@tournament_preferences_registry.register
 class PublicBreakingAdjs(BooleanPreference):
     help_text = _("Enables the public page showing breaking adjudicators. Intended for use after the break announcement.")
     verbose_name = _("Release adjudicators break to public")


### PR DESCRIPTION
PR based on an idea shared by @tienne-B 
"As we release the break but want to avoid revealing speaks or extra metrics, we are left with two unideal options: temporarily removing speaks from the standings precedence, or not releasing the break on Tabbycat."

Fix : 
- Adds a "Hide metrics on public break page" toggle under Public Features in preferences.py
- When enabled, speaker score and draw strength  columns are hidden from the public break page, while keeping points, 1sts and 2nds visible
