### PR TITLE
Improve registration form UI

### DIFF
--- a/tabbycat/templates/components/form-field.html
+++ b/tabbycat/templates/components/form-field.html
@@ -11,7 +11,11 @@
     </label>
   {% endif %}
 
-  {{ field|addcss:"form-control" }}
+  {% if field|is_choice_widget %}
+    {{ field }}
+  {% else %}
+    {{ field|addcss:"form-control" }}
+  {% endif %}
 
   {% if field.help_text  %}
     <small class="form-text text-muted">{{ field.help_text|linebreaks }}</small>

--- a/tabbycat/templates/scss/modules/forms.scss
+++ b/tabbycat/templates/scss/modules/forms.scss
@@ -63,6 +63,15 @@ input[type="range"] {
   padding-top: 10px;
 }
 
+// Choice widget labels (radios/checkboxes) don't need the extra padding
+.list-group-item {
+
+  .form-check label,
+  label.form-check-label {
+    padding-top: 0;
+  }
+}
+
 // Don't pad form panels as the elements already have padding
 .card-body.form-panel {
   padding-bottom: 0;

--- a/tabbycat/utils/templatetags/add_field_css.py
+++ b/tabbycat/utils/templatetags/add_field_css.py
@@ -1,5 +1,5 @@
 from django import template
-from django.forms import CheckboxInput, CheckboxSelectMultiple, RadioSelect
+from django.forms import CheckboxSelectMultiple, RadioSelect
 
 register = template.Library()
 
@@ -12,7 +12,7 @@ def addcss(field, css):
 @register.filter(name='is_choice_widget')
 def is_choice_widget(field):
     widget = field.field.widget
-    return isinstance(widget, (RadioSelect, CheckboxSelectMultiple, CheckboxInput))
+    return isinstance(widget, (RadioSelect, CheckboxSelectMultiple))
 
 
 @register.filter(name='addboundwidgetcss')

--- a/tabbycat/utils/templatetags/add_field_css.py
+++ b/tabbycat/utils/templatetags/add_field_css.py
@@ -1,4 +1,5 @@
 from django import template
+from django.forms import CheckboxInput, CheckboxSelectMultiple, RadioSelect
 
 register = template.Library()
 
@@ -6,6 +7,12 @@ register = template.Library()
 @register.filter(name='addcss')
 def addcss(field, css):
     return field.as_widget(attrs={"class": css})
+
+
+@register.filter(name='is_choice_widget')
+def is_choice_widget(field):
+    widget = field.field.widget
+    return isinstance(widget, (RadioSelect, CheckboxSelectMultiple, CheckboxInput))
 
 
 @register.filter(name='addboundwidgetcss')


### PR DESCRIPTION
Hey!

Closes #2844.

`RadioSelect`, `CheckboxSelectMultiple`, and `CheckboxInput` widgets were wrapped with Bootstrap's form-control class, causing misaligned bordered containers. Add `is_choice_widget` template filter to detect these widgets and render them without `form-control`. Zero out extra label padding for form-check elements inside `list-group-items`.

The fix looks correct, other parts look unaffected, as in most cases they use Vue and not Django Framework.

<img width="1076" height="272" alt="Screenshot 2026-04-19 at 18 52 20" src="https://github.com/user-attachments/assets/ca12d383-3f8e-43af-acfb-1fd4f15a9dd6" />
<img width="1770" height="298" alt="Screenshot 2026-04-19 at 19 41 00" src="https://github.com/user-attachments/assets/04bd9bd3-8bee-4488-974c-1123c5ceed19" />
<img width="646" height="86" alt="Screenshot 2026-04-19 at 19 41 05" src="https://github.com/user-attachments/assets/755776b5-c1f5-4a8d-8eb4-565f459664ed" />
