### PR TITLE
Show ordinal pull-up count in draw remarks

### DIFF
--- a/tabbycat/draw/prefetch.py
+++ b/tabbycat/draw/prefetch.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from django.db.models import Count, OuterRef, Subquery
+from django.db.models import OuterRef, Subquery
 from django.db.models.expressions import RawSQL
 
 from .models import Debate, DebateTeam
@@ -67,31 +67,3 @@ def populate_history(debates):
 
     for debate in debates_annotated:
         debates_by_id[debate.id]._history = debate.past_debates
-
-
-def populate_pullup_counts(debates):
-    """Sets _pullup_count on each DebateTeam, giving the total number of times
-    that team has been pulled up up to and including the current round."""
-    if not debates:
-        return
-
-    round_seq = debates[0].round.seq
-    tournament = debates[0].round.tournament
-
-    debateteams = [dt for debate in debates for dt in debate.debateteams]
-    if not debateteams:
-        return
-
-    team_ids = [dt.team_id for dt in debateteams]
-
-    counts = DebateTeam.objects.filter(
-        team_id__in=team_ids,
-        debate__round__tournament=tournament,
-        debate__round__seq__lte=round_seq,
-        flags__contains=['pullup'],
-    ).values('team_id').annotate(count=Count('id'))
-
-    counts_by_team = {row['team_id']: row['count'] for row in counts}
-
-    for dt in debateteams:
-        dt._pullup_count = counts_by_team.get(dt.team_id, 0)

--- a/tabbycat/draw/prefetch.py
+++ b/tabbycat/draw/prefetch.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from django.db.models import OuterRef, Subquery
+from django.db.models import Count, OuterRef, Subquery
 from django.db.models.expressions import RawSQL
 
 from .models import Debate, DebateTeam
@@ -67,3 +67,31 @@ def populate_history(debates):
 
     for debate in debates_annotated:
         debates_by_id[debate.id]._history = debate.past_debates
+
+
+def populate_pullup_counts(debates):
+    """Sets _pullup_count on each DebateTeam, giving the total number of times
+    that team has been pulled up up to and including the current round."""
+    if not debates:
+        return
+
+    round_seq = debates[0].round.seq
+    tournament = debates[0].round.tournament
+
+    debateteams = [dt for debate in debates for dt in debate.debateteams]
+    if not debateteams:
+        return
+
+    team_ids = [dt.team_id for dt in debateteams]
+
+    counts = DebateTeam.objects.filter(
+        team_id__in=team_ids,
+        debate__round__tournament=tournament,
+        debate__round__seq__lte=round_seq,
+        flags__contains=['pullup'],
+    ).values('team_id').annotate(count=Count('id'))
+
+    counts_by_team = {row['team_id']: row['count'] for row in counts}
+
+    for dt in debateteams:
+        dt._pullup_count = counts_by_team.get(dt.team_id, 0)

--- a/tabbycat/draw/views.py
+++ b/tabbycat/draw/views.py
@@ -55,7 +55,7 @@ from .forms import ConfirmDrawDeletionForm
 from .generator import DrawFatalError, DrawUserError
 from .manager import DrawManager
 from .models import Debate, TeamSideAllocation
-from .prefetch import populate_history, populate_pullup_counts
+from .prefetch import populate_history
 from .serializers import EditDebateTeamsDebateSerializer, EditDebateTeamsTeamSerializer
 from .tables import (AdminDrawTableBuilder, PositionBalanceReportDrawTableBuilder,
         PositionBalanceReportSummaryTableBuilder, PublicDrawTableBuilder)
