### PR TITLE
Fix/speaker registration

### DIFF
--- a/tabbycat/registration/templates/speaker_registration_form.html
+++ b/tabbycat/registration/templates/speaker_registration_form.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+{% load add_field_css i18n %}
+
+{% block content %}
+
+<div class="row">
+
+    <form class="col-lg-8 ml-lg-auto mr-md-auto d-flex flex-column gap-3" action="." method="POST">
+
+      {% csrf_token %}
+      <div class="card">
+        {% include "components/form-main.html" %}
+      </div>
+
+      <div class="card">
+        {% trans "Register as Speaker" context "button" as title %}
+        {% trans "Cancel and go back to the site home page" as subtitle %}
+        {% url 'tabbycat-index' as suburl %}
+        {% include "components/form-submit.html" %}
+      </div>
+
+    </form>
+
+</div>
+
+{% endblock %}

--- a/tabbycat/registration/views.py
+++ b/tabbycat/registration/views.py
@@ -461,7 +461,7 @@ class PublicCreateAdjudicatorFormView(BaseCreateAdjudicatorFormView):
 
 class CreateSpeakerFormView(LogActionMixin, PublicTournamentPageMixin, CustomQuestionFormMixin, FormView):
     form_class = SpeakerForm
-    template_name = 'adjudicator_registration_form.html'
+    template_name = 'speaker_registration_form.html'
     page_emoji = '👄'
     page_title = gettext_lazy("Register Speaker")
     action_log_type = ActionLogEntry.ActionType.SPEAKER_REGISTER
@@ -482,7 +482,6 @@ class CreateSpeakerFormView(LogActionMixin, PublicTournamentPageMixin, CustomQue
         if self.key:
             team = Team.objects.all_with_unconfirmed.prefetch_related('speaker_set').filter(tournament=tournament, pk=self.kwargs['pk']).first()
             return (
-                tournament.pref('institution_participant_registration') and
                 Invitation.objects.filter(tournament=tournament, for_content_type=ContentType.objects.get_for_model(Speaker), team=team, url_key=self.key).exists() and
                 team.speaker_set.count() < tournament.pref('speakers_in_team')
             )


### PR DESCRIPTION
Hey! 

I have found two issues with team registration form:

1. When `Enable open team registration` is checked without `Enable institutional participant registration` and participant is trying to register a one speaker team, it will get a link to pass to the second speaker, but without `Enable institutional participant registration` person will get 403 error, for this we should omit check for `institution_participant_registration`.
2. Form for speaker as actually an adjudicator registration form, and people can be confused to see `Register as Adjudicator` button instead of `Register as Speaker`. So a separate template was created.

P.S. Maybe the first issue was on purpose, but I'd suggested to let people to have an option without additional option, in case institutional registration is not planned for a tournament.