### PR TITLE
Add configurable adjudicator feedback score step

### DIFF
--- a/tabbycat/adjfeedback/forms.py
+++ b/tabbycat/adjfeedback/forms.py
@@ -79,9 +79,11 @@ class BaseFeedbackForm(CustomQuestionsFormMixin, forms.Form):
         # Feedback questions defined for the tournament
         adj_min_score = self._tournament.pref('adj_min_score')
         adj_max_score = self._tournament.pref('adj_max_score')
+        adj_score_step = self._tournament.pref('adj_score_step')
         score_label = mark_safe(_("Overall score (%(min)d=worst; %(max)d=best)*") % {
                 'min': int(adj_min_score), 'max': int(adj_max_score)})
-        self.fields['score'] = forms.FloatField(min_value=adj_min_score, max_value=adj_max_score, label=score_label)
+        self.fields['score'] = forms.FloatField(
+            min_value=adj_min_score, max_value=adj_max_score, step_size=adj_score_step, label=score_label)
 
         self.add_question_fields()
 

--- a/tabbycat/options/forms.py
+++ b/tabbycat/options/forms.py
@@ -40,8 +40,18 @@ class TournamentPreferenceForm(PreferenceForm):
                 raise ValidationError({'debate_rules__teams_in_debate': _("Four-team formats require consensus ballots")})
 
         elif section == 'feedback':
-            if get_pref('adj_min_score') > get_pref('adj_max_score'):
+            adj_min_score = get_pref('adj_min_score')
+            adj_max_score = get_pref('adj_max_score')
+            if adj_min_score > adj_max_score:
                 raise ValidationError({'feedback__adj_min_score': score_range_msg, 'feedback__adj_max_score': score_range_msg})
+            adj_score_step = get_pref('adj_score_step')
+            if adj_score_step is not None:
+                if adj_score_step <= 0:
+                    raise ValidationError({'feedback__adj_score_step': _("Score step must be greater than 0.")})
+                if adj_score_step > adj_max_score:
+                    raise ValidationError({'feedback__adj_score_step': _(
+                        "Score step (%(step)s) cannot be greater than the maximum score (%(max)s).") % {
+                            'step': adj_score_step, 'max': adj_max_score}})
 
         elif section == 'data_entry':
             if get_pref('public_use_password') and len(get_pref('public_password')) == 0:

--- a/tabbycat/options/preferences.py
+++ b/tabbycat/options/preferences.py
@@ -478,6 +478,15 @@ class MaximumAdjScore(FloatPreference):
 
 
 @tournament_preferences_registry.register
+class AdjScoreStep(FloatPreference):
+    help_text = _("Score step allowed when entering adjudicator feedback scores, e.g. full points (1) or half points (0.5)")
+    verbose_name = _("Adjudicator score step")
+    section = feedback
+    name = 'adj_score_step'
+    default = 1.0
+
+
+@tournament_preferences_registry.register
 class FeedbackPaths(ChoicePreference):
     help_text = _("Used to inform available choices in the feedback forms for adjudicators (both online and printed) and feedback progress")
     verbose_name = _("Allow and expect feedback to be submitted by")


### PR DESCRIPTION
Adds a new tournament preference (adj_score_step) to control the increment step allowed when entering adjudicator feedback scores. Options are any decimal, 0.5 increments, or whole numbers only.

The setting is editable via a new modal on the feedback overview page (accessible from the Score Step link in the breakdown card) and is enforced on all feedback submission forms via the NumberInput step attr.