@@ -483,7 +483,6 @@ class AdminDrawView(RoundMixin, AdministratorMixin, AdminDrawUtilitiesMixin, Vue
 
         draw = self.get_draw()
         populate_history(draw)
-        populate_pullup_counts(draw)
 
         if r.is_break_round:
             table.add_room_rank_columns(draw)
@@ -495,6 +494,7 @@ class AdminDrawView(RoundMixin, AdministratorMixin, AdminDrawUtilitiesMixin, Vue
         table.add_debate_team_columns(draw)
 
         # For draw details and draw draft pages
+        standings = None
         if r.draw_status is Round.Status.DRAFT or self.detailed:
             if r.prev:
                 teams = Team.objects.filter(debateteam__debate__round=r)
@@ -507,8 +507,12 @@ class AdminDrawView(RoundMixin, AdministratorMixin, AdminDrawUtilitiesMixin, Vue
 
                 # subrank only makes sense if there's a second metric to rank on
                 rankings = ('rank', 'subrank') if len(metrics) > 1 else ('rank',)
-                generator = TeamStandingsGenerator(metrics, rankings,
-                    extra_metrics=(pullup_metric,) if pullup_metric and pullup_metric not in metrics else ())
+                extra_metrics = []
+                if pullup_metric and pullup_metric not in metrics:
+                    extra_metrics.append(pullup_metric)
+                if 'npullups' not in metrics and 'npullups' not in extra_metrics:
+                    extra_metrics.append('npullups')
+                generator = TeamStandingsGenerator(metrics, rankings, extra_metrics=tuple(extra_metrics))
                 standings = generator.generate(teams, round=r.prev)
                 if not r.is_break_round:
                     table.add_debate_ranking_columns(draw, standings)
@@ -521,7 +525,7 @@ class AdminDrawView(RoundMixin, AdministratorMixin, AdminDrawUtilitiesMixin, Vue
         else:
             table.add_debate_adjudicators_column(draw, show_splits=False, for_admin=True)
 
-        table.add_draw_conflicts_columns(draw, self.venue_conflicts, self.adjudicator_conflicts)
+        table.add_draw_conflicts_columns(draw, self.venue_conflicts, self.adjudicator_conflicts, standings)
 
         if not r.is_break_round:
             table.highlight_column = 0  # Highlight based on first column (bracket)

--- a/tabbycat/draw/views.py
+++ b/tabbycat/draw/views.py
@@ -55,7 +55,7 @@ from .forms import ConfirmDrawDeletionForm
 from .generator import DrawFatalError, DrawUserError
 from .manager import DrawManager
 from .models import Debate, TeamSideAllocation
-from .prefetch import populate_history
+from .prefetch import populate_history, populate_pullup_counts
 from .serializers import EditDebateTeamsDebateSerializer, EditDebateTeamsTeamSerializer
 from .tables import (AdminDrawTableBuilder, PositionBalanceReportDrawTableBuilder,
         PositionBalanceReportSummaryTableBuilder, PublicDrawTableBuilder)
@@ -483,6 +483,7 @@ class AdminDrawView(RoundMixin, AdministratorMixin, AdminDrawUtilitiesMixin, Vue
 
         draw = self.get_draw()
         populate_history(draw)
+        populate_pullup_counts(draw)
 
         if r.is_break_round:
             table.add_room_rank_columns(draw)

--- a/tabbycat/utils/tables.py
+++ b/tabbycat/utils/tables.py
@@ -796,10 +796,17 @@ class TabbycatTableBuilder(BaseTableBuilder):
             # conflicts is a list of (level, message) tuples
             conflicts = [("secondary", _draw_flags_dict.get(flag, flag)) for flag in debate.flags]
             if not debate.is_bye:
-                conflicts += [("secondary", "%(team)s: %(flag)s" % {
+                for dt in debate.debateteams:
+                    for flag in dt.flags:
+                        pullup_count = getattr(dt, '_pullup_count', 0)
+                        if flag == 'pullup' and pullup_count > 0:
+                            flag_text = _("Pull-up team (%(ordinal)s pull-up)") % {'ordinal': ordinal(pullup_count)}
+                        else:
+                            flag_text = _draw_flags_dict.get(flag, flag)
+                        conflicts.append(("secondary", "%(team)s: %(flag)s" % {
                             'team': self._team_short_name(dt.team),
-                            'flag': _draw_flags_dict.get(flag, flag),
-                        }) for dt in debate.debateteams for flag in dt.flags]
+                            'flag': flag_text,
+                        }))
 
             if self.tournament.pref('avoid_team_history'):
                 history = debate.history

--- a/tabbycat/utils/tables.py
+++ b/tabbycat/utils/tables.py
@@ -789,7 +789,7 @@ class TabbycatTableBuilder(BaseTableBuilder):
         }
         self.add_column(header, cells)
 
-    def add_draw_conflicts_columns(self, debates, venue_conflicts, adjudicator_conflicts):
+    def add_draw_conflicts_columns(self, debates, venue_conflicts, adjudicator_conflicts, standings=None):
 
         conflicts_by_debate = []
         for debate in debates:
@@ -798,9 +798,12 @@ class TabbycatTableBuilder(BaseTableBuilder):
             if not debate.is_bye:
                 for dt in debate.debateteams:
                     for flag in dt.flags:
-                        pullup_count = getattr(dt, '_pullup_count', 0)
-                        if flag == 'pullup' and pullup_count > 0:
-                            flag_text = _("Pull-up team (%(ordinal)s pull-up)") % {'ordinal': ordinal(pullup_count)}
+                        if flag == 'pullup' and standings is not None:
+                            try:
+                                prev_pullups = standings.get_standing(dt.team).metrics.get('npullups', 0) or 0
+                            except ValueError:
+                                prev_pullups = 0
+                            flag_text = _("Pull-up team (%(ordinal)s pull-up)") % {'ordinal': ordinal(prev_pullups + 1)}
                         else:
                             flag_text = _draw_flags_dict.get(flag, flag)
                         conflicts.append(("secondary", "%(team)s: %(flag)s" % {

--- a/tabbycat/utils/tables.py
+++ b/tabbycat/utils/tables.py
@@ -799,10 +799,7 @@ class TabbycatTableBuilder(BaseTableBuilder):
                 for dt in debate.debateteams:
                     for flag in dt.flags:
                         if flag == 'pullup' and standings is not None:
-                            try:
-                                prev_pullups = standings.get_standing(dt.team).metrics.get('npullups', 0) or 0
-                            except ValueError:
-                                prev_pullups = 0
+                            prev_pullups = standings.get_standing(dt.team).metrics['npullups']
                             flag_text = _("Pull-up team (%(ordinal)s pull-up)") % {'ordinal': ordinal(prev_pullups + 1)}
                         else:
                             flag_text = _draw_flags_dict.get(flag, flag)


### PR DESCRIPTION
When a team appears in the draw with a pull-up flag, the draw remarks column now shows how many times they have been pulled up in total (up to and including the current round), as an ordinal — e.g. "Pull-up team (2nd pull-up)" instead of just "Pull-up team".

This makes it easier for tab directors to spot teams who have been repeatedly pulled up. 