### PR TITLE
API: Add links to ballots on round standings

### DIFF
--- a/tabbycat/api/fields.py
+++ b/tabbycat/api/fields.py
@@ -96,9 +96,8 @@ class RoundHyperlinkedIdentityField(RoundHyperlinkedRelatedField, HyperlinkedIde
     pass
 
 
-class DebateHyperlinkedIdentityField(RoundHyperlinkedIdentityField):
+class DebateHyperlinkedRelatedField(RoundHyperlinkedRelatedField):
     default_tournament_field = 'debate__round__tournament'
-    round_field = 'debate__round'
 
     def get_round(self, obj):
         return obj.debate.round
@@ -112,7 +111,11 @@ class DebateHyperlinkedIdentityField(RoundHyperlinkedIdentityField):
         return {'debate': self.context['debate']}
 
     def get_queryset(self):
-        return super().get_queryset().select_related('debate')
+        return super().get_queryset().select_related('debate__round__tournament')
+
+
+class DebateHyperlinkedIdentityField(DebateHyperlinkedRelatedField, HyperlinkedIdentityField):
+    pass
 
 
 class AnonymisingParticipantNameField(CharField):

--- a/tabbycat/api/serializers.py
+++ b/tabbycat/api/serializers.py
@@ -1744,9 +1744,11 @@ class PreformedPanelSerializer(serializers.ModelSerializer):
 class SpeakerRoundScoresSerializer(serializers.ModelSerializer):
     class RoundScoresSerializer(serializers.ModelSerializer):
         class RoundSpeechSerializer(serializers.ModelSerializer):
+            ballot_url = fields.DebateHyperlinkedRelatedField(view_name='api-ballot-detail', source='ballot_submission', queryset=BallotSubmission.objects.all(), allow_null=True)
+
             class Meta:
                 model = SpeakerScore
-                fields = ('score', 'position', 'ghost')
+                fields = ('score', 'position', 'ghost', 'rank', 'ballot_url')
 
         round = fields.TournamentHyperlinkedRelatedField(view_name='api-round-detail', source='debate.round',
             lookup_field='seq', lookup_url_kwarg='round_seq',
@@ -1773,13 +1775,15 @@ class TeamRoundScoresSerializer(serializers.ModelSerializer):
             lookup_field='seq', lookup_url_kwarg='round_seq',
             queryset=Round.objects.all())
 
+        ballot_url = fields.DebateHyperlinkedRelatedField(view_name='api-ballot-detail', source='ballot.ballot_submission', queryset=BallotSubmission.objects.all(), allow_null=True)
         points = serializers.IntegerField(source='ballot.points')
         score = serializers.FloatField(source='ballot.score')
         has_ghost = serializers.BooleanField(source='ballot.has_ghost')
+        win = serializers.BooleanField(source='ballot.win')
 
         class Meta:
             model = TeamScore
-            fields = ('round', 'points', 'score', 'has_ghost')
+            fields = ('round', 'ballot_url', 'points', 'score', 'has_ghost', 'win')
 
     team = fields.TournamentHyperlinkedIdentityField(view_name='api-team-detail')
     rounds = ScoreSerializer(many=True, source="debateteam_set")

--- a/tabbycat/api/views.py
+++ b/tabbycat/api/views.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from copy import deepcopy
 from itertools import groupby
 
@@ -1023,14 +1024,19 @@ class SpeakerRoundStandingsRoundsView(TournamentAPIMixin, TournamentPublicAPIMix
     list_permission = Permission.VIEW_SPEAKERSSTANDINGS
 
     def get_queryset(self):
-        qs = super().get_queryset().prefetch_related(Prefetch('team__debateteam_set', queryset=DebateTeam.objects.all().select_related('debate__round__tournament')))
-        data = {s.id: s for s in qs.all()}
+        qs = super().get_queryset()
+        data = {s.id: s for s in qs}
+
+        # Bulk load debateteams for all speakers' teams (avoids N+1 from per-speaker access)
+        team_ids = list({s.team_id for s in data.values()})
+        debateteams_by_team_id = defaultdict(list)
+        for dt in DebateTeam.objects.filter(team_id__in=team_ids).select_related('debate__round__tournament'):
+            debateteams_by_team_id[dt.team_id].append(dt)
 
         params_serializer = SpeakerRoundStandingsRoundsParamsSerializer(data=self.request.query_params, context={'tournament': self.tournament})
         params_serializer.is_valid(raise_exception=True)
 
-        speaker_scores = SpeakerScore.objects.select_related('speaker', 'ballot_submission',
-            'debate_team__debate__round__tournament').filter(
+        speaker_scores = SpeakerScore.objects.select_related('speaker', 'ballot_submission__debate__round__tournament').filter(
             ballot_submission__confirmed=True, speaker_id__in=data.keys(),
         ).order_by('speaker_id', 'debate_team_id', 'position')
 
@@ -1042,7 +1048,7 @@ class SpeakerRoundStandingsRoundsView(TournamentAPIMixin, TournamentPublicAPIMix
             speaker_scores = speaker_scores.filter(position__lte=self.tournament.last_substantive_position)
 
         for spk in data.values():
-            spk.debateteams = deepcopy(spk.team.debateteam_set.all())
+            spk.debateteams = deepcopy(debateteams_by_team_id[spk.team_id])
             for dt in spk.debateteams:
                 dt.scores = []
 
@@ -1067,7 +1073,7 @@ class TeamRoundStandingsRoundsView(TournamentAPIMixin, TournamentPublicAPIMixin,
     list_permission = Permission.VIEW_TEAMSTANDINGS
 
     def get_queryset(self):
-        ts_pf = Prefetch('teamscore_set', queryset=TeamScore.objects.filter(ballot_submission__confirmed=True), to_attr='round_scores')
+        ts_pf = Prefetch('teamscore_set', queryset=TeamScore.objects.select_related('ballot_submission__debate__round__tournament').filter(ballot_submission__confirmed=True), to_attr='round_scores')
         qs = super().get_queryset().prefetch_related(
             Prefetch('debateteam_set', queryset=DebateTeam.objects.all().prefetch_related(ts_pf).select_related('debate__round__tournament')))
 
@@ -1183,7 +1189,10 @@ class BallotViewSet(RoundAPIMixin, TournamentPublicAPIMixin, ModelViewSet):
             return (
                 (view.action in ['list', 'retrieve', 'create'] and view.tournament.pref('participant_ballots') == 'private-urls' and view.participant_requester) or
                 (view.action == 'create' and view.tournament.pref('participant_ballots') == 'public') or
-                (view.action in ['list', 'retrieve'] and view.tournament.pref('private_ballots_released') is True)
+                (view.action in ['list', 'retrieve'] and (
+                    view.tournament.pref('private_ballots_released') or
+                    view.tournament.pref('ballots_released') or
+                    (view.tournament.pref('all_results_released') and view.tournament.pref('speaker_tab_released'))))
             )
 
     serializer_class = serializers.BallotSerializer
@@ -1193,7 +1202,7 @@ class BallotViewSet(RoundAPIMixin, TournamentPublicAPIMixin, ModelViewSet):
     round_field = 'debate__round'
 
     authentication_classes = [TokenAuthentication, SessionAuthentication, URLKeyAuthentication]
-    permission_classes = [PerTournamentPermissionRequired | PublicPreferencePermission | CustomPermission]
+    permission_classes = [PerTournamentPermissionRequired | CustomPermission]
 
     list_permission = Permission.VIEW_BALLOTSUBMISSIONS
     create_permission = Permission.ADD_BALLOTSUBMISSIONS


### PR DESCRIPTION
* Each score now gets identified with the ballot from where the score was obtained
* Ballots are now available if all results are released and the speaker tab is public.