### PR TITLE
Add warning if first round should be seeded

### DIFF
--- a/tabbycat/availability/templates/availability_index.html
+++ b/tabbycat/availability/templates/availability_index.html
@@ -202,6 +202,27 @@
     </div>
   {% endif %}
 
+  {% if has_seeds and round.draw_type != round.DrawType.SEEDED %}
+    <div class="alert alert-warning" id="seeded-draw-alert">
+      <div class="row align-items-center">
+        <div class="col-auto pr-1">
+          <i data-feather="alert-circle"></i>
+        </div>
+        <div class="col pl-0 pr-0">
+          {% blocktrans trimmed %}
+            One or more teams have a <strong>seed</strong> assigned, but this round's draw type
+            is not <strong>Seeded</strong>.
+          {% endblocktrans %}
+        </div>
+        <div class="col-auto pl-2">
+          <button class="btn btn-sm btn-warning" id="set-seeded-draw-btn" onclick="setSeededDrawType()">
+            {% trans "Set draw type to Seeded" %}
+          </button>
+        </div>
+      </div>
+    </div>
+  {% endif %}
+
   {% if pref.team_standings_precedence|length == 0 %}
     {% tournamenturl 'options-tournament-section' section='standings' as standings_config_url %}
     {% blocktrans trimmed asvar message %}
@@ -229,3 +250,39 @@
   </div>
 
 {% endblock content %}
+
+{% block js %}
+  {{ block.super }}
+  {% if has_seeds and round.draw_type != round.DrawType.SEEDED %}
+  <script>
+    function setSeededDrawType() {
+      const btn = document.getElementById('set-seeded-draw-btn');
+      btn.disabled = true;
+
+      const csrfToken = (document.cookie.split(';')
+        .map(c => c.trim())
+        .find(c => c.startsWith('csrftoken=')) || '').split('=')[1] || '';
+
+      fetch('/api/v1/tournaments/{{ tournament.slug }}/rounds/{{ round.seq }}', {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRFToken': csrfToken,
+        },
+        body: JSON.stringify({ draw_type: 'S' }),
+      })
+      .then(response => {
+        if (response.ok) {
+          window.location.reload();
+        } else {
+          return response.json().then(data => { throw new Error(data.detail || '{% trans "Request failed" %}'); });
+        }
+      })
+      .catch(error => {
+        btn.disabled = false;
+        alert(error.message);
+      });
+    }
+  </script>
+  {% endif %}
+{% endblock js %}

--- a/tabbycat/availability/views.py
+++ b/tabbycat/availability/views.py
@@ -87,6 +87,10 @@ class AvailabilityIndexView(RoundMixin, AdministratorMixin, TemplateView):
         kwargs['min_venues'] = teams['in_now'] // per_room_divisor
 
         kwargs['error_type'] = getattr(self, 'error_type', None)
+
+        if not self.round.prev:
+            kwargs['has_seeds'] = self.tournament.team_set.filter(seed__isnull=False).exists()
+
         return super().get_context_data(**kwargs)
 
     def _get_breaking_teams_dict(self):


### PR DESCRIPTION
When tournaments are created, the first round's draw type is RANDOM, but if teams have seeds, they should be using the SEEDED type, which isn't automatic nor obvious.