### PR TITLE
Hotfix to prevent vnode hoisting in tables + sentry vue integration guard

### DIFF
--- a/tabbycat/templates/js-bundles/main.js
+++ b/tabbycat/templates/js-bundles/main.js
@@ -258,7 +258,9 @@ if (typeof vueData !== 'undefined') {
       components: vueComponents,
       data: () => vueData,
     })
-    Sentry.addIntegration(Sentry.vueIntegration({ app }));
+    if (window.buildData.sentry === true) {
+      Sentry.addIntegration(Sentry.vueIntegration({ app }));
+    }
     app.use(pinia)
     useDragAndDropStore(pinia)
     app.mixin(vueTranslationMixin)

--- a/tabbycat/templates/tables/TablesContainer.vue
+++ b/tabbycat/templates/tables/TablesContainer.vue
@@ -15,6 +15,10 @@ const filterKey = ref('')
 
 const table = ref([])
 
+const setTableRef = (i) => (el) => {
+  table.value[i] = el
+}
+
 const tableClass = computed(() => {
   if (props.tablesData.length === 1) {
     return 'col-md-12'
@@ -86,7 +90,7 @@ const copyTableTrigger = (i) => {
             </small>
           </h4>
           <smart-table
-            ref="table"
+            :ref="setTableRef(i)"
             :table-headers="table.head"
             :table-content="table.data"
             :table-class="table.class"


### PR DESCRIPTION
Hey! 

I have tried fresh local install via docker for the latest develop branch and I saw that all smart tables were missing, looking at the dev logs, the issue was with Vue.js rendering. With the help of LLM "friend" I come up with the fix, below is a concise report of what was the issue + side Sentry bug was fixed upon examining the issue. 

Can you please verify the issue is valid?

--
Cheers

## Report

### Problem

All Vue-rendered tables/components fail to render with:

>Uncaught TypeError: Cannot read properties of undefined (reading 'refs') at runtime-core.esm-bundler.js

This only occurs in production builds (npm run build), because Vue's dev guard for this error is stripped via tree-shaking.

### Steps to reproduce

1. Run Tabbycat with DISABLE_SENTRY=1 (default for Docker and local dev)
2. Open any page with a table (e.g. team standings, availability)
3. Tables are empty, browser console shows the refs error

### Root cause

`TablesContainer.vue`: The v-for loop variable table shadows the `const table = ref([])` from `<script setup>`. This causes Vue 3.5's compiler to hoist the `ref="table"` vnode, which loses its component instance context. In production builds the `!owner` guard is stripped, so `owner.refs` crashes.

`main.js`: `Sentry.addIntegration(Sentry.vueIntegration({ app }))` runs unconditionally, even when
`Sentry.init()` is skipped. Not the cause of the crash, but a latent bug.

### Fix

- Replace static `ref="table"` with a dynamic function ref (`:ref="setTableRef(i)"`) to prevent vnode hoisting
- Guard `addIntegration()` with `window.buildData.sentry === true`, matching the existing `Sentry.init()` guard