### PR TITLE
jQuery validate broken on ballot entry pages

### DIFF
--- a/tabbycat/templates/js-bundles/jquery-shim.js
+++ b/tabbycat/templates/js-bundles/jquery-shim.js
@@ -1,0 +1,4 @@
+// Re-export the global jQuery loaded via <script> tag in base.html.
+// This ensures the Vite bundle (and Bootstrap) use the same jQuery
+// instance that jquery.validate.js and other plugins attach to.
+export default window.jQuery

--- a/tabbycat/templates/js-bundles/main.js
+++ b/tabbycat/templates/js-bundles/main.js
@@ -3,8 +3,8 @@ import { createApp, defineAsyncComponent } from 'vue'
 import { createPinia } from 'pinia'
 import * as Sentry from '@sentry/vue';
 import feather from 'feather-icons'
-import $ from 'jquery'
 import 'bootstrap' // Import bootstrap javascript plugins
+const $ = window.jQuery
 
 // Generic Templates
 import CheckboxTablesContainer from '../tables/CheckboxTablesContainer.vue'
@@ -43,9 +43,6 @@ if (window.buildData.sentry === true) {
 // -----------------------------------------------------------------------------
 // TCI: jQuery, Lodash, and Boostrap
 // -----------------------------------------------------------------------------
-
-window.jQuery = $ // Set for bootstrap
-window.$ = $ // Set for browser window
 
 // Add alerts programmatically
 $.fn.extend({

--- a/vite.config.js
+++ b/vite.config.js
@@ -17,6 +17,7 @@ module.exports = defineConfig(({ command }) => {
     resolve: {
       alias: {
         vue: 'vue/dist/vue.esm-bundler.js',
+        jquery: path.resolve(templatesRoot, 'js-bundles/jquery-shim.js'),
       },
     },
     server: {


### PR DESCRIPTION
Hey! 

Spotted another error on `develop`: when opening ballot edits, places are not rendered, dev log shows error with `JQuery` validation. Running on local docker install, see the report below.

## Report

### Problem

>$(...).validate is not a function error on all ballot entry pages (enter_results, public_enter_results, public_enter_results_error). Ballot form validation does not run — speaker positions, scores, and other fields are not validated client-side.

### Steps to reproduce

1. Navigate to any ballot entry page (admin or public)
2. Open browser console
3. `Error: jquery.js:4059 Uncaught TypeError: $(...).validate is not a function at HTMLDocument.<anonymous>`

### Root cause

`app.js` is loaded as a Vite module (`<script type="module">`), which is deferred. It imports its own jQuery and overwrites `window.$` / `window.jQuery`. The `jquery.validate.js` plugin is attached to the original jQuery instance loaded via `<script>` tag, but by the time `$(document).ready()` callbacks fire, `$` already points to the bundled instance — which lacks the validate plugin.

### Fix

Wrap the inline script in an IIFE `(function($) { ... })(jQuery)` to capture the jQuery reference at evaluation time (when the validate plugin is still attached), before `app.js` overwrites the global.