### PR TITLE
Fix panellist ballot speaker names mirroring chair selection

### DIFF
--- a/tabbycat/results/templates/ballot/ballot_speaks.html
+++ b/tabbycat/results/templates/ballot/ballot_speaks.html
@@ -1,12 +1,12 @@
 {% load add_field_css debate_tags i18n %}
 
 <div class="list-group-item js-team-speakers side-{{ team.side_code }} s{{ position.pos }}">
-  <div class="row flex-column flex-md-row">
-    <div class="col-4 col-md-2 pt-2 p-lg-2 pr-0 p-md-1 speaker-position-label">
+  <div class="row flex-column flex-md-row align-items-center">
+    <div class="col-4 col-md-2 pr-0 speaker-position-label">
       {{ position.name }}
     </div>
 
-    <div class="col mb-0 mb-3 pr-md-2 pr-1 form-group {{ position.speaker.errors|yesno:'error,' }}">
+    <div class="col mb-0 pr-md-2 pr-1 form-group {{ position.speaker.errors|yesno:'error,' }}">
 
       {% if forloop.parentloop.parentloop.first %}
 

--- a/tabbycat/templates/js-bundles/enter_results.js
+++ b/tabbycat/templates/js-bundles/enter_results.js
@@ -162,8 +162,8 @@ function update_speaker() {
   var speaker = $(':selected', this).text();
 
   // Update speaker names for all judges other than the first
-  // e.g. '.aff.s1 .speaker-name'
-  $('.' + side + '.' + pos + ' .speaker-name').html(speaker);
+  // e.g. '.side-0.s1 .speaker-name' (side_code matches form field prefix, e.g. id_0_speaker_s1)
+  $('.side-' + side + '.' + pos + ' .speaker-name').html(speaker);
 
   var others = [];
   var posno = parseInt(pos.charAt(1));


### PR DESCRIPTION
Use .side-{n} selectors to match template side_code classes so update_speaker() populates panellist .speaker-name elements.

Also some CSS improvements for alignment.