### PR TITLE
Dark mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@popperjs/core": "^2.6.0",
         "@sentry/vue": "^10.32.1",
         "@vue/compiler-sfc": "^3.5.0",
-        "bootstrap": "^4.6.1",
+        "bootstrap": "^5.3.0",
         "browserify": "17.0.x",
         "browserslist": "^4.18.1",
         "core-js": "^3.19.2",
@@ -31,7 +31,6 @@
         "lodash": "^4.17.21",
         "npm-run-all": "^4.1.5",
         "pinia": "^2.1.7",
-        "popper.js": "^1.16.1",
         "quagga": "0.12.x",
         "sass": "^1.56.1",
         "vue": "^3.5.0"
@@ -131,7 +130,6 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.2.tgz",
       "integrity": "sha512-A8pri1YJiC5UnkdrWcmfZTJTV85b4UXTAfImGmCfYmax4TR9Cw8sDS0MOk++Gp2mE/BefVJ5nwy5yzqNJbP/DQ==",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.16.7",
@@ -2224,9 +2222,10 @@
       ]
     },
     "node_modules/@popperjs/core": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.6.0.tgz",
-      "integrity": "sha512-cPqjjzuFWNK3BSKLm0abspP0sp/IGOli4p5I5fKFAzdS8fvjdOwDCfZqAaIiXd9lPkOWi3SUUfZof3hEb7J/uw==",
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -2579,7 +2578,6 @@
       "integrity": "sha512-87KgUXET09CRjGCi2Ejxy3PULXna63/bMYv72tCAlDJC3Yqwln0HiFJ3VJMst2+mEtNtZu5oFvX4qJGjKsnAgg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
         "@typescript-eslint/scope-manager": "8.50.0",
@@ -3073,7 +3071,6 @@
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3471,16 +3468,22 @@
       "license": "ISC"
     },
     "node_modules/bootstrap": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.1.tgz",
-      "integrity": "sha512-0dj+VgI9Ecom+rvvpNZ4MUZJz8dcX7WCX+eTID9+/8HgOkv3dsRzi8BGeZJCQU6flWQVYxwTQnEZFrmJSEO7og==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/bootstrap"
-      },
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.8.tgz",
+      "integrity": "sha512-HP1SZDqaLDPwsNiqRqi5NcP0SSXciX2s9E+RyqJIIqGo+vJeN5AJVM98CXmW/Wux0nQ5L7jeWUdplCEf0Ee+tg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ],
+      "license": "MIT",
       "peerDependencies": {
-        "jquery": "1.9.1 - 3",
-        "popper.js": "^1.16.1"
+        "@popperjs/core": "^2.11.8"
       }
     },
     "node_modules/brace-expansion": {
@@ -3817,7 +3820,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4896,8 +4898,7 @@
     "node_modules/d3-selection": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-2.0.0.tgz",
-      "integrity": "sha512-XoGGqhLUN/W14NmaqcO/bb1nqjDAw5WtSYb2X8wiuQWvSZUsUVYsOSkOybUrNvcBjaywBdYPy03eXHMXjk9nZA==",
-      "peer": true
+      "integrity": "sha512-XoGGqhLUN/W14NmaqcO/bb1nqjDAw5WtSYb2X8wiuQWvSZUsUVYsOSkOybUrNvcBjaywBdYPy03eXHMXjk9nZA=="
     },
     "node_modules/d3-shape": {
       "version": "2.0.0",
@@ -5763,7 +5764,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6094,7 +6094,6 @@
       "integrity": "sha512-nA5yUs/B1KmKzvC42fyD0+l9Yd+LtEpVhWRbXuDj0e+ZURcTtyRbMDWUeJmTAh2wC6jC83raS63anNM2YT3NPw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "natural-compare": "^1.4.0",
@@ -7703,8 +7702,7 @@
     "node_modules/jquery": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
-      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==",
-      "peer": true
+      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
     },
     "node_modules/jquery-validation": {
       "version": "1.21.0",
@@ -8949,7 +8947,6 @@
       "resolved": "https://registry.npmjs.org/pinia/-/pinia-2.3.1.tgz",
       "integrity": "sha512-khUlZSwt9xXCaTbbxFYBKDc/bWAGWJjOgvxETwkTN7KRm66EeT1ZdZj6i2ceh9sP2Pzqsbc704r2yngBrxBVug==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/devtools-api": "^6.6.3",
         "vue-demi": "^0.14.10"
@@ -8973,17 +8970,6 @@
       "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
       "engines": {
         "node": ">=4.0.0"
-      }
-    },
-    "node_modules/popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
-      "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/posix-character-classes": {
@@ -9553,7 +9539,6 @@
       "version": "1.56.1",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.56.1.tgz",
       "integrity": "sha512-VpEyKpyBPCxE7qGDtOcdJ6fFbcpOM+Emu7uZLxVrkX8KVU/Dp5UF7WLvzqRuUhB6mqqQt1xffLoG+AndxTZrCQ==",
-      "peer": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -10186,7 +10171,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10471,7 +10455,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "napi-postinstall": "^0.3.0"
       },
@@ -10651,7 +10634,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.18.tgz",
       "integrity": "sha512-sAOqI5wNM9QvSEE70W3UGMdT8cyEn0+PmJMTFvTB8wB0YbYUWw3gUbY62AOyrXosGieF2htmeLATvNxpv/zNyQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.14.27",
         "postcss": "^8.4.13",
@@ -10694,7 +10676,6 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.26.tgz",
       "integrity": "sha512-SJ/NTccVyAoNUJmkM9KUqPcYlY+u8OVL1X5EW9RIs3ch5H2uERxyyIUI4MRxVCSOiEcupX9xNGde1tL9ZKpimA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.26",
         "@vue/compiler-sfc": "3.5.26",
@@ -10743,6 +10724,7 @@
       "integrity": "sha512-CydUvFOQKD928UzZhTp4pr2vWz1L+H99t7Pkln2QSPdvmURT0MoC4wUccfCnuEaihNsu9aYYyk+bep8rlfkUXw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "eslint-scope": "^8.2.0",
@@ -10767,6 +10749,7 @@
       "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -10937,7 +10920,6 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.2.tgz",
       "integrity": "sha512-A8pri1YJiC5UnkdrWcmfZTJTV85b4UXTAfImGmCfYmax4TR9Cw8sDS0MOk++Gp2mE/BefVJ5nwy5yzqNJbP/DQ==",
-      "peer": true,
       "requires": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.16.7",
@@ -12324,9 +12306,9 @@
       "optional": true
     },
     "@popperjs/core": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.6.0.tgz",
-      "integrity": "sha512-cPqjjzuFWNK3BSKLm0abspP0sp/IGOli4p5I5fKFAzdS8fvjdOwDCfZqAaIiXd9lPkOWi3SUUfZof3hEb7J/uw=="
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="
     },
     "@sentry-internal/browser-utils": {
       "version": "10.32.1",
@@ -12552,7 +12534,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.50.0.tgz",
       "integrity": "sha512-87KgUXET09CRjGCi2Ejxy3PULXna63/bMYv72tCAlDJC3Yqwln0HiFJ3VJMst2+mEtNtZu5oFvX4qJGjKsnAgg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.7.0",
         "@typescript-eslint/scope-manager": "8.50.0",
@@ -12858,8 +12839,7 @@
     "acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-      "peer": true
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -13175,9 +13155,9 @@
       "dev": true
     },
     "bootstrap": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.1.tgz",
-      "integrity": "sha512-0dj+VgI9Ecom+rvvpNZ4MUZJz8dcX7WCX+eTID9+/8HgOkv3dsRzi8BGeZJCQU6flWQVYxwTQnEZFrmJSEO7og==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.8.tgz",
+      "integrity": "sha512-HP1SZDqaLDPwsNiqRqi5NcP0SSXciX2s9E+RyqJIIqGo+vJeN5AJVM98CXmW/Wux0nQ5L7jeWUdplCEf0Ee+tg==",
       "requires": {}
     },
     "brace-expansion": {
@@ -13464,7 +13444,6 @@
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
       "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
-      "peer": true,
       "requires": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -14349,8 +14328,7 @@
     "d3-selection": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-2.0.0.tgz",
-      "integrity": "sha512-XoGGqhLUN/W14NmaqcO/bb1nqjDAw5WtSYb2X8wiuQWvSZUsUVYsOSkOybUrNvcBjaywBdYPy03eXHMXjk9nZA==",
-      "peer": true
+      "integrity": "sha512-XoGGqhLUN/W14NmaqcO/bb1nqjDAw5WtSYb2X8wiuQWvSZUsUVYsOSkOybUrNvcBjaywBdYPy03eXHMXjk9nZA=="
     },
     "d3-shape": {
       "version": "2.0.0",
@@ -14913,7 +14891,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -15219,7 +15196,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-10.6.2.tgz",
       "integrity": "sha512-nA5yUs/B1KmKzvC42fyD0+l9Yd+LtEpVhWRbXuDj0e+ZURcTtyRbMDWUeJmTAh2wC6jC83raS63anNM2YT3NPw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "natural-compare": "^1.4.0",
@@ -16267,8 +16243,7 @@
     "jquery": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
-      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==",
-      "peer": true
+      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
     },
     "jquery-validation": {
       "version": "1.21.0",
@@ -17157,7 +17132,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/pinia/-/pinia-2.3.1.tgz",
       "integrity": "sha512-khUlZSwt9xXCaTbbxFYBKDc/bWAGWJjOgvxETwkTN7KRm66EeT1ZdZj6i2ceh9sP2Pzqsbc704r2yngBrxBVug==",
-      "peer": true,
       "requires": {
         "@vue/devtools-api": "^6.6.3",
         "vue-demi": "^0.14.10"
@@ -17167,12 +17141,6 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
       "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w=="
-    },
-    "popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
-      "peer": true
     },
     "posix-character-classes": {
       "version": "0.1.1",
@@ -17571,7 +17539,6 @@
       "version": "1.56.1",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.56.1.tgz",
       "integrity": "sha512-VpEyKpyBPCxE7qGDtOcdJ6fFbcpOM+Emu7uZLxVrkX8KVU/Dp5UF7WLvzqRuUhB6mqqQt1xffLoG+AndxTZrCQ==",
-      "peer": true,
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -18033,8 +18000,7 @@
           "version": "4.0.3",
           "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
           "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-          "dev": true,
-          "peer": true
+          "dev": true
         }
       }
     },
@@ -18232,7 +18198,6 @@
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
       "integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@unrs/resolver-binding-android-arm-eabi": "1.11.1",
         "@unrs/resolver-binding-android-arm64": "1.11.1",
@@ -18369,7 +18334,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.18.tgz",
       "integrity": "sha512-sAOqI5wNM9QvSEE70W3UGMdT8cyEn0+PmJMTFvTB8wB0YbYUWw3gUbY62AOyrXosGieF2htmeLATvNxpv/zNyQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "esbuild": "^0.14.27",
         "fsevents": "~2.3.2",
@@ -18387,7 +18351,6 @@
       "version": "3.5.26",
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.26.tgz",
       "integrity": "sha512-SJ/NTccVyAoNUJmkM9KUqPcYlY+u8OVL1X5EW9RIs3ch5H2uERxyyIUI4MRxVCSOiEcupX9xNGde1tL9ZKpimA==",
-      "peer": true,
       "requires": {
         "@vue/compiler-dom": "3.5.26",
         "@vue/compiler-sfc": "3.5.26",
@@ -18407,6 +18370,7 @@
       "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-10.2.0.tgz",
       "integrity": "sha512-CydUvFOQKD928UzZhTp4pr2vWz1L+H99t7Pkln2QSPdvmURT0MoC4wUccfCnuEaihNsu9aYYyk+bep8rlfkUXw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "debug": "^4.4.0",
         "eslint-scope": "^8.2.0",
@@ -18420,7 +18384,8 @@
           "version": "7.7.3",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
           "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-          "dev": true
+          "dev": true,
+          "peer": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@popperjs/core": "^2.6.0",
     "@sentry/vue": "^10.32.1",
     "@vue/compiler-sfc": "^3.5.0",
-    "bootstrap": "^4.6.1",
+    "bootstrap": "^5.3.0",
     "browserify": "17.0.x",
     "browserslist": "^4.18.1",
     "core-js": "^3.19.2",
@@ -47,7 +47,6 @@
     "lodash": "^4.17.21",
     "npm-run-all": "^4.1.5",
     "pinia": "^2.1.7",
-    "popper.js": "^1.16.1",
     "quagga": "0.12.x",
     "sass": "^1.56.1",
     "vue": "^3.5.0"

--- a/tabbycat/adjallocation/templates/DebateOrPanelImportance.vue
+++ b/tabbycat/adjallocation/templates/DebateOrPanelImportance.vue
@@ -49,7 +49,7 @@ const importanceDescription = computed(() => {
 
     <div
       v-if="showTooltip"
-      class="tooltip top tooltip-vue mt-5 ml-3"
+      class="tooltip top tooltip-vue mt-5 ms-3"
       role="tooltip"
     >
       <div class="tooltip-arrow" />

--- a/tabbycat/adjallocation/templates/DraggableAdjudicator.vue
+++ b/tabbycat/adjallocation/templates/DraggableAdjudicator.vue
@@ -148,7 +148,7 @@ const scoreB = computed(() => {
   >
     <template #number>
       <span>
-        <small class="pl-2 vue-draggable-muted ">{{ scoreA }}{{ scoreB }}</small>
+        <small class="ps-2 vue-draggable-muted ">{{ scoreA }}{{ scoreB }}</small>
       </span>
     </template>
     <template #title>

--- a/tabbycat/adjallocation/templates/DraggableAllocation.vue
+++ b/tabbycat/adjallocation/templates/DraggableAllocation.vue
@@ -50,10 +50,10 @@ const hidePanelHoverConflicts = () => {
     :drag-payload="getPanelDragPayload()"
     class="mx-1 d-flex flex-fill align-items-stretch align-items-center draggable-panel"
   >
-    <div :class="['panel-stats small text-monospace text-center', panelIsDragging ? 'd-none' : '']">
+    <div :class="['panel-stats small font-monospace text-center', panelIsDragging ? 'd-none' : '']">
       <div
         class="py-1"
-        data-toggle="tooltip"
+        data-bs-toggle="tooltip"
         :title="gettext('Average score of panel (excluding trainees)')"
       >
         <span v-if="averageScore">{{ averageScore }}</span>
@@ -64,7 +64,7 @@ const hidePanelHoverConflicts = () => {
       </div>
       <div
         class="py-1"
-        data-toggle="tooltip"
+        data-bs-toggle="tooltip"
         :title="gettext('Average score of voting majority in panel')"
       >
         <span v-if="averageVotingScore">{{ averageVotingScore }}</span>

--- a/tabbycat/adjallocation/templates/EditDebateAdjudicatorsContainer.vue
+++ b/tabbycat/adjallocation/templates/EditDebateAdjudicatorsContainer.vue
@@ -87,28 +87,28 @@ const { moveAdjudicator, swapPanels, showShard, showAllocate, showPrioritise } =
         <template #default-highlights>
           <button
             class="btn conflictable conflicts-toolbar hover-histories-2-ago"
-            data-toggle="tooltip"
+            data-bs-toggle="tooltip"
             :title="'Has judged this team or with this adjudicator previously'"
           >
             {{ gettext('Seen') }}
           </button>
           <button
             class="btn conflictable conflicts-toolbar hover-institution"
-            data-toggle="tooltip"
+            data-bs-toggle="tooltip"
             :title="'Is from the same institution as this team or panelist.'"
           >
             {{ gettext('Institution') }}
           </button>
           <button
             class="btn conflictable conflicts-toolbar hover-adjudicator"
-            data-toggle="tooltip"
+            data-bs-toggle="tooltip"
             :title="'Has a nominated conflict with this team or panelist.'"
           >
             {{ gettext('Conflict') }}
           </button>
           <button
             class="btn panel-incomplete"
-            data-toggle="tooltip"
+            data-bs-toggle="tooltip"
             :title="'Panel is missing a chair or enough adjudicators for a voting majority.'"
           >
             {{ gettext('Missing') }}

--- a/tabbycat/adjallocation/templates/EditPanelAdjudicatorsContainer.vue
+++ b/tabbycat/adjallocation/templates/EditPanelAdjudicatorsContainer.vue
@@ -86,28 +86,28 @@ const { moveAdjudicator, swapPanels, showShard, showAllocate, showPrioritise } =
         <template #default-highlights>
           <button
             class="btn conflictable conflicts-toolbar hover-histories-2-ago"
-            data-toggle="tooltip"
+            data-bs-toggle="tooltip"
             title="This adjudicator has judged with this adjudicator previously"
           >
             {{ gettext('Seen') }}
           </button>
           <button
             class="btn conflictable conflicts-toolbar hover-institution"
-            data-toggle="tooltip"
+            data-bs-toggle="tooltip"
             title="This adjudicator is from the same institution as this panelist."
           >
             {{ gettext('Institution') }}
           </button>
           <button
             class="btn conflictable conflicts-toolbar hover-adjudicator"
-            data-toggle="tooltip"
+            data-bs-toggle="tooltip"
             title="This adjudicator has a nominated conflict with this panelist."
           >
             {{ gettext('Conflict') }}
           </button>
           <button
             class="btn panel-incomplete"
-            data-toggle="tooltip"
+            data-bs-toggle="tooltip"
             title="Panel is either missing a chair or enough adjudicators for a voting majority."
           >
             {{ gettext('Missing') }}

--- a/tabbycat/adjfeedback/templates/feedback_card.html
+++ b/tabbycat/adjfeedback/templates/feedback_card.html
@@ -4,13 +4,13 @@
   <div class="list-group list-group-flush">
 
     {% if not feedback.confirmed %}
-      <div class="list-group-item list-group-item-warning h6" data-toggle="tooltip"
+      <div class="list-group-item list-group-item-warning h6" data-bs-toggle="tooltip"
            title="{% trans 'This is most likely because the team or adjudicator who submitted this feedback has submitted several times on the same person; or because a team has submitted feedback on multiple panellists (rather than just the orallist).' %}">
       {% trans "Unconfirmed; will not affect this adjudicator's score." %}
       </div>
     {% endif %}
     {% if feedback.ignored %}
-      <div class="list-group-item list-group-item-warning h6" data-toggle="tooltip"
+      <div class="list-group-item list-group-item-warning h6" data-bs-toggle="tooltip"
            title="{% trans 'The feedback is counted for the adjudicator, but is not taken into account when calculating scores.' %}">
       {% trans "Ignored; will not affect this adjudicator's score." %}
       </div>
@@ -21,11 +21,11 @@
       </div>
     {% endif %}
     <div class="list-group-item h5">
-      <span class="badge float-right
-            {% if feedback.score <= score_thresholds.low_score %}badge-danger
-            {% elif feedback.score <= score_thresholds.medium_score %}badge-warning
-            {% elif feedback.score > score_thresholds.high_score %}badge-success
-            {% else %}badge-primary{% endif %}" data-toggle="tooltip"
+      <span class="badge float-end
+            {% if feedback.score <= score_thresholds.low_score %}text-bg-danger
+            {% elif feedback.score <= score_thresholds.medium_score %}text-bg-warning
+            {% elif feedback.score > score_thresholds.high_score %}text-bg-success
+            {% else %}text-bg-primary{% endif %}" data-bs-toggle="tooltip"
             title="{% trans "The score given in this piece of feedback." %}">
         {% blocktrans trimmed with score=feedback.score round=feedback.round.abbreviation %}
           {{ round }} {{ score }}
@@ -42,7 +42,7 @@
           Received as {{ as_type }}
         {% endblocktranslate %}
       </span>
-      <span class="badge float-right badge-secondary" data-toggle="tooltip">
+      <span class="badge float-end text-bg-secondary" data-bs-toggle="tooltip">
         {% blocktrans trimmed with base=feedback.adjudicator.base_score|floatformat:"1" %}
           Base {{ base }}
         {% endblocktrans %}
@@ -91,17 +91,17 @@
           {{ time }}
         {% endblocktrans %}
       </span>
-      <span class="float-right" data-toggle="tooltip"
+      <span class="float-end" data-bs-toggle="tooltip"
             title="{% trans "Unconfirmed feedback is not counted as having been submitted and does not affect this adjudicator's score." %}">
         <form method="POST" action="{% tournamenturl 'adjfeedback-confirm-feedback' feedback.id %}" class='text-secondary'>
           {% csrf_token %}
           <input type="hidden" name="next" value="{{ request.path }}">
-          <button type="submit" class="btn btn-link text-muted pl-3 p-0">
+          <button type="submit" class="btn btn-link text-muted ps-3 p-0">
             <small>{% if feedback.confirmed %}{% trans "Un-confirm" %}{% else %}{% trans "Confirm" %}{% endif %}</small>
           </button>
         </form>
       </span>
-      <span class="float-right" data-toggle="tooltip"
+      <span class="float-end" data-bs-toggle="tooltip"
             title="{% trans "Ignored feedback is counted as having been submitted, but does not affect this adjudicator's score." %}">
         <form method="POST" action="{% tournamenturl 'adjfeedback-ignore-feedback' feedback.id %}" class='text-secondary'>
           {% csrf_token %}

--- a/tabbycat/adjfeedback/templates/overview_breakdowns.html
+++ b/tabbycat/adjfeedback/templates/overview_breakdowns.html
@@ -9,7 +9,7 @@
           {% if threshold.count != 0 %}
             {% widthratio threshold.count c_total 100 as c_percentage %}
             <div class="progress-bar rank-display ranking-{{ threshold.class }}" role="progressbar"
-                 style="width: {{ c_percentage }}%;" data-toggle="tooltip"
+                 style="width: {{ c_percentage }}%;" data-bs-toggle="tooltip"
                  title="{% blocktrans trimmed with min=threshold.min max=threshold.max percent=c_percentage|floatformat:"0" count count=threshold.count %}
                    {{ count }} adjudicator currently has a score equal to or above
                    {{ min }} and below {{ max }}. That is {{ percent }}% of the adjudicator pool.
@@ -36,20 +36,20 @@
   <div class="card">
     <div class="card-body text-center pb-1 pt-2 px-2">
       <div class="row">
-        <div class="col pr-0 mb-0">
+        <div class="col pe-0 mb-0">
           <h5 class="mb-0 mt-2">
             {{ test_percent|floatformat:"0" }}%
           </h5>
           <small>{% trans "Base" %}</small>
         </div>
-        <div class="col pl-0 mb-0">
+        <div class="col ps-0 mb-0">
           <h5 class="mb-0 mt-2">
             {{ feedback_percent|floatformat:"0" }}%
           </h5>
           <small>{% trans "Feedback" %}</small>
         </div>
       </div>
-      <h6 class="pt-2 text-secondary" data-toggle="tooltip"
+      <h6 class="pt-2 text-secondary" data-bs-toggle="tooltip"
           title="{% blocktrans trimmed with round=current_round.abbreviation %}
             The proportion of an adjudicator's score determined by feedback vs the
             base score is set on a per-round basis. Click to edit the feedback weight for {{ round }}.{% endblocktrans %}">
@@ -67,7 +67,7 @@
       <div class="progress">
         {% if c_chairs > 0 %}
           <div class="progress-bar position-display chair" role="progressbar"
-               style="width: {% percentage c_chairs c_total %}%;" data-toggle="tooltip"
+               style="width: {% percentage c_chairs c_total %}%;" data-bs-toggle="tooltip"
               {% if c_chairs == c_debates %}
                title="{% blocktrans trimmed count count=c_chairs %}
                   There is {{ c_chairs }} debate per round, so there needs to be {{ c_chairs }} chair.
@@ -91,7 +91,7 @@
         {% endif %}
         {% if c_panellists > 0 %}
           <div class="progress-bar position-display panellist" role="progressbar"
-               style="width: {% percentage c_panellists c_total %}%;" data-toggle="tooltip"
+               style="width: {% percentage c_panellists c_total %}%;" data-bs-toggle="tooltip"
                title="{% blocktrans trimmed %}
                 All adjudicators with a score high enough to vote, but who aren't allocated as chairs,
                 are allocated as panellists by the auto-allocator.
@@ -105,7 +105,7 @@
         {% endif %}
         {% if c_trainees > 0 %}
           <div class="progress-bar position-display trainee" role="progressbar"
-               style="width: {% percentage c_trainees c_total %}%;" data-toggle="tooltip"
+               style="width: {% percentage c_trainees c_total %}%;" data-bs-toggle="tooltip"
                title="{% blocktrans trimmed with min_voting=pref.adj_min_voting_score %}
                 Adjudicators are allocated as trainees by the auto-allocator if their score is less
                 than the 'minimum voting score' (currently {{ min_voting }}) set in this

--- a/tabbycat/availability/templates/availability_index.html
+++ b/tabbycat/availability/templates/availability_index.html
@@ -44,43 +44,43 @@
       {% csrf_token %}
       {% if previous_unconfirmed %}
         <button class="btn btn-warning" id="createDraw"
-          data-toggle="tooltip" title="{% blocktrans trimmed with round=round.prev.name %}{{ previous_unconfirmed }} debates from
+          data-bs-toggle="tooltip" title="{% blocktrans trimmed with round=round.prev.name %}{{ previous_unconfirmed }} debates from
           {{ round }} do not have a completed ballot — this may lead to a draw that fails or is incorrect{% endblocktrans %}">
           {% trans "Generate Draw" %} <i data-feather="chevron-right"></i>
         </button>
       {% elif availability_info.teams.in_now == 0 %}
         <button class="btn btn-danger disabled"
-          data-toggle="tooltip" title="{% trans "The draw cannot be generated until some teams have been marked as available." %}">
+          data-bs-toggle="tooltip" title="{% trans "The draw cannot be generated until some teams have been marked as available." %}">
           {% trans "Generate Draw" %} <i data-feather="chevron-right"></i>
         </button>
       {% elif availability_info.adjs.in_now == 0 %}
         <button class="btn btn-danger disabled"
-          data-toggle="tooltip" title="{% trans "The draw cannot be generated until some adjudicators have been marked as available." %}">
+          data-bs-toggle="tooltip" title="{% trans "The draw cannot be generated until some adjudicators have been marked as available." %}">
           {% trans "Generate Draw" %} <i data-feather="chevron-right"></i>
         </button>
       {% elif availability_info.venues.in_now == 0 %}
         <button class="btn btn-warning" id="createDraw"
-          data-toggle="tooltip" title="{% trans "No rooms are marked as available. You can still generate the draw and assign rooms later." %}">
+          data-bs-toggle="tooltip" title="{% trans "No rooms are marked as available. You can still generate the draw and assign rooms later." %}">
           {% trans "Generate Draw" %} <i data-feather="chevron-right"></i>
         </button>
       {% elif min_venues > availability_info.venues.in_now %}
         <button class="btn btn-warning" id="createDraw"
-          data-toggle="tooltip" title="{% trans "There aren't enough rooms marked as available for the number of debates — the draw may not generate properly." %}">
+          data-bs-toggle="tooltip" title="{% trans "There aren't enough rooms marked as available for the number of debates — the draw may not generate properly." %}">
           {% trans "Generate Draw" %} <i data-feather="chevron-right"></i>
         </button>
       {% elif min_adjudicators > availability_info.adjs.in_now %}
         <button class="btn btn-warning" id="createDraw"
-          data-toggle="tooltip" title="{% trans "There aren't enough adjudicators marked as available for the number of debates — the draw may not generate properly." %}">
+          data-bs-toggle="tooltip" title="{% trans "There aren't enough adjudicators marked as available for the number of debates — the draw may not generate properly." %}">
           {% trans "Generate Draw" %} <i data-feather="chevron-right"></i>
         </button>
       {% elif pref.teams_in_debate == 2 and not availability_info.teams.in_now|divisibleby:2  %}
         <button class="btn btn-warning" id="createDraw"
-          data-toggle="tooltip" title="{% trans "There is an uneven number of teams marked as available — the draw may not generate properly." %}">
+          data-bs-toggle="tooltip" title="{% trans "There is an uneven number of teams marked as available — the draw may not generate properly." %}">
           {% trans "Generate Draw" %} <i data-feather="chevron-right"></i>
         </button>
       {% elif pref.teams_in_debate == 4 and not availability_info.teams.in_now|divisibleby:4  %}
         <button class="btn btn-warning" id="createDraw"
-          data-toggle="tooltip" title="{% trans "The number of teams marked as available is not a multiple of 4 — the draw may not generate properly." %}">
+          data-bs-toggle="tooltip" title="{% trans "The number of teams marked as available is not a multiple of 4 — the draw may not generate properly." %}">
           {% trans "Generate Draw" %} <i data-feather="chevron-right"></i>
         </button>
       {% else %}
@@ -137,10 +137,10 @@
   {% if not round.prev and round.draw_type == round.DrawType.POWERPAIRED %}
     <div class="alert alert-info">
       <div class="row align-items-center">
-        <div class="col-auto pr-1">
+        <div class="col-auto pe-1">
           <i data-feather="alert-circle"></i>
         </div>
-        <div class="col pl-0 pr-0">
+        <div class="col ps-0 pe-0">
           {% blocktrans trimmed %}
             This is the first round, but its draw type is <strong>{{ draw_type }}</strong>.
             Did you intend for it to be <strong>Random</strong> or <strong>Seeded</strong> instead?
@@ -205,16 +205,16 @@
   {% if has_seeds and round.draw_type != round.DrawType.SEEDED %}
     <div class="alert alert-warning" id="seeded-draw-alert">
       <div class="row align-items-center">
-        <div class="col-auto pr-1">
+        <div class="col-auto pe-1">
           <i data-feather="alert-circle"></i>
         </div>
-        <div class="col pl-0 pr-0">
+        <div class="col ps-0 pe-0">
           {% blocktrans trimmed %}
             One or more teams have a <strong>seed</strong> assigned, but this round's draw type
             is not <strong>Seeded</strong>.
           {% endblocktrans %}
         </div>
-        <div class="col-auto pl-2">
+        <div class="col-auto ps-2">
           <button class="btn btn-sm btn-warning" id="set-seeded-draw-btn" onclick="setSeededDrawType()">
             {% trans "Set draw type to Seeded" %}
           </button>

--- a/tabbycat/availability/templates/checkin_progress.html
+++ b/tabbycat/availability/templates/checkin_progress.html
@@ -15,7 +15,7 @@
 
     <div class="list-group-item">
       <div class="d-flex justify-content-end">
-        <span class="mr-auto">{{ round.name }}</span>
+        <span class="me-auto">{{ round.name }}</span>
         <strong>{{ info.in_now }}/{{ info.total }}</strong>
       </div>
       {% include "components/progress-bar.html" with value=info.in_now total=info.total type="success" %}
@@ -24,7 +24,7 @@
     {% if info.in_before is not None %}
       <div class="list-group-item">
         <div class="d-flex justify-content-end">
-          <span class="mr-auto">{{ round.prev.name }}</span>
+          <span class="me-auto">{{ round.prev.name }}</span>
           <strong>{{ info.in_before }}/{{ info.total }}</strong>
         </div>
         {% include "components/progress-bar.html" with value=info.in_before total=info.total type="info" %}

--- a/tabbycat/breakqual/templates/breaking_index.html
+++ b/tabbycat/breakqual/templates/breaking_index.html
@@ -50,7 +50,7 @@
                   {{ category }} Break
                 {% endblocktrans %}
               {% blocktrans trimmed with size=category.break_size %}
-              <span class="badge float-right badge-light">
+              <span class="badge float-end text-bg-light">
                 {{ size }} Spots
               </span>
               {% endblocktrans %}
@@ -61,7 +61,7 @@
 
               <div class="list-group-item">
                 <div class="d-flex justify-content-end">
-                  <span class="mr-auto">{% trans "Teams Eligible" %}</span>
+                  <span class="me-auto">{% trans "Teams Eligible" %}</span>
                   <strong>{{ category.eligible }}/{{ teams_in_tournament }}</strong>
                 </div>
                 {% include "components/progress-bar.html" with value=category.eligible total=teams_in_tournament type="secondary" %}
@@ -73,7 +73,7 @@
 
                 <div class="list-group-item">
                   <div class="d-flex justify-content-end">
-                    <span class="mr-auto">{% trans "Breaking" %}</span>
+                    <span class="me-auto">{% trans "Breaking" %}</span>
                     <strong>{{ category.breaking }}</strong>
                   </div>
                   {% include "components/progress-bar.html" with value=category.breaking type="success" %}
@@ -81,7 +81,7 @@
 
                 <div class="list-group-item">
                   <div class="d-flex justify-content-end">
-                    <span class="mr-auto">{% trans "Excluded" %}</span>
+                    <span class="me-auto">{% trans "Excluded" %}</span>
                     <strong>{{ category.excluded }}</strong>
                   </div>
                   {% include "components/progress-bar.html" with value=category.excluded type="warning" %}
@@ -89,7 +89,7 @@
 
                 <div class="list-group-item">
                   <div class="d-flex justify-content-end">
-                    <span class="mr-auto">{% trans "Eligible" %}</span>
+                    <span class="me-auto">{% trans "Eligible" %}</span>
                     <strong>{{ category.eligible }}</strong>
                   </div>
                   {% include "components/progress-bar.html" with value=category.eligible type="info" %}

--- a/tabbycat/checkins/templates/CheckInScanContainer.vue
+++ b/tabbycat/checkins/templates/CheckInScanContainer.vue
@@ -34,7 +34,7 @@ const playSound = (elementID) => {
 const finishCheckIn = (payload) => {
   const checkin = payload.checkins[0]
   const substitutions = [checkin.time, checkin.identifier, checkin.owner_name]
-  const msg = tct('<span class="text-monospace">%s checked in %s:</span> %s', substitutions)
+  const msg = tct('<span class="font-monospace">%s checked in %s:</span> %s', substitutions)
   window.$?.fn?.showAlert?.('success', msg, 0)
   playSound('finishedScanSound')
 }
@@ -200,7 +200,7 @@ onBeforeUnmount(() => {
     </div>
     <div class="list-group-item pb-3">
       <div class="d-flex">
-        <div class="flex-fill pr-2">
+        <div class="flex-fill pe-2">
           <button
             v-if="!liveScanning"
             class="btn btn-block btn-success"
@@ -218,7 +218,7 @@ onBeforeUnmount(() => {
         </div>
         <div
           v-if="!sound"
-          class="flex-fill pl-2"
+          class="flex-fill ps-2"
         >
           <button
             class="btn btn-block btn-success"
@@ -231,7 +231,7 @@ onBeforeUnmount(() => {
       <div
         v-if="liveScanning"
         id="scanCanvas"
-        class="scan-container ml-auto mt-3 mr-auto"
+        class="scan-container ms-auto mt-3 me-auto"
       />
     </div>
     <!-- extra items for error messages -->

--- a/tabbycat/checkins/templates/CheckInStatusContainer.vue
+++ b/tabbycat/checkins/templates/CheckInStatusContainer.vue
@@ -545,38 +545,38 @@ const forAdmin = toRef(props, 'forAdmin')
       class="card mt-1"
     >
       <div class="card-body p-0">
-        <div class="row no-gutters">
+        <div class="row g-0">
           <div class="col-12 col-md-3 col-lg-2 d-flex flex-nowrap align-items-center">
-            <div class="mr-auto strong my-1 px-2">
+            <div class="me-auto strong my-1 px-2">
               {{ grouper }}
             </div>
             <button
               v-if="forAdmin && statusForGroup(entities) === false"
-              class="btn btn-info my-1 mr-1 px-2 align-self-stretch btn-sm hoverable p-1"
+              class="btn btn-info my-1 me-1 px-2 align-self-stretch btn-sm hoverable p-1"
               @click="checkInOrOutGroup(entities, true)"
             >
               {{ gettext('✓ All') }}
             </button>
             <button
               v-if="forAdmin && statusForGroup(entities) === true"
-              class="btn btn-secondary my-1 mr-1 px-2 align-self-stretch btn-sm hoverable p-1"
+              class="btn btn-secondary my-1 me-1 px-2 align-self-stretch btn-sm hoverable p-1"
               @click="checkInOrOutGroup(entities, false)"
             >
               {{ gettext('☓ All') }}
             </button>
           </div>
 
-          <div class="col-12 col-md-9 col-lg-10 pt-md-1 pl-md-0 pl-1">
-            <div class="row no-gutters">
+          <div class="col-12 col-md-9 col-lg-10 pt-md-1 ps-md-0 ps-1">
+            <div class="row g-0">
               <div
                 v-for="entity in entities"
                 :key="entity.id"
                 class="col-lg-3 col-md-4 col-6 check-in-person"
               >
-                <div class="row no-gutters h6 mb-0 pb-1 pr-1 p-0 text-white">
+                <div class="row g-0 h6 mb-0 pb-1 pe-1 p-0 text-white">
                   <div
                     :class="['col p-2 text-truncate ', getEntityStatusClass(entity)]"
-                    data-toggle="tooltip"
+                    data-bs-toggle="tooltip"
                     :title="getToolTipForEntity(entity)"
                   >
                     {{ entity.name }}
@@ -627,7 +627,7 @@ const forAdmin = toRef(props, 'forAdmin')
                     <div
                       v-if="!entity.identifier[0]"
                       class="col-auto p-2 btn-secondary text-white text-center"
-                      data-toggle="tooltip"
+                      data-bs-toggle="tooltip"
                       :title="gettext('This person does not have a check-in identifier so they can\'t be checked in')"
                     >
                       ?

--- a/tabbycat/checkins/templates/checkin_ids.html
+++ b/tabbycat/checkins/templates/checkin_ids.html
@@ -15,7 +15,7 @@
 
             <div class="list-group-item">
               <div class="d-flex justify-content-end">
-                <span class="mr-auto">{% trans "With identifiers" %}</span>
+                <span class="me-auto">{% trans "With identifiers" %}</span>
                 <strong>{{ check_info.in }}/{{ check_info.total }}</strong>
               </div>
               {% include "components/progress-bar.html" with value=check_info.in total=check_info.total type="success" %}

--- a/tabbycat/draw/templates/DebateSideStatus.vue
+++ b/tabbycat/draw/templates/DebateSideStatus.vue
@@ -23,8 +23,8 @@ const updateStatus = (e) => {
 
 <template>
   <div :class="['flex-3 flex-truncate d-flex', !confirmed ? 'bg-danger text-white' : '']">
-    <div class="align-self-center flex-fill pl-3 ">
-      <label class="form-check-label m-0 pl-3 ">
+    <div class="align-self-center flex-fill ps-3 ">
+      <label class="form-check-label m-0 ps-3 ">
         <input
           type="checkbox"
           class="form-check-input"

--- a/tabbycat/draw/templates/EditDebateTeamsContainer.vue
+++ b/tabbycat/draw/templates/EditDebateTeamsContainer.vue
@@ -92,8 +92,8 @@ const { allDebatesOrPanels, sortedDebatesOrPanels, debatesOrPanelsCount, unalloc
       >
         <button
           type="button"
-          class="close"
-          data-dismiss="alert"
+          class="btn-close"
+          data-bs-dismiss="alert"
           aria-label="Close"
         >
           <span aria-hidden="true">×</span>

--- a/tabbycat/draw/templates/draw_display_admin.html
+++ b/tabbycat/draw/templates/draw_display_admin.html
@@ -18,7 +18,7 @@
   </a>
 
   <a href="" class="btn {% if round.starts_at %}btn-outline-primary{% else %}btn-primary{% endif %}"
-     data-toggle="modal" data-target="#editStartTime">
+     data-bs-toggle="modal" data-bs-target="#editStartTime">
     {% if round.starts_at %}
       {% blocktrans trimmed with start_time=round.starts_at %}
         Debates start at {{ start_time }}

--- a/tabbycat/draw/templates/draw_display_by.html
+++ b/tabbycat/draw/templates/draw_display_by.html
@@ -60,7 +60,7 @@
     </div>
   </div>
 
-  <div class="btn btn-secondary btn-sm btn btn-stop-scrolling fixed-top text-white mt-2 mr-2"
+  <div class="btn btn-secondary btn-sm btn btn-stop-scrolling fixed-top text-white mt-2 me-2"
      data-target="draw-xs" id="stop_scrolling">
     {% trans "Stop Scroll" %}
   </div>

--- a/tabbycat/importer/templates/archive_importer.html
+++ b/tabbycat/importer/templates/archive_importer.html
@@ -9,7 +9,7 @@
 
 <div class="row">
 
-  <div class="col-lg-8 ml-lg-auto mr-md-auto">
+  <div class="col-lg-8 ms-lg-auto me-md-auto">
 
     <div class="card">
       <form action="." method="POST">

--- a/tabbycat/motions/templates/motion_global_statistics.html
+++ b/tabbycat/motions/templates/motion_global_statistics.html
@@ -9,7 +9,7 @@
         {{ motion.text }} <small class="text-muted d-md-inline d-none">({{ motion.reference }})</small>
         {% if motion.nrounds > 0 %}
           {% for m_round in motion.rounds.all %}
-            <span class="badge mr-2 float-right badge-light">
+            <span class="badge me-2 float-end text-bg-light">
               {{ m_round.abbreviation }}
             </span>
           {% endfor %}
@@ -17,8 +17,8 @@
       </h4>
 
       {% if motion.info_slide %}
-        <span class="h6 badge badge-light text-secondary mx-auto mb-3 mt-0 hover-target"
-              data-toggle="modal" data-target="#info_{{ motion.id }}">
+        <span class="h6 badge text-bg-light text-secondary mx-auto mb-3 mt-0 hover-target"
+              data-bs-toggle="modal" data-bs-target="#info_{{ motion.id }}">
           {% trans "View Info Slide" %}
         </span>
         {% include 'motions_info.html' %}

--- a/tabbycat/motions/templates/motion_round_statistics.html
+++ b/tabbycat/motions/templates/motion_round_statistics.html
@@ -7,7 +7,7 @@
   <div class="list-group mt-3">
 
     <div class="list-group-item disabled text-center h5" style="margin-bottom:0;">
-      <span class="badge badge-secondary">{{ round.name }}</span>
+      <span class="badge text-bg-secondary">{{ round.name }}</span>
     </div>
 
     {% for r_motion in motions %}
@@ -18,7 +18,7 @@
           {{ motion.text }} <small class="text-muted d-md-inline d-none">({{ motion.reference }})</small>
           {% if motion.nrounds > 1 %}
             {% for m_round in motion.rounds.all %}
-              <span class="badge mr-2 float-right badge-light">
+              <span class="badge me-2 float-end text-bg-light">
                 {{ m_round.abbreviation }}
               </span>
             {% endfor %}
@@ -26,8 +26,8 @@
         </h4>
 
         {% if motion.info_slide %}
-          <span class="h6 badge badge-light text-secondary mx-auto mb-3 mt-0 hover-target"
-                data-toggle="modal" data-target="#info_{{ motion.id }}">
+          <span class="h6 badge text-bg-light text-secondary mx-auto mb-3 mt-0 hover-target"
+                data-bs-toggle="modal" data-bs-target="#info_{{ motion.id }}">
             {% trans "View Info Slide" %}
           </span>
           {% include 'motions_info.html' %}

--- a/tabbycat/motions/templates/motion_statistics_bp_elim.html
+++ b/tabbycat/motions/templates/motion_statistics_bp_elim.html
@@ -35,7 +35,7 @@
           {% endblocktrans %}
 
           <div class="progress-bar progress-bar-advancing"
-               style="width: {{ advancing_pc|unlocalize }}%" data-toggle="tooltip"
+               style="width: {{ advancing_pc|unlocalize }}%" data-bs-toggle="tooltip"
                title="{{ advancing_tooltip_text }}">
             {% if advancing_pc >= 25 %}
               {% trans "advanced" %}
@@ -44,7 +44,7 @@
             {% endif %}
           </div>
           <div class="progress-bar progress-bar-eliminated"
-               style="width: {{ eliminated_pc|unlocalize }}%" data-toggle="tooltip"
+               style="width: {{ eliminated_pc|unlocalize }}%" data-bs-toggle="tooltip"
                title="{{ eliminated_tooltip_text }}">
             {% if eliminated_pc >= 25 %}
               {% trans "eliminated" %}

--- a/tabbycat/motions/templates/motion_statistics_bp_prelim.html
+++ b/tabbycat/motions/templates/motion_statistics_bp_prelim.html
@@ -4,7 +4,7 @@
 
 {% if motion.ndebates > 0 %}
 
-  <div class="row no-gutters">
+  <div class="row g-0">
 
     <div class="col-12 col-md-6 mb-2 px-2">
       <div class="progress">
@@ -41,7 +41,7 @@
 
   </div>
 
-  <div class="row no-gutters">
+  <div class="row g-0">
     <div class="col-md-12 mb-2 px-2">
       <div class="progress">
         {% for side, average, width in motion.averages %}
@@ -66,7 +66,7 @@
     </div>
   </div>
 
-  <div class="row no-gutters">
+  <div class="row g-0">
 
     {% for side, counts_dict in motion.counts_by_side %}
 
@@ -82,7 +82,7 @@
             {% endblocktrans %}
 
             <div class="progress-bar progress-points-{{ points }}"
-                 style="width: {{ percentage|unlocalize }}%" data-toggle="tooltip"
+                 style="width: {{ percentage|unlocalize }}%" data-bs-toggle="tooltip"
                  title="{{ tooltip_text }}">
               {% if count > 0 %}
                 <span class="d-none d-md-inline">

--- a/tabbycat/motions/templates/motion_statistics_twoteam.html
+++ b/tabbycat/motions/templates/motion_statistics_twoteam.html
@@ -26,15 +26,15 @@
   <div class="row pb-3 mt-2">
     {% if motion.ndebates > 0 %}
 
-      <div class="col text-left h6">
-        <span class="text-aff pr-1 d-md-inline d-block">
+      <div class="col text-start h6">
+        <span class="text-aff pe-1 d-md-inline d-block">
           {% blocktrans trimmed with side=side_names.0 count count=motion.s0_wins %}
             {{ count }} {{ side }} win
           {% plural %}
             {{ count }} {{ side }} wins
           {% endblocktrans %}
         </span>
-        <span class="text-neg pr-1 d-md-inline d-block">
+        <span class="text-neg pe-1 d-md-inline d-block">
           {% blocktrans trimmed with side=side_names.1 count count=motion.s1_wins %}
             {{ count }} {{ side }} win
           {% plural %}
@@ -43,7 +43,7 @@
         </span>
       </div>
 
-      <div class="col-auto h6 text-muted" data-toggle="tooltip" title="{{ motion.χ2_info }}">
+      <div class="col-auto h6 text-muted" data-bs-toggle="tooltip" title="{{ motion.χ2_info }}">
         {{ motion.χ2_label }}
       </div>
 
@@ -86,15 +86,15 @@
     <div class="row pb-3 mt-2">
       {% if motion.s0_vetoes or motion.s1_vetoes %}
 
-        <div class="col text-left h6">
-          <span class="text-aff pr-1 d-md-inline d-block">
+        <div class="col text-start h6">
+          <span class="text-aff pe-1 d-md-inline d-block">
             {% blocktrans trimmed with side=side_names.0 count count=motion.s0_vetoes %}
               {{ count }} {{ side }} veto
             {% plural %}
               {{ count }} {{ side }} vetoes
             {% endblocktrans %}
           </span>
-          <span class="text-neg pr-1 d-md-inline d-block">
+          <span class="text-neg pe-1 d-md-inline d-block">
             {% blocktrans trimmed with side=side_names.1 count count=motion.s1_vetoes %}
               {{ count }} {{ side }} veto
             {% plural %}
@@ -103,13 +103,13 @@
           </span>
         </div>
 
-        <div class="col-auto h6 text-muted" data-toggle="tooltip" title="{{ motion.veto_χ2_info }}">
+        <div class="col-auto h6 text-muted" data-bs-toggle="tooltip" title="{{ motion.veto_χ2_info }}">
           {{ motion.veto_χ2_label }}
         </div>
 
       {% else %}
 
-        <div class="col text-muted text-right h6">
+        <div class="col text-muted text-end h6">
           {% trans "No teams vetoed this motion" %}
         </div>
 

--- a/tabbycat/motions/templates/motions_edit.html
+++ b/tabbycat/motions/templates/motions_edit.html
@@ -26,7 +26,7 @@
           {% if round.roundmotion_set.all.length == 0 %}
             <button class="btn btn-outline-primary" id="repeatMotions" type="submit">
           {% else %}
-            <button class="btn btn-outline-primary" id="repeatMotions" type="submit" data-toggle="tooltip" title="{% trans "This will replace all existing motions for this round. The motions themselves will still be in the database." %}">
+            <button class="btn btn-outline-primary" id="repeatMotions" type="submit" data-bs-toggle="tooltip" title="{% trans "This will replace all existing motions for this round. The motions themselves will still be in the database." %}">
           {% endif %}
             {% trans "Reuse Motions from Last Round" %}
           </button>
@@ -58,12 +58,12 @@
   <form method="POST">
     {% csrf_token %}
 
-    <div class="card-deck pr-3 mb-3">
+    <div class="card-deck pe-3 mb-3">
 
       {{ formset.management_form }}
 
       {% for form in formset %}
-        <div class="card mr-0">
+        <div class="card me-0">
           <div class="list-group list-group-flush">
             <div class="list-group-item">
 

--- a/tabbycat/motions/templates/motions_info.html
+++ b/tabbycat/motions/templates/motions_info.html
@@ -2,12 +2,11 @@
 
 <div class="modal fade" id="info_{{ motion.id }}" tabindex="-1" role="dialog"
      aria-labelledby="" aria-hidden="true">
-  <div class="modal-dialog modal-dialog-centered modal-lg text-left" role="document">
+  <div class="modal-dialog modal-dialog-centered modal-lg text-start" role="document">
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title">{% trans "Info Slide" %}</h5>
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-          <span aria-hidden="true">&times;</span>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
         </button>
       </div>
       <div class="modal-body lead">

--- a/tabbycat/motions/templates/public_motions.html
+++ b/tabbycat/motions/templates/public_motions.html
@@ -18,17 +18,17 @@
           {% with motion=r_motion.motion %}
             <li class="list-group-item d-flex flex-column flex-md-row align-items-md-center">
               {% if pref.enable_motions %}
-                <div class="badge badge-info mr-3 d-none d-md-block">
+                <div class="badge text-bg-info me-3 d-none d-md-block">
                   {{ r_motion.seq }}
                 </div>
               {% endif %}
-              <div class="mr-auto pr-3 lead">
+              <div class="me-auto pe-3 lead">
                 {{ motion.text }}
               </div>
               {% if motion.info_slide %}
                 <div class="pt-md-0 pt-2">
                   <button class="btn btn-sm btn-secondary btn-block"
-                          data-toggle="modal" data-target="#info_{{ motion.id }}">
+                          data-bs-toggle="modal" data-bs-target="#info_{{ motion.id }}">
                     {% trans "View Info Slide" %}
                   </button>
                   {% include 'motions_info.html' %}

--- a/tabbycat/motions/templates/show.html
+++ b/tabbycat/motions/templates/show.html
@@ -19,7 +19,7 @@
        style="width: 100%; height: 95vh;">
     <div>
       {% if infos %}
-        <button class="btn btn-lg btn-info btn-block mb-5" data-toggle="modal" data-target="#infoPop">
+        <button class="btn btn-lg btn-info btn-block mb-5" data-bs-toggle="modal" data-bs-target="#infoPop">
           {% blocktrans trimmed with round=round.name count ninfos=infos|length %}
             Reveal Info Slide for {{ round }}
           {% plural %}
@@ -27,7 +27,7 @@
           {% endblocktrans %}
         </button>
       {% endif %}
-      <button class="btn btn-lg btn-success btn-block" data-toggle="modal" data-target="#motionPop">
+      <button class="btn btn-lg btn-success btn-block" data-bs-toggle="modal" data-bs-target="#motionPop">
         {% blocktrans trimmed with round=round.name count nmotions=motions|length %}
           Reveal Motion for {{ round }}
         {% plural %}

--- a/tabbycat/notifications/templates/test_email.html
+++ b/tabbycat/notifications/templates/test_email.html
@@ -9,7 +9,7 @@
 
 <div class="row">
 
-  <div class="col-lg-8 ml-lg-auto mr-md-auto">
+  <div class="col-lg-8 ms-lg-auto me-md-auto">
 
     <div class="card">
       <form action="." method="POST">

--- a/tabbycat/options/templates/preferences_state.html
+++ b/tabbycat/options/templates/preferences_state.html
@@ -21,8 +21,14 @@
               {{ preference.errors }}
             {% endif %}
           </div>
-          <div class="col-md col-12 form-group">
-            {{ preference|addcss:"form-control" }}
+          <div class="col-md col-12 mb-3">
+            {% if preference|is_checkbox %}
+              <div class="form-check form-switch">
+                {{ preference|addcss:"form-check-input" }}
+              </div>
+            {% else %}
+              {{ preference|addcss:"form-control" }}
+            {% endif %}
           </div>
         </div>
       </li>

--- a/tabbycat/participants/templates/current_round/common.html
+++ b/tabbycat/participants/templates/current_round/common.html
@@ -62,8 +62,8 @@
         {% with motion=debate.round.motion_set.first %}
         <strong>{% trans "Motion:" %}</strong> {{ motion.text }}
             {% if motion.info_slide %}
-              <span class="h6 badge badge-light text-secondary mx-auto mb-3 mt-0 hover-target"
-                    data-toggle="modal" data-target="#info_{{ motion.id }}">
+              <span class="h6 badge text-bg-light text-secondary mx-auto mb-3 mt-0 hover-target"
+                    data-bs-toggle="modal" data-bs-target="#info_{{ motion.id }}">
                 {% trans "View Info-slide" %}
               </span>
               {% include 'motions_info.html' %}
@@ -77,8 +77,8 @@
             {{ rm.motion.text }}
 
             {% if rm.motion.info_slide %}
-              <span class="h6 badge badge-light text-secondary mx-auto mb-3 mt-0 hover-target"
-                    data-toggle="modal" data-target="#info_{{ rm.motion.id }}">
+              <span class="h6 badge text-bg-light text-secondary mx-auto mb-3 mt-0 hover-target"
+                    data-bs-toggle="modal" data-bs-target="#info_{{ rm.motion.id }}">
                 {% trans "View Info-slide" %}
               </span>
               {% include 'motions_info.html' with motion=rm.motion %}

--- a/tabbycat/participants/templates/feedback_progress_panel.html
+++ b/tabbycat/participants/templates/feedback_progress_panel.html
@@ -13,7 +13,7 @@
     {% for tracker in feedback_progress.trackers %}
       {% if tracker.fulfilled %}
         <div class="list-group-item {% if not pref.feedback_progress %}list-group-item-secondary{% endif %} text-success">
-          <span class="badge badge-secondary">{{ tracker.round.name }}</span>
+          <span class="badge text-bg-secondary">{{ tracker.round.name }}</span>
           {% person_display_name tracker.submission.adjudicator as adjudicator %}
           {% blocktrans trimmed with adjudicator=adjudicator %}
             Has submitted feedback for <strong>{{ adjudicator }}</strong>
@@ -21,7 +21,7 @@
         </div>
       {% elif tracker.expected and tracker.count == 0 %}
         <div class="list-group-item {% if not pref.feedback_progress %}list-group-item-secondary{% endif %} text-danger">
-          <span class="badge badge-secondary">{{ tracker.round.name }}</span>
+          <span class="badge text-bg-secondary">{{ tracker.round.name }}</span>
           {% if tracker.acceptable_targets|length > 1 %}
             {% blocktrans trimmed with adjudicators=tracker.acceptable_target_names|join:", " %}
               Has not submitted feedback for one of: <strong>{{ adjudicators }}</strong>
@@ -35,7 +35,7 @@
         </div>
       {% elif tracker.expected %}
         <div class="list-group-item {% if not pref.feedback_progress %}list-group-item-secondary{% endif %} text-warning">
-          <span class="badge badge-secondary">{{ tracker.round.name }}</span>
+          <span class="badge text-bg-secondary">{{ tracker.round.name }}</span>
           {% trans "More feedback submissions than expected for this debate:" %}
           {% for submission in tracker.acceptable_submissions %}
             <strong>{% person_display_name submission.adjudicator %}</strong>{% if not forloop.last %},{% endif %}
@@ -43,7 +43,7 @@
         </div>
       {% else %} {# if not tracker.fulfilled and not tracker.expected #}
         <div class="list-group-item {% if not pref.feedback_progress %}list-group-item-secondary{% endif %} text-warning">
-          <span class="badge badge-secondary">{{ tracker.round.name }}</span>
+          <span class="badge text-bg-secondary">{{ tracker.round.name }}</span>
           {% person_display_name tracker.submission.adjudicator as adjudicator %}
           {% blocktrans trimmed with adjudicator=adjudicator %}
             Unexpected feedback submission for <strong>{{ adjudicator }}</strong>

--- a/tabbycat/participants/templates/participants_subnav.html
+++ b/tabbycat/participants/templates/participants_subnav.html
@@ -14,13 +14,13 @@
     {% trans "Gender Diversity" %}
   </a>
   <a class="btn btn-outline-primary {% if adj_req_nav %}active{% endif %}"
-     href="{% tournamenturl 'participants-adj-rule' %}" data-toggle="tooltip" title="{% trans '' %}">
+     href="{% tournamenturl 'participants-adj-rule' %}" data-bs-toggle="tooltip" title="{% trans '' %}">
     {% trans "Adjudicator Rule" %}
   </a>
 </div>
 <div class="btn-group btn-group">
   {% if email_sent %}
-    <a href="{% tournamenturl 'participants-email' %}" class="btn btn-outline-secondary" data-toggle="tooltip" title="{% trans "Emails have already been sent." %}">
+    <a href="{% tournamenturl 'participants-email' %}" class="btn btn-outline-secondary" data-bs-toggle="tooltip" title="{% trans "Emails have already been sent." %}">
   {% else %}
     <a href="{% tournamenturl 'participants-email' %}" class="btn btn-outline-primary">
   {% endif %}

--- a/tabbycat/printing/templates/PrintableBallotHeader.vue
+++ b/tabbycat/printing/templates/PrintableBallotHeader.vue
@@ -38,7 +38,7 @@ const { gettext, tct } = useDjangoI18n()
 
     <div
       v-if="ballot.venue === '' || ballot.venue === null"
-      class="ml-auto"
+      class="ms-auto"
     >
       <span v-if="ballot.barcode">
         {{ tct('ID %s,', [ballot.barcode]) }}
@@ -52,7 +52,7 @@ const { gettext, tct } = useDjangoI18n()
 
     <div
       v-else
-      class="ml-auto "
+      class="ms-auto "
     >
       <span v-if="ballot.barcode">{{ tct('ID %s,', [ballot.barcode]) }}</span>
       {{ ballot.venue.display_name }}

--- a/tabbycat/printing/templates/PrintableDebateInfo.vue
+++ b/tabbycat/printing/templates/PrintableDebateInfo.vue
@@ -140,7 +140,7 @@ const motionsAccountingForBlanks = computed(() => {
               <div class="text-center pb-2">
                 {{ tct('Circle %s', [choice_type]) }}
               </div>
-              <div class="d-flex text-monospace">
+              <div class="d-flex font-monospace">
                 <div
                   v-for="motion in motionsAccountingForBlanks"
                   class="db-align-horizontal-center db-align-vertical-start
@@ -188,7 +188,7 @@ const motionsAccountingForBlanks = computed(() => {
             <div class="text-center pb-2">
               {{ tct('Circle %s', [choice_type]) }}
             </div>
-            <div class="d-flex text-monospace">
+            <div class="d-flex font-monospace">
               <div
                 v-for="motion in motionsAccountingForBlanks"
                 class="db-align-horizontal-center db-align-vertical-start
@@ -215,7 +215,7 @@ const motionsAccountingForBlanks = computed(() => {
           >
             <div
               v-for="choice_type in ['1', '2', '3', ]"
-              class="flex-fill db-fill-in strong mr-3 pt-3 mt-2"
+              class="flex-fill db-fill-in strong me-3 pt-3 mt-2"
             >
               {{ tct('%s:', [choice_type]) }}
             </div>

--- a/tabbycat/printing/templates/PrintableTeamScores.vue
+++ b/tabbycat/printing/templates/PrintableTeamScores.vue
@@ -79,7 +79,7 @@ const titleCasePosition = computed(() => {
 
       <div
         v-if="roundInfo.showDigits"
-        class="db-flex-item-2 align-items-center d-flex pr-1 small db-bottom-border"
+        class="db-flex-item-2 align-items-center d-flex pe-1 small db-bottom-border"
       >
         <div
           class="db-flex-item-2 db-padding-horizontal text-secondary"
@@ -107,7 +107,7 @@ const titleCasePosition = computed(() => {
             class="flex-grow-1 db-align-vertical-center db-align-horizontal-center"
           >
             <span
-              class="db-circle text-monospace"
+              class="db-circle font-monospace"
               v-html="ord"
             />
           </div>
@@ -129,7 +129,7 @@ const titleCasePosition = computed(() => {
 
     <div
       v-if="roundInfo.showDigits"
-      class="db-flex-item-2 align-items-center d-flex pr-1 small"
+      class="db-flex-item-2 align-items-center d-flex pe-1 small"
     >
       <div class="db-flex-item-2 db-padding-horizontal text-secondary">
         {{ gettext('Circle the last digit of the team\'s total:') }}

--- a/tabbycat/printing/templates/scoresheet_list.html
+++ b/tabbycat/printing/templates/scoresheet_list.html
@@ -10,7 +10,7 @@
       {% endblocktrans %}
       <small class="text-muted d-md-inline d-none">{{ subtitle }}</small>
     </div>
-    <button class="btn btn-outline-primary" data-toggle="modal" data-target="#editMotionsModal">
+    <button class="btn btn-outline-primary" data-bs-toggle="modal" data-bs-target="#editMotionsModal">
       {% trans "Edit Motion(s)" %}
     </button>
   </div>
@@ -38,8 +38,7 @@
         <div class="modal-content">
           <div class="modal-header">
             <h3 class="modal-title">{% trans "Edit Ballot Motions" %}</h3>
-            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-              <span aria-hidden="true">{% trans "&times;" %}</span>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
             </button>
           </div>
           <div class="modal-body">

--- a/tabbycat/privateurls/templates/private_url_landing.html
+++ b/tabbycat/privateurls/templates/private_url_landing.html
@@ -117,8 +117,7 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
                 </button>
             </div>
             <div class="modal-body text-center">

--- a/tabbycat/privateurls/templates/private_urls_nav.html
+++ b/tabbycat/privateurls/templates/private_urls_nav.html
@@ -19,7 +19,7 @@
     {% if to_email_exists %}
       <a href="{% tournamenturl 'privateurls-email' %}" class="btn btn-outline-primary">
     {% else %}
-      <a href="{% tournamenturl 'privateurls-email' %}" class="btn btn-outline-secondary" data-toggle="tooltip" title="{% trans "All reachable participants have already been sent their private URLs." %}">
+      <a href="{% tournamenturl 'privateurls-email' %}" class="btn btn-outline-secondary" data-bs-toggle="tooltip" title="{% trans "All reachable participants have already been sent their private URLs." %}">
     {% endif %}
       {% trans "Email URLs" %}
     </a>
@@ -28,14 +28,14 @@
     <div class="btn-group">
       <form action="{% tournamenturl 'privateurls-generate' %}" method="POST">
       {% csrf_token %}
-      <button class="btn btn-outline-success" id="generateRandomisedUrls" type="submit" data-toggle="tooltip" title="{% trans "This button only generates private URLs for participants who do not already have one." %}">
+      <button class="btn btn-outline-success" id="generateRandomisedUrls" type="submit" data-bs-toggle="tooltip" title="{% trans "This button only generates private URLs for participants who do not already have one." %}">
         {% trans "Generate URLs" %}
       </button>
       </form>
     </div>
   {% else %}
     <div class="btn-group">
-      <button class="btn btn-outline-secondary" id="generateRandomisedUrls" data-toggle="tooltip" title="{% trans "All participants already have private URLs." %}">
+      <button class="btn btn-outline-secondary" id="generateRandomisedUrls" data-bs-toggle="tooltip" title="{% trans "All participants already have private URLs." %}">
         {% trans "Generate URLs" %}
       </button>
     </div>

--- a/tabbycat/registration/templates/adjudicator_registration_form.html
+++ b/tabbycat/registration/templates/adjudicator_registration_form.html
@@ -5,7 +5,7 @@
 
 <div class="row">
 
-    <form class="col-lg-8 ml-lg-auto mr-md-auto d-flex flex-column gap-3" action="." method="POST">
+    <form class="col-lg-8 ms-lg-auto me-md-auto d-flex flex-column gap-3" action="." method="POST">
 
       {% if pref.adjudicator_register_message %}
         <div class="card">

--- a/tabbycat/registration/templates/registration/institution_edit.html
+++ b/tabbycat/registration/templates/registration/institution_edit.html
@@ -4,7 +4,7 @@
 {% block content %}
 
 <div class="row">
-  <form class="col-lg-8 ml-lg-auto mr-md-auto d-flex flex-column gap-3" action="." method="POST">
+  <form class="col-lg-8 ms-lg-auto me-md-auto d-flex flex-column gap-3" action="." method="POST">
     {% csrf_token %}
 
     <div class="card">

--- a/tabbycat/registration/templates/registration/institution_view_response.html
+++ b/tabbycat/registration/templates/registration/institution_view_response.html
@@ -5,7 +5,7 @@
 
 <!-- This form is read-only: coaches can view their institution and primary contact response but cannot edit. -->
 <div class="row">
-  <div class="col-lg-8 ml-lg-auto mr-md-auto">
+  <div class="col-lg-8 ms-lg-auto me-md-auto">
     <div class="alert alert-info mb-4">
       {% trans "This form is read-only. You can view your institution's registration response below but cannot edit it here." %}
     </div>

--- a/tabbycat/registration/templates/slot_transfer_request_form.html
+++ b/tabbycat/registration/templates/slot_transfer_request_form.html
@@ -4,7 +4,7 @@
 {% block content %}
 
 <div class="row">
-  <form class="col-lg-8 ml-lg-auto mr-md-auto d-flex flex-column gap-3" action="." method="POST" id="slot-transfer-form">
+  <form class="col-lg-8 ms-lg-auto me-md-auto d-flex flex-column gap-3" action="." method="POST" id="slot-transfer-form">
     {% csrf_token %}
 
     <div class="card">

--- a/tabbycat/registration/templates/speaker_registration_form.html
+++ b/tabbycat/registration/templates/speaker_registration_form.html
@@ -5,7 +5,7 @@
 
 <div class="row">
 
-    <form class="col-lg-8 ml-lg-auto mr-md-auto d-flex flex-column gap-3" action="." method="POST">
+    <form class="col-lg-8 ms-lg-auto me-md-auto d-flex flex-column gap-3" action="." method="POST">
 
       {% csrf_token %}
       <div class="card">

--- a/tabbycat/registration/templates/team_wizard_speakers.html
+++ b/tabbycat/registration/templates/team_wizard_speakers.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 
 {% block page-alerts %}
-<div class="col-lg-8 ml-lg-auto mr-md-auto d-flex flex-column gap-3">
+<div class="col-lg-8 ms-lg-auto me-md-auto d-flex flex-column gap-3">
   {% blocktrans trimmed asvar p1 %}
     You may register speakers for the team, but if not all speakers are included, a link will be generated to let speakers register themselves to the team after submission which you can then distribute.
   {% endblocktrans %}

--- a/tabbycat/registration/templates/wizard_registration_form.html
+++ b/tabbycat/registration/templates/wizard_registration_form.html
@@ -5,7 +5,7 @@
 
 <div class="row">
 
-    <form class="col-lg-8 ml-lg-auto mr-md-auto d-flex flex-column gap-3" action="." method="POST">
+    <form class="col-lg-8 ms-lg-auto me-md-auto d-flex flex-column gap-3" action="." method="POST">
 
       {% block registration_header%}
       {% endblock %}

--- a/tabbycat/results/templates/BallotEntryContainer.vue
+++ b/tabbycat/results/templates/BallotEntryContainer.vue
@@ -121,12 +121,12 @@ onMounted(() => {
       <div class="list-group list-group-flush">
         <div class="list-group-item pt-4">
           <h4
-            class="card-title float-left mt-0 mb-2"
+            class="card-title float-start mt-0 mb-2"
             v-html="sheet.title"
           />
           <div
             v-if="sheet.subtitle !== ''"
-            class="badge badge-secondary float-right ml-2 mt-1"
+            class="badge text-bg-secondary float-end ms-2 mt-1"
           >
             <p class="mb-0">
               {{ sheet.subtitle }}

--- a/tabbycat/results/templates/BallotEntryFooter.vue
+++ b/tabbycat/results/templates/BallotEntryFooter.vue
@@ -61,7 +61,7 @@ const invalidate = () => {
         <h4 class="card-title mt-0 mb-2 d-inline-block">
           Ballot Status
         </h4>
-        <h4 class="text-secondary float-right">
+        <h4 class="text-secondary float-end">
           <small>only the confirmed ballot set will affect this debate's result</small>
         </h4>
       </div>
@@ -111,7 +111,7 @@ const invalidate = () => {
         <h4 class="card-title mt-0 mb-2 d-inline-block">
           Debate Status
         </h4>
-        <h4 class="text-secondary float-right">
+        <h4 class="text-secondary float-end">
           <small>all debates must be confirmed to complete the round</small>
         </h4>
       </div>

--- a/tabbycat/results/templates/BallotEntryHeader.vue
+++ b/tabbycat/results/templates/BallotEntryHeader.vue
@@ -116,13 +116,13 @@ onMounted(() => {
           <span v-if="isNew">New Ballot Set</span>
           <span v-if="!isNew">Edit Ballot Set</span>
         </h4>
-        <div class="badge badge-secondary float-right ml-2 mt-1">
+        <div class="badge text-bg-secondary float-end ms-2 mt-1">
           {{ debate }}
         </div>
-        <div class="badge badge-secondary float-right ml-2 mt-1">
+        <div class="badge text-bg-secondary float-end ms-2 mt-1">
           {{ round }}
         </div>
-        <div class="badge badge-secondary float-right ml-2 mt-1">
+        <div class="badge text-bg-secondary float-end ms-2 mt-1">
           {{ venue }}
         </div>
       </div>
@@ -136,7 +136,7 @@ onMounted(() => {
           <label>Selected Motion</label>
           <select
             v-model="selectedMotion"
-            class="required custom-select form-control"
+            class="required form-select form-control"
             :disabled="!isNew && !isAdmin"
             tabindex="1"
             @change="setSelected()"
@@ -180,7 +180,7 @@ onMounted(() => {
             <label>{{ team }}'s Veto</label>
             <select
               v-model="motionVetoes[team]['value']"
-              class="required custom-select form-control"
+              class="required form-select form-control"
               :disabled="!isNew && !isAdmin"
               :tabindex="index + 1"
               @change="setVetoed(team)"
@@ -209,7 +209,7 @@ onMounted(() => {
         >
           <select
             v-model="ironStatus"
-            class="required custom-select form-control"
+            class="required form-select form-control"
             :disabled="!isNew && !isAdmin"
             :tabindex="4"
             @change="setIron()"

--- a/tabbycat/results/templates/BallotEntryScoresheet.vue
+++ b/tabbycat/results/templates/BallotEntryScoresheet.vue
@@ -68,16 +68,16 @@ const blindValidationFail = () => {
 </script>
 
 <template>
-  <div class="card pr-0 mr-0 m-2">
+  <div class="card pe-0 me-0 m-2">
     <div class="list-group list-group-flush">
       <div class="list-group-item pb-0">
         <div class="row">
           <!-- team-name class used by unknown sides switcher -->
           <div
-            class="col mr-auto card-title pl-md-2 pl-1"
+            class="col me-auto card-title ps-md-2 ps-1"
             v-html="team.name"
           />
-          <div class="col-auto card-subtitle text-muted text-right pt-2 pr-md-2 pr-1">
+          <div class="col-auto card-subtitle text-muted text-end pt-2 pe-md-2 pe-1">
             <h6>{{ team.position }}</h6>
           </div>
         </div>
@@ -101,7 +101,7 @@ const blindValidationFail = () => {
 
       <div class="list-group-item">
         <div class="row">
-          <div class="col offset-md-2 mb-0 pr-md-2 pr-1 pl-1">
+          <div class="col offset-md-2 mb-0 pe-md-2 pe-1 ps-1">
             <div class="btn-group d-flex">
               <button
                 tabindex="-1"
@@ -112,7 +112,7 @@ const blindValidationFail = () => {
               </button>
               <button
                 tabindex="-1"
-                :class="['btn btn-no-hover flex-grow-1 text-monospace border-right-0 ', rankClasses[teamRank]]"
+                :class="['btn btn-no-hover flex-grow-1 font-monospace border-right-0 ', rankClasses[teamRank]]"
                 readonly
               >
                 {{ rankLabels[teamRank] }}
@@ -126,7 +126,7 @@ const blindValidationFail = () => {
               </button>
               <button
                 tabindex="-1"
-                :class="['btn btn-no-hover flex-grow-1 text-monospace', rankClasses[teamRank]]"
+                :class="['btn btn-no-hover flex-grow-1 font-monospace', rankClasses[teamRank]]"
                 readonly
               >
                 <span v-if="teamMargin >= 0">+</span>{{ teamMargin }}
@@ -134,7 +134,7 @@ const blindValidationFail = () => {
             </div>
           </div>
 
-          <div class="col-3 form-group pr-1 pl-1">
+          <div class="col-3 form-group pe-1 ps-1">
             <button
               tabindex="-1"
               :class="['btn btn-block btn-no-hover', rankClasses[teamRank]]"

--- a/tabbycat/results/templates/BallotEntrySpeaker.vue
+++ b/tabbycat/results/templates/BallotEntrySpeaker.vue
@@ -181,7 +181,7 @@ onMounted(async () => {
           <span class="mt-2" />
           <label
             :for="'dupeCheck' + speaker.position"
-            :class="['ml-2 hoverable', blindDuplicateMatches ? '' : 'text-danger']"
+            :class="['ms-2 hoverable', blindDuplicateMatches ? '' : 'text-danger']"
           >
             Mark as a duplicate speech
           </label>
@@ -253,7 +253,7 @@ onMounted(async () => {
           <span class="mt-2" />
           <label
             :for="'check' + speaker.position"
-            :class="['ml-2 hoverable', blindDuplicateMatches ? '' : 'text-danger']"
+            :class="['ms-2 hoverable', blindDuplicateMatches ? '' : 'text-danger']"
           >
             Mark as a duplicate speech
           </label>

--- a/tabbycat/results/templates/BallotEntrySpeaker.vue
+++ b/tabbycat/results/templates/BallotEntrySpeaker.vue
@@ -130,16 +130,16 @@ onMounted(async () => {
       class="row"
     >
       <div
-        class="col-2 d-flex align-items-center mb-0 pl-2 pr-0 h6 text-muted"
+        class="col-2 d-flex align-items-center mb-0 ps-2 pe-0 h6 text-muted"
         v-html="blindReveal ? 'Re-Entry of ' + speaker.position : speaker.position"
       />
 
-      <div class="col mb-0 pr-md-1 pr-md-2 pr-1 pl-1 form-group">
+      <div class="col mb-0 pe-md-1 pe-md-2 pe-1 ps-1 form-group">
         <select
           v-model="speakerNameShadow"
           :disabled="blindReveal"
           v-bind="selectAttributes"
-          :class="['custom-select mb-2', !blindSpeakerMatches && blindReveal ? 'is-invalid bg-dark text-white' : '',
+          :class="['form-select mb-2', !blindSpeakerMatches && blindReveal ? 'is-invalid bg-dark text-white' : '',
                    blindSpeakerMatches && blindReveal ? 'is-valid' : '']"
         >
           <option
@@ -188,7 +188,7 @@ onMounted(async () => {
         </div>
       </div>
 
-      <div class="col-3 form-group pr-1 pl-1">
+      <div class="col-3 form-group pe-1 ps-1">
         <input
           v-model.number="speakerScoreShadow"
           :class="['form-control mb-2', !blindScoreMatches && blindReveal ? 'is-invalid bg-dark text-white' : '',
@@ -209,17 +209,17 @@ onMounted(async () => {
       class="row"
     >
       <div
-        :class="['col-2 d-flex align-items-center mb-0 pl-2 pr-0 h6',
+        :class="['col-2 d-flex align-items-center mb-0 ps-2 pe-0 h6',
                  blindEntry ? 'text-primary' : 'text-muted']"
       >
         <span v-if="blindEntry">Draft</span>
         <span v-if="!blindEntry">{{ speaker.position }}</span>
       </div>
 
-      <div class="col mb-0 pr-md-1 pr-md-2 pr-1 pl-1 form-group">
+      <div class="col mb-0 pe-md-1 pe-md-2 pe-1 ps-1 form-group">
         <select
           v-model="speakerName"
-          :class="['custom-select', speakerError ? 'border-danger text-danger' : '',
+          :class="['form-select', speakerError ? 'border-danger text-danger' : '',
                    !blindSpeakerMatches && blindEntry ? 'is-invalid' : '',
                    blindSpeakerMatches && blindEntry ? 'is-valid' : '']"
           v-bind="selectAttributes"
@@ -260,7 +260,7 @@ onMounted(async () => {
         </div>
       </div>
 
-      <div class="col-3 form-group pr-1 pl-1">
+      <div class="col-3 form-group pe-1 ps-1">
         <input
           v-model.number="speakerScore"
           :class="['form-control', scoreError ? 'border-danger text-danger' : '',

--- a/tabbycat/results/templates/BallotsCell.vue
+++ b/tabbycat/results/templates/BallotsCell.vue
@@ -53,7 +53,7 @@ const ballotText = (ballot) => {
 
 <template>
   <td>
-    <div class="ballot-cell pr-2">
+    <div class="ballot-cell pe-2">
       <div
         v-for="ballot in cellData.ballots"
         :key="ballot.id"
@@ -76,7 +76,7 @@ const ballotText = (ballot) => {
         <span
           v-else
           class="ballot-link"
-          data-toggle="tooltip"
+          data-bs-toggle="tooltip"
           :title="gettext('You cannot confirm this ballot because you entered it')"
         >
           <del v-if="ballot.discarded">
@@ -89,7 +89,7 @@ const ballotText = (ballot) => {
 
         <!-- Ballot metadata -->
         <span class="small text-muted ballot-info">
-          <span class="text-monospace">{{ ballot.short_time }}</span>&nbsp;
+          <span class="font-monospace">{{ ballot.short_time }}</span>&nbsp;
           <span
             v-if="ballot.private_url"
             class="text-info"

--- a/tabbycat/results/templates/ResultsStats.vue
+++ b/tabbycat/results/templates/ResultsStats.vue
@@ -38,7 +38,7 @@ const statusWidths = computed(() => {
               class="progress-bar bg-secondary"
               role="progressbar"
               :style="{ width: checksWidths.checked }"
-              data-toggle="tooltip"
+              data-bs-toggle="tooltip"
               :title="checks.checked + ' ' + gettext('Checked-In')"
             >
               <i data-feather="x" />&nbsp;&nbsp;{{ checks.checked }}
@@ -47,7 +47,7 @@ const statusWidths = computed(() => {
               class="progress-bar bg-dark"
               role="progressbar"
               :style="{ width: checksWidths.missing }"
-              data-toggle="tooltip"
+              data-bs-toggle="tooltip"
               :title="checks.missing + ' ' + gettext('Not Checked-In')"
             >
               <i data-feather="circle" />&nbsp;&nbsp;{{ checks.missing }}
@@ -64,7 +64,7 @@ const statusWidths = computed(() => {
               class="progress-bar bg-danger"
               role="progressbar"
               :style="{ width: statusWidths.none }"
-              data-toggle="tooltip"
+              data-bs-toggle="tooltip"
               :title="statuses.none + ' ' + gettext('Unknown')"
             >
               <i data-feather="x" />&nbsp;&nbsp;{{ statuses.none }}
@@ -73,7 +73,7 @@ const statusWidths = computed(() => {
               class="progress-bar bg-warning"
               role="progressbar"
               :style="{ width: statusWidths.postponed }"
-              data-toggle="tooltip"
+              data-bs-toggle="tooltip"
               :title="statuses.postponed + ' ' + gettext('Postponed')"
             >
               <i data-feather="pause" />&nbsp;&nbsp;{{ statuses.postponed }}
@@ -82,7 +82,7 @@ const statusWidths = computed(() => {
               class="progress-bar bg-info"
               role="progressbar"
               :style="{ width: statusWidths.draft }"
-              data-toggle="tooltip"
+              data-bs-toggle="tooltip"
               :title="statuses.draft + ' ' + gettext('Unconfirmed')"
             >
               <i data-feather="circle" />&nbsp;&nbsp;{{ statuses.draft }}
@@ -91,7 +91,7 @@ const statusWidths = computed(() => {
               class="progress-bar bg-success"
               role="progressbar"
               :style="{ width: statusWidths.confirmed }"
-              data-toggle="tooltip"
+              data-bs-toggle="tooltip"
               :title="statuses.confirmed + ' ' + gettext('Confirmed')"
             >
               <i data-feather="check" />&nbsp;&nbsp;{{ statuses.confirmed }}

--- a/tabbycat/results/templates/admin_results.html
+++ b/tabbycat/results/templates/admin_results.html
@@ -8,7 +8,7 @@
   <a class="btn btn-outline-primary" href="{% tournamenturl 'admin-checkin-prescan' %}">
     {% trans "Check-In Ballots" %}
   </a>
-  <a class="btn btn-outline-primary" href="" data-toggle="modal" data-target="#ironSpeeches">
+  <a class="btn btn-outline-primary" href="" data-bs-toggle="modal" data-bs-target="#ironSpeeches">
     {% trans "Recent 'Iron-Persons'" %}
   </a>
 
@@ -18,8 +18,7 @@
       <div class="modal-content">
         <div class="modal-header">
           <h4 class="modal-title">{% trans "Teams who have recently missed a speaker" %}</h4>
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-            <span aria-hidden="true">&times;</span>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
           </button>
         </div>
         <div class="list-group">

--- a/tabbycat/results/templates/ballot/ballot_debate_info.html
+++ b/tabbycat/results/templates/ballot/ballot_debate_info.html
@@ -42,7 +42,7 @@
     {% if form.has_scores %}
       <div class="list-group-item pb-3 pt-3">
         <div class="form-group">
-          <select class="required custom-select form-control" id="hasIron" name="iron"
+          <select class="required form-select form-control" id="hasIron" name="iron"
                   tabindex="{{ form.irontabindex }}" required="" aria-required="true">
             <option value="0">
               {% trans "No speakers spoke twice (no 'iron-person' speeches)" %}

--- a/tabbycat/results/templates/ballot/ballot_scoresheet.html
+++ b/tabbycat/results/templates/ballot/ballot_scoresheet.html
@@ -1,12 +1,12 @@
 {% load add_field_css debate_tags i18n team_name_for_data_entry %}
 
-<div class="card pr-0 mr-0 position" {% if forloop.parentloop.first %}id="team-{{ team.team.id }}"{% endif %}>
+<div class="card pe-0 me-0 position" {% if forloop.parentloop.first %}id="team-{{ team.team.id }}"{% endif %}>
   <div class="list-group list-group-flush">
 
     <div class="list-group-item pb-0">
       <div class="row">
         <!-- team-name class used by unknown sides switcher -->
-        <div class="col mr-auto card-title pl-md-2 pl-1 {{ team.side_code }}-team-name">
+        <div class="col me-auto card-title ps-md-2 ps-1 {{ team.side_code }}-team-name">
           {% team_name_for_data_entry team.team use_team_code_names %}
         </div>
         {% if team.forfeit %}
@@ -15,7 +15,7 @@
             {{ team.forfeit.errors }}
           </div>
         {% endif %}
-        <div class="col-auto card-subtitle text-muted text-right pt-2 pr-md-2 pr-1">
+        <div class="col-auto card-subtitle text-muted text-end pt-2 pe-md-2 pe-1">
           <h6>{{ team.side_name }}</h6>
         </div>
       </div>
@@ -28,7 +28,7 @@
     <div class="list-group-item">
       <div class="row">
 
-        <div class="col-6 flex-column flex-md-row mr-0 col-mr-auto pl-md-2 pl-1 btn-group">
+        <div class="col-6 flex-column flex-md-row me-0 col-mr-auto ps-md-2 ps-1 btn-group">
 
           <button class="btn btn-outline-secondary btn-no-hover" readonly>
             {% if pref.teams_in_debate != 4 %}{% trans "Result" %}{% else %}{% trans "Rank" %}{% endif %}
@@ -46,7 +46,7 @@
 
         <div class="col d-none d-md-block"></div>
 
-        <div class="col-6 col-md-4 btn-group pr-md-2 pr-1">
+        <div class="col-6 col-md-4 btn-group pe-md-2 pe-1">
           <button name="{{ team.side_code }}_total"
                   class="btn btn-block btn-secondary btn-no-hover {{ team.side_code }}_total" readonly>00</button>
         </div>

--- a/tabbycat/results/templates/ballot/ballot_set.html
+++ b/tabbycat/results/templates/ballot/ballot_set.html
@@ -28,11 +28,11 @@
         {% include "components/form-title.html" %}
       {% else %}
         <div class="list-group-item pt-4">
-          <h4 class="card-title float-left mt-0 {% if not text %}mb-2{% endif %}">
+          <h4 class="card-title float-start mt-0 {% if not text %}mb-2{% endif %}">
             {% trans "Scoresheet" %}
           </h4>
             {% for da in debate.adjudicators.voting_with_positions reversed %}
-              <div class="badge badge-secondary float-right ml-2 mt-1">
+              <div class="badge text-bg-secondary float-end ms-2 mt-1">
                 <p class="mb-0">{{ da.0.name }} ({% if da.1 == "o" %}{% trans "Solo Chair" %}{% elif da.1 == "c" %}{% trans "Chair" %}{% elif da.1 == "p" %}{% trans "Panellist" %}{% elif da.1 == "t" %}{% trans "Trainee" %}{% endif %})</p>
               </div>
             {% endfor %}
@@ -57,7 +57,7 @@
 
           {% for checkbox in sheet.advancing %}
             <div class="card px-3">
-              <div class="form-check pl-4 pt-1 h6">
+              <div class="form-check ps-4 pt-1 h6">
                 {{ checkbox|addboundwidgetcss:"form-check-input" }}
               </div>
             </div>

--- a/tabbycat/results/templates/ballot/ballot_speaks.html
+++ b/tabbycat/results/templates/ballot/ballot_speaks.html
@@ -2,20 +2,20 @@
 
 <div class="list-group-item js-team-speakers side-{{ team.side_code }} s{{ position.pos }}">
   <div class="row flex-column flex-md-row align-items-center">
-    <div class="col-4 col-md-2 pr-0 speaker-position-label">
+    <div class="col-4 col-md-2 pe-0 speaker-position-label">
       {{ position.name }}
     </div>
 
-    <div class="col mb-0 pr-md-2 pr-1 form-group {{ position.speaker.errors|yesno:'error,' }}">
+    <div class="col mb-0 pe-md-2 pe-1 form-group {{ position.speaker.errors|yesno:'error,' }}">
 
       {% if forloop.parentloop.parentloop.first %}
 
         {# On the first form, display the speaker selection dropdown. #}
-        {{ position.speaker|addcss:"js-speaker form-control custom-select" }}
+        {{ position.speaker|addcss:"js-speaker form-control form-select" }}
         {{ position.speaker.errors }}
 
         <div class="iron-person small pt-0 m-0 form-check form-check-inline" style="display: none;"
-               data-toggle="tooltip" data-placement="bottom"
+               data-bs-toggle="tooltip" data-placement="bottom"
                title="{% trans "Duplicate speeches are hidden from the speaker tab. If a speaker is 'iron-personing' you would typically mark only the lesser of their scores as a duplicate." %}">
           {{ position.ghost|addcss:"form-check-input" }}
           <span class="mt-2"></span>
@@ -33,13 +33,13 @@
     </div>
 
     {% if position.srank %}
-      <div class="col-4 form-group side-{{ team.side_code }} pr-md-2 pr-1 srank {{ position.srank_errors|yesno:'error,' }}">
+      <div class="col-4 form-group side-{{ team.side_code }} pe-md-2 pe-1 srank {{ position.srank_errors|yesno:'error,' }}">
         {{ position.srank|addcss:"form-control" }}
         {{ position.srank.errors }}
       </div>
     {% endif %}
 
-    <div class="col col-md-4 form-group side-{{ team.side_code }} pr-md-2 pr-1 score {{ position.score_errors|yesno:'error,' }}">
+    <div class="col col-md-4 form-group side-{{ team.side_code }} pe-md-2 pe-1 score {{ position.score_errors|yesno:'error,' }}">
       {% for criterion, field in position.criteria %}
       <div class="criterion mb-3 w-auto">
         {{ criterion.name }}

--- a/tabbycat/results/templates/ballot/other_ballots_list.html
+++ b/tabbycat/results/templates/ballot/other_ballots_list.html
@@ -38,11 +38,11 @@
       {% endif %}
 
         {% if other == ballotsub %}
-          <span class="badge badge-success float-right">{% trans "CURRENTLY VIEWING" %}</span>
+          <span class="badge text-bg-success float-end">{% trans "CURRENTLY VIEWING" %}</span>
         {% endif %}
 
         {% if other.merged %}
-          <span class="badge badge-success float-right">{% trans "MERGING" %}</span>
+          <span class="badge text-bg-success float-end">{% trans "MERGING" %}</span>
         {% endif %}
 
         {% blocktrans trimmed with version=other.version %}

--- a/tabbycat/results/templates/public_ballot_set.html
+++ b/tabbycat/results/templates/public_ballot_set.html
@@ -73,7 +73,7 @@
           {% endif %}
         </h4>
 
-        <div class="row pl-3 pt-3 p-0">
+        <div class="row ps-3 pt-3 p-0">
 
           {% for team in sheet.teams %}
             <div class="col-6 list-group mb-3">
@@ -82,11 +82,11 @@
                 <li class="list-group-item">
                   <strong>{{ position.name }}</strong>
                   {% person_display_name position.speaker %}
-                  <span class="badge mr-2 badge-secondary float-right">
+                  <span class="badge me-2 text-bg-secondary float-end">
                     {{ position.score }}
                   </span>
                   {% if pref.speaker_ranks != 'none' %}
-                    <span class="badge mr-2 badge-secondary float-right">
+                    <span class="badge me-2 text-bg-secondary float-end">
                       {{ position.rank }}
                     </span>
                   {% endif %}
@@ -103,7 +103,7 @@
                       <em>Total for {{ name }} ({{ side }})</em>
                     {% endblocktrans %}
                   {% endif %}
-                  <span class="badge mr-2 badge-secondary float-right">
+                  <span class="badge me-2 text-bg-secondary float-end">
                     {{ team.total }}
                   </span>
                 {% else %}
@@ -116,7 +116,7 @@
                       <em>{{ name }} ({{ side }})</em>
                     {% endblocktrans %}
                   {% endif %}
-                  <span class="badge badge-secondary float-right">
+                  <span class="badge text-bg-secondary float-end">
                     {% if team.rank is not None %}
                       {{ team.rank|ordinal }}
                     {% else %}

--- a/tabbycat/speakershuffler/simulate_fairness.py
+++ b/tabbycat/speakershuffler/simulate_fairness.py
@@ -1,0 +1,223 @@
+"""Placement-weighted score fairness simulation.
+
+Standalone script (no Django). Verifies that placement-weighted coefficients
+(1st=1.1, 2nd=1.075, 3rd=1.05, 4th=1.0) are fair — speakers who place 4th
+in round 1 can still recover and reach the top.
+
+Usage:
+    python tabbycat/speakershuffler/simulate_fairness.py
+"""
+
+import random
+from collections import defaultdict
+
+# ── Parameters ──────────────────────────────────────────────────────────────
+NUM_SPEAKERS = 32
+NUM_TEAMS = 16
+SPEAKERS_PER_TEAM = 2
+TEAMS_PER_ROOM = 4
+SPEAKERS_PER_ROOM = TEAMS_PER_ROOM * SPEAKERS_PER_TEAM  # 8
+NUM_ROOMS = NUM_TEAMS // TEAMS_PER_ROOM  # 4
+NUM_ROUNDS = 5
+ITERATIONS = 10_000
+BREAK_SIZE = 16
+
+SCORE_MIN = 59
+SCORE_MAX = 78
+TEAM_TOTAL_MIN = SCORE_MIN * SPEAKERS_PER_TEAM  # 118
+TEAM_TOTAL_MAX = SCORE_MAX * SPEAKERS_PER_TEAM  # 156
+
+# Placement coefficients: 1st place → 1.1, 2nd → 1.075, 3rd → 1.05, 4th → 1.0
+# In the codebase these are keyed by team points (3=1st, 2=2nd, 1=3rd, 0=4th)
+COEFFICIENTS = {1: 1.06, 2: 1.04, 3: 1.02, 4: 1.0}
+
+
+def generate_room_scores():
+    """Generate scores for one room (4 teams of 2 speakers).
+
+    Returns list of 4 tuples: (placement, score1, score2)
+    where placement is 1..4 (1=first, 4=last).
+    """
+    # Pick 4 distinct team totals in [118, 156], sort descending
+    totals = sorted(random.sample(range(TEAM_TOTAL_MIN, TEAM_TOTAL_MAX + 1), 4),
+                    reverse=True)
+
+    results = []
+    for placement, total in enumerate(totals, start=1):
+        # Split total into 2 individual scores in [59, 78] with |s1-s2| ≤ 5
+        # s1 bounds: [59, 78], s2=T-s1 in [59, 78], |2*s1-T| ≤ 5
+        lo = max(SCORE_MIN, total - SCORE_MAX, -(-((total - 5)) // 2))
+        hi = min(SCORE_MAX, total - SCORE_MIN, (total + 5) // 2)
+        s1 = random.randint(lo, hi)
+        s2 = total - s1
+        assert SCORE_MIN <= s1 <= SCORE_MAX and SCORE_MIN <= s2 <= SCORE_MAX, \
+            f"Bad split: {s1}, {s2} from total {total}"
+        results.append((placement, s1, s2))
+
+    return results
+
+
+def simulate_once():
+    """Run one full 5-round simulation. Returns per-speaker stats."""
+
+    # Track cumulative scores and R1 placement per speaker
+    raw_totals = [0.0] * NUM_SPEAKERS
+    weighted_totals = [0.0] * NUM_SPEAKERS
+    r1_placement = [0] * NUM_SPEAKERS  # 1..4
+
+    for rnd in range(NUM_ROUNDS):
+        if rnd == 0:
+            # Round 1: random assignment
+            order = list(range(NUM_SPEAKERS))
+            random.shuffle(order)
+        else:
+            # Rounds 2–5: rank by cumulative weighted score, chunk into rooms
+            order = sorted(range(NUM_SPEAKERS),
+                           key=lambda s: weighted_totals[s], reverse=True)
+
+        # Process each room
+        for room_idx in range(NUM_ROOMS):
+            room_speakers = order[room_idx * SPEAKERS_PER_ROOM:
+                                  (room_idx + 1) * SPEAKERS_PER_ROOM]
+
+            # Random pairing within the room
+            random.shuffle(room_speakers)
+            teams = []
+            for i in range(0, SPEAKERS_PER_ROOM, SPEAKERS_PER_TEAM):
+                teams.append(room_speakers[i:i + SPEAKERS_PER_TEAM])
+
+            # Generate scores for this room
+            room_scores = generate_room_scores()
+
+            # Randomly assign placements to teams
+            placements = list(range(TEAMS_PER_ROOM))
+            random.shuffle(placements)
+
+            for team_idx, team in enumerate(teams):
+                placement, s1, s2 = room_scores[placements[team_idx]]
+                coeff = COEFFICIENTS[placement]
+
+                for speaker, score in zip(team, [s1, s2]):
+                    raw_totals[speaker] += score
+                    weighted_totals[speaker] += score * coeff
+
+                    if rnd == 0:
+                        r1_placement[speaker] = placement
+
+    return raw_totals, weighted_totals, r1_placement
+
+
+def rank_speakers(totals):
+    """Return 1-based ranks (1=best). Ties broken arbitrarily."""
+    indexed = sorted(enumerate(totals), key=lambda x: x[1], reverse=True)
+    ranks = [0] * len(totals)
+    for rank, (idx, _) in enumerate(indexed, start=1):
+        ranks[idx] = rank
+    return ranks
+
+
+def spearman_correlation(xs, ys):
+    """Spearman rank correlation between two lists of ranks."""
+    n = len(xs)
+    d_sq = sum((x - y) ** 2 for x, y in zip(xs, ys))
+    return 1.0 - (6.0 * d_sq) / (n * (n * n - 1))
+
+
+def main():
+    # Accumulators per R1 placement (1..4)
+    raw_rank_sums = defaultdict(float)
+    weighted_rank_sums = defaultdict(float)
+    raw_break_counts = defaultdict(int)
+    weighted_break_counts = defaultdict(int)
+    placement_counts = defaultdict(int)
+    best_raw_rank = defaultdict(lambda: NUM_SPEAKERS + 1)
+    worst_raw_rank = defaultdict(lambda: 0)
+    best_weighted_rank = defaultdict(lambda: NUM_SPEAKERS + 1)
+    worst_weighted_rank = defaultdict(lambda: 0)
+
+    # For Spearman correlation
+    all_raw_ranks = []
+    all_weighted_ranks = []
+
+    for _ in range(ITERATIONS):
+        raw_totals, weighted_totals, r1_placement = simulate_once()
+        raw_ranks = rank_speakers(raw_totals)
+        weighted_ranks = rank_speakers(weighted_totals)
+
+        all_raw_ranks.append(raw_ranks[:])
+        all_weighted_ranks.append(weighted_ranks[:])
+
+        for speaker in range(NUM_SPEAKERS):
+            p = r1_placement[speaker]
+            placement_counts[p] += 1
+
+            rr = raw_ranks[speaker]
+            wr = weighted_ranks[speaker]
+
+            raw_rank_sums[p] += rr
+            weighted_rank_sums[p] += wr
+
+            if rr <= BREAK_SIZE:
+                raw_break_counts[p] += 1
+            if wr <= BREAK_SIZE:
+                weighted_break_counts[p] += 1
+
+            best_raw_rank[p] = min(best_raw_rank[p], rr)
+            worst_raw_rank[p] = max(worst_raw_rank[p], rr)
+            best_weighted_rank[p] = min(best_weighted_rank[p], wr)
+            worst_weighted_rank[p] = max(worst_weighted_rank[p], wr)
+
+    # Spearman correlation between raw and weighted rankings
+    correlations = []
+    for raw_r, weighted_r in zip(all_raw_ranks, all_weighted_ranks):
+        corr = spearman_correlation(raw_r, weighted_r)
+        correlations.append(corr)
+    avg_spearman = sum(correlations) / len(correlations)
+
+    # ── Print results ───────────────────────────────────────────────────────
+    print(f"Simulation: {ITERATIONS:,} iterations, {NUM_SPEAKERS} speakers, "
+          f"{NUM_ROUNDS} rounds, break = top {BREAK_SIZE}")
+    print(f"Coefficients: {COEFFICIENTS}")
+    print()
+
+    header = (f"{'R1 Place':>10} │ {'Count':>8} │ "
+              f"{'Avg Rank (raw)':>15} │ {'Avg Rank (wtd)':>15} │ "
+              f"{'Break % (raw)':>14} │ {'Break % (wtd)':>14} │ "
+              f"{'Best/Worst (raw)':>17} │ {'Best/Worst (wtd)':>17}")
+    print(header)
+    print("─" * len(header))
+
+    for p in sorted(COEFFICIENTS.keys()):
+        n = placement_counts[p]
+        avg_rr = raw_rank_sums[p] / n
+        avg_wr = weighted_rank_sums[p] / n
+        brk_rr = 100.0 * raw_break_counts[p] / n
+        brk_wr = 100.0 * weighted_break_counts[p] / n
+        bw_rr = f"{best_raw_rank[p]}–{worst_raw_rank[p]}"
+        bw_wr = f"{best_weighted_rank[p]}–{worst_weighted_rank[p]}"
+
+        label = {1: "1st", 2: "2nd", 3: "3rd", 4: "4th"}[p]
+        print(f"{label:>10} │ {n:>8,} │ {avg_rr:>15.2f} │ {avg_wr:>15.2f} │ "
+              f"{brk_rr:>13.1f}% │ {brk_wr:>13.1f}% │ "
+              f"{bw_rr:>17} │ {bw_wr:>17}")
+
+    print()
+    print(f"Avg Spearman correlation (raw vs weighted rankings): {avg_spearman:.4f}")
+
+    # Fairness check
+    r4_break_pct = 100.0 * weighted_break_counts[4] / placement_counts[4]
+    r1_avg = weighted_rank_sums[1] / placement_counts[1]
+    r4_avg = weighted_rank_sums[4] / placement_counts[4]
+    gap = r4_avg - r1_avg
+
+    print()
+    if r4_break_pct > 20.0:
+        print(f"✓ R1-4th break rate ({r4_break_pct:.1f}%) exceeds 20% threshold")
+    else:
+        print(f"✗ R1-4th break rate ({r4_break_pct:.1f}%) below 20% threshold")
+
+    print(f"  R1-1st vs R1-4th avg weighted rank gap: {gap:.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tabbycat/standings/templates/standings_index.html
+++ b/tabbycat/standings/templates/standings_index.html
@@ -22,7 +22,7 @@
           {% blocktrans trimmed with speaker=top_speak.speaker round=top_speak.debate_team.debate.round.abbreviation %}
           {{ speaker }} in {{ round }}
           {% endblocktrans %}
-          <span class="badge badge-secondary float-right">{{ top_speak.score|floatformat }}</span>
+          <span class="badge text-bg-secondary float-end">{{ top_speak.score|floatformat }}</span>
         </li>
       {% empty %}
         <li class="list-group-item">{% trans "No data yet" %}</li>
@@ -41,7 +41,7 @@
           {% blocktrans trimmed with speaker=bottom_speak.speaker round=bottom_speak.debate_team.debate.round.abbreviation %}
           {{ speaker }} in {{ round }}
           {% endblocktrans %}
-          <span class="badge badge-secondary float-right">{{ bottom_speak.score|floatformat }}</span>
+          <span class="badge text-bg-secondary float-end">{{ bottom_speak.score|floatformat }}</span>
         </li>
       {% empty %}
       <li class="list-group-item">{% trans "No data yet" %}</li>{% endfor %}
@@ -60,7 +60,7 @@
             {% blocktrans trimmed with team=top_margin.debate_team.team.short_name opp=top_margin.debate_team.opponent.team.short_name round=top_margin.debate_team.debate.round.abbreviation %}
             {{ team }} vs {{ opp }} in {{ round }}
             {% endblocktrans %}
-            <span class="badge badge-secondary float-right">{{ top_margin.margin|floatformat }}</span>
+            <span class="badge text-bg-secondary float-end">{{ top_margin.margin|floatformat }}</span>
           </li>
         {% empty %}
           <li class="list-group-item">{% trans "No data yet" %}</li>
@@ -81,7 +81,7 @@
             {% blocktrans trimmed with team=bottom_margin.debate_team.team.short_name opp=bottom_margin.debate_team.opponent.team.short_name round=bottom_margin.debate_team.debate.round.abbreviation %}
             {{ team }} vs {{ opp }} in {{ round }}
             {% endblocktrans %}
-            <span class="badge badge-secondary float-right">{{ bottom_margin.margin|floatformat }}</span>
+            <span class="badge text-bg-secondary float-end">{{ bottom_margin.margin|floatformat }}</span>
           </li>
         {% empty %}
           <li class="list-group-item">{% trans "No data yet" %}</li>
@@ -102,7 +102,7 @@
             {% blocktrans trimmed with team=top_score.debate_team.team.short_name round=top_score.debate_team.debate.round.abbreviation %}
             {{ team }} in {{ round }}
             {% endblocktrans %}
-            <span class="badge badge-secondary float-right">{{ top_score.score }}</span>
+            <span class="badge text-bg-secondary float-end">{{ top_score.score }}</span>
           </li>
         {% empty %}
           <li class="list-group-item">{% trans "No data yet" %}</li>
@@ -123,7 +123,7 @@
             {% blocktrans trimmed with team=bottom_score.debate_team.team.short_name round=bottom_score.debate_team.debate.round.abbreviation %}
             {{ team }} in {{ round }}
             {% endblocktrans %}
-            <span class="badge badge-secondary float-right">{{ bottom_score.score }}</span>
+            <span class="badge text-bg-secondary float-end">{{ bottom_score.score }}</span>
           </li>
         {% empty %}
           <li class="list-group-item">{% trans "No data yet" %}</li>
@@ -146,7 +146,7 @@
               {{ round.abbreviation }}
               {% if not forloop.last %}, {% endif %}
             {% endfor %}
-            <span class="badge badge-secondary float-right">{{ top_motion.ballotsubmission__count }}</span>
+            <span class="badge text-bg-secondary float-end">{{ top_motion.ballotsubmission__count }}</span>
           </li>
         {% empty %}
           <li class="list-group-item">{% trans "No data yet" %}</li>
@@ -161,7 +161,7 @@
               {{ round.abbreviation }}
               {% if not forloop.last %}, {% endif %}
             {% endfor %}
-            <span class="badge badge-secondary float-right">{{ bottom_motion.ballotsubmission__count }}</span>
+            <span class="badge text-bg-secondary float-end">{{ bottom_motion.ballotsubmission__count }}</span>
           </li>
         {% empty %}
           <li class="list-group-item">{% trans "No data yet" %}</li>
@@ -180,7 +180,7 @@
         {% for round_speak in round_speaks %}
           <li class="list-group-item">
             {{ round_speak.round }}
-            <span class="badge badge-secondary float-right">{{ round_speak.score|floatformat }}</span>
+            <span class="badge text-bg-secondary float-end">{{ round_speak.score|floatformat }}</span>
           </li>
         {% empty %}
           <li class="list-group-item">{% trans "No data yet" %}</li>

--- a/tabbycat/templates/allocations/AutoSaveCounter.vue
+++ b/tabbycat/templates/allocations/AutoSaveCounter.vue
@@ -61,7 +61,7 @@ watch(() => props.lastSaved, () => {
 <template>
   <button
     :class="['btn px-0 border-primary text-primary d-xl-inline vc-auto-save', animationClass]"
-    data-toggle="tooltip"
+    data-bs-toggle="tooltip"
     data-placement="bottom"
     :title="gettext('The time of the last saved change (changes are automatically saved)')"
   >

--- a/tabbycat/templates/allocations/DragAndDropActions.vue
+++ b/tabbycat/templates/allocations/DragAndDropActions.vue
@@ -39,7 +39,7 @@ const shardingEnabled = computed(() => sharding.value.index !== null)
         <a
           :href="extra.backUrl"
           class="btn btn-outline-primary"
-          data-toggle="tooltip"
+          data-bs-toggle="tooltip"
           data-placement="bottom"
           :title="extra.backLabel"
         >
@@ -73,8 +73,8 @@ const shardingEnabled = computed(() => sharding.value.index !== null)
       <div class="dropdown">
         <button
           id="dropdownMenuOffset"
-          class="btn btn-sm ml-2 btn-outline-primary dropdown-toggle"
-          data-toggle="dropdown"
+          class="btn btn-sm ms-2 btn-outline-primary dropdown-toggle"
+          data-bs-toggle="dropdown"
           title="Sort the draw"
         >
           <i data-feather="list" />
@@ -121,7 +121,7 @@ const shardingEnabled = computed(() => sharding.value.index !== null)
     <div class="btn-group btn-group-sm">
       <button
         class="btn btn-outline-secondary disabled d-xl-inline d-none"
-        data-toggle="tooltip"
+        data-bs-toggle="tooltip"
         :title="('Key for the color highlights.')"
       >
         <i data-feather="help-circle" />
@@ -130,7 +130,7 @@ const shardingEnabled = computed(() => sharding.value.index !== null)
         <slot name="default-highlights" />
         <button
           class="btn btn-dark"
-          data-toggle="tooltip"
+          data-bs-toggle="tooltip"
           :title="('Has not been marked as available for this round or has been allocated twice.')"
         >
           {{ gettext('Unavailable') }}
@@ -153,7 +153,7 @@ const shardingEnabled = computed(() => sharding.value.index !== null)
         @click="store.toggleHighlight(highlightKey)"
       >
         <span><i :data-feather="highlight.active ? 'eye-off' : 'eye'" /></span>
-        <span class="pl-1">{{ gettext(titleCase(highlightKey)) }}</span>
+        <span class="ps-1">{{ gettext(titleCase(highlightKey)) }}</span>
       </button>
     </div>
   </nav>

--- a/tabbycat/templates/allocations/DragAndDropDebate.vue
+++ b/tabbycat/templates/allocations/DragAndDropDebate.vue
@@ -48,7 +48,7 @@ const liveness = computed(() => {
 </script>
 
 <template>
-  <div class="d-flex border-bottom bg-white">
+  <div class="d-flex border-bottom bg-body">
     <slot
       v-if="!isElimination"
       name="bracket"

--- a/tabbycat/templates/allocations/DragAndDropDebate.vue
+++ b/tabbycat/templates/allocations/DragAndDropDebate.vue
@@ -56,7 +56,7 @@ const liveness = computed(() => {
       <div
         v-if="debateOrPanel.bracket >= 0"
         class="flex-1-25 flex-truncate d-flex border-right"
-        data-toggle="tooltip"
+        data-bs-toggle="tooltip"
         :title="gettext(`The debate's bracket`)"
       >
         <div class="align-self-center flex-fill text-center">
@@ -66,7 +66,7 @@ const liveness = computed(() => {
       <div
         v-else
         class="flex-2 flex-truncate d-flex border-right"
-        data-toggle="tooltip"
+        data-bs-toggle="tooltip"
         :title="gettext(`The bracket range of the hypothetical debate`)"
       >
         <div class="align-self-center flex-fill text-center">
@@ -84,7 +84,7 @@ const liveness = computed(() => {
       <div
         v-if="debateOrPanel.bracket >= 0"
         class="flex-1-25 flex-truncate d-flex border-right"
-        data-toggle="tooltip"
+        data-bs-toggle="tooltip"
         :title="gettext(`The debate's room rank (break rank of highest-ranked team)`)"
       >
         <div class="align-self-center flex-fill text-center">
@@ -99,7 +99,7 @@ const liveness = computed(() => {
       <div
         v-if="debateOrPanel.bracket >= 0"
         class="flex-1-25 flex-truncate border-right d-flex"
-        data-toggle="tooltip"
+        data-bs-toggle="tooltip"
         :title="gettext(`The total number of live break categories across
               all teams`)"
       >
@@ -110,7 +110,7 @@ const liveness = computed(() => {
       <div
         v-else
         class="flex-1-25 flex-truncate border-right d-flex"
-        data-toggle="tooltip"
+        data-bs-toggle="tooltip"
         :title="gettext(`The maximum possible number of live teams in
               the hypothetical debate for the open category`)"
       >
@@ -122,7 +122,7 @@ const liveness = computed(() => {
     <slot name="importance">
       <div
         class="flex-1-25 flex-truncate border-right d-flex"
-        data-toggle="tooltip"
+        data-bs-toggle="tooltip"
         :title="gettext(`This debate's priority`)"
       >
         <div class="align-self-center flex-fill text-center">

--- a/tabbycat/templates/allocations/DragAndDropUnallocatedItems.vue
+++ b/tabbycat/templates/allocations/DragAndDropUnallocatedItems.vue
@@ -166,10 +166,10 @@ onBeforeUnmount(() => {
       :drop-context="{ 'assignment': null, 'position': null }"
     >
       <section class="mb-1 d-flex">
-        <div class="small mt-2 pl-1 text-muted text-unselectable">
+        <div class="small mt-2 ps-1 text-muted text-unselectable">
           <span
             v-for="(value, key) in sorts"
-            :class="['pr-2', value.active ? 'font-weight-bold' : 'hoverable']"
+            :class="['pr-2', value.active ? 'fw-bold' : 'hoverable']"
             @click="setSort(key)"
           >{{ gettext(value.label) }}</span>
         </div>
@@ -185,13 +185,13 @@ onBeforeUnmount(() => {
         </div>
         <div class="small text-muted mt-2 mx-1 text-unselectable">
           <span
-            :class="['', !showUnavailable ? 'font-weight-bold' : 'hoverable']"
+            :class="['', !showUnavailable ? 'fw-bold' : 'hoverable']"
             @click="showUnavailable = false"
           >
             Show Available ({{ filteredAvailable.length }})
           </span>
           <span
-            :class="['pl-2', showUnavailable ? 'font-weight-bold' : 'hoverable']"
+            :class="['pl-2', showUnavailable ? 'fw-bold' : 'hoverable']"
             @click="showUnavailable = true"
           >
             Show All ({{ filteredAll.length }})

--- a/tabbycat/templates/allocations/DragAndDropUnallocatedItems.vue
+++ b/tabbycat/templates/allocations/DragAndDropUnallocatedItems.vue
@@ -169,7 +169,7 @@ onBeforeUnmount(() => {
         <div class="small mt-2 ps-1 text-muted text-unselectable">
           <span
             v-for="(value, key) in sorts"
-            :class="['pr-2', value.active ? 'fw-bold' : 'hoverable']"
+            :class="['pe-2', value.active ? 'fw-bold' : 'hoverable']"
             @click="setSort(key)"
           >{{ gettext(value.label) }}</span>
         </div>
@@ -191,7 +191,7 @@ onBeforeUnmount(() => {
             Show Available ({{ filteredAvailable.length }})
           </span>
           <span
-            :class="['pl-2', showUnavailable ? 'fw-bold' : 'hoverable']"
+            :class="['ps-2', showUnavailable ? 'fw-bold' : 'hoverable']"
             @click="showUnavailable = true"
           >
             Show All ({{ filteredAll.length }})

--- a/tabbycat/templates/allocations/DraggableItem.vue
+++ b/tabbycat/templates/allocations/DraggableItem.vue
@@ -68,10 +68,10 @@ const hideHovers = () => {
     @mouseleave="hideHovers"
   >
     <slot>
-      <h4 class="mb-0 py-1 text-monospace vc-draggable-number vc-number">
+      <h4 class="mb-0 py-1 font-monospace vc-draggable-number vc-number">
         <slot name="number" />
       </h4>
-      <div class="py-1 pl-2 pr-2 d-flex flex-column flex-truncate">
+      <div class="py-1 ps-2 pe-2 d-flex flex-column flex-truncate">
         <h5 class="mb-0 vc-title text-truncate">
           <slot name="title" />
         </h5>

--- a/tabbycat/templates/allocations/HoverPanel.vue
+++ b/tabbycat/templates/allocations/HoverPanel.vue
@@ -266,7 +266,7 @@ const panelRows = computed(() => [topRow.value, bottomRow.value])
         <div
           v-for="(row, idx) in panelRows"
           :key="idx"
-          class="list-group-item flex-horizontal pl-2 flex-justify"
+          class="list-group-item flex-horizontal ps-2 flex-justify"
         >
           <div class="flex-align-start">
             <hover-panel-group :groups="row['left']" />

--- a/tabbycat/templates/allocations/HoverPanelGroup.vue
+++ b/tabbycat/templates/allocations/HoverPanelGroup.vue
@@ -7,7 +7,7 @@ defineProps({ groups: Array })
     <template v-if="groups !== null && groups.length > 0">
       <div
         v-for="group in groups"
-        class="btn-group btn-group-sm mr-2"
+        class="btn-group btn-group-sm me-2"
       >
         <button
           v-for="item in group"

--- a/tabbycat/templates/base.html
+++ b/tabbycat/templates/base.html
@@ -1,8 +1,15 @@
 {% load static statici18n i18n debate_tags %}<!DOCTYPE html>
 {% get_current_language as LANGUAGE_CODE %}
-<html lang="{{ LANGUAGE_CODE }}">
+<html lang="{{ LANGUAGE_CODE }}" data-bs-theme="light">
 <head>
 
+  <script>
+    (function() {
+      var mode = localStorage.getItem('tabbycat-theme') || 'auto';
+      var dark = mode === 'dark' || (mode === 'auto' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+      document.documentElement.setAttribute('data-bs-theme', dark ? 'dark' : 'light');
+    })();
+  </script>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
@@ -221,6 +228,56 @@
     {% endif %}
 
   {% endblock js %}
+
+  <script>
+    (function() {
+      var toggle = document.getElementById('theme-toggle');
+      if (!toggle) return;
+
+      // Cycle: light → dark → auto (system)
+      var modes = ['light', 'dark', 'auto'];
+
+      function resolveTheme(mode) {
+        if (mode === 'auto') {
+          return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        }
+        return mode;
+      }
+
+      function getMode() {
+        return localStorage.getItem('tabbycat-theme') || 'auto';
+      }
+
+      function updateIcons(mode) {
+        var resolved = resolveTheme(mode);
+        var lightIcon = toggle.querySelector('.theme-icon-light');
+        var darkIcon = toggle.querySelector('.theme-icon-dark');
+        var autoIcon = toggle.querySelector('.theme-icon-auto');
+        if (lightIcon) lightIcon.style.display = mode === 'light' ? '' : 'none';
+        if (darkIcon) darkIcon.style.display = mode === 'dark' ? '' : 'none';
+        if (autoIcon) autoIcon.style.display = mode === 'auto' ? '' : 'none';
+      }
+
+      function applyMode(mode) {
+        document.documentElement.setAttribute('data-bs-theme', resolveTheme(mode));
+        updateIcons(mode);
+      }
+
+      applyMode(getMode());
+
+      toggle.addEventListener('click', function() {
+        var current = getMode();
+        var next = modes[(modes.indexOf(current) + 1) % modes.length];
+        localStorage.setItem('tabbycat-theme', next);
+        applyMode(next);
+      });
+
+      // React to OS theme changes when in auto mode
+      window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function() {
+        if (getMode() === 'auto') applyMode('auto');
+      });
+    })();
+  </script>
 
 </body>
 </html>

--- a/tabbycat/templates/base.html
+++ b/tabbycat/templates/base.html
@@ -77,17 +77,17 @@
     {% if user_role == "admin" %}
       <!-- Fake full height for menu -->
       <div class="row">
-        <div class="col-md-2 col-1 float-left pl-0 pr-lg-3 pr-md-3 pr-0 d-none d-sm-block width fake-sidebar">
+        <div class="col-md-2 col-1 float-start ps-0 pe-lg-3 pe-md-3 pe-0 d-none d-sm-block width fake-sidebar">
           <div class="list-group-item"></div>
         </div>
       </div>
 
       <!-- Insert a second level column structure for a side nav -->
       <div class="row">
-        <div class="admin-sidebar col-md-2 col-1 float-left pl-0 pr-md-3 pr-0 collapse width show">
+        <div class="admin-sidebar col-md-2 col-1 float-start ps-0 pe-md-3 pe-0 collapse width show">
           {% block sidebar %}{% include "nav/admin_nav.html" %}{% endblock %}
         </div>
-        <main class="col-md-10 col-11 float-left pl-md-0 pl-3 main">
+        <main class="col-md-10 col-11 float-start ps-md-0 ps-3 main">
     {% endif %}
 
     {% block header %}

--- a/tabbycat/templates/base.html
+++ b/tabbycat/templates/base.html
@@ -234,13 +234,11 @@
       var toggle = document.getElementById('theme-toggle');
       if (!toggle) return;
 
-      // Cycle: light → dark → auto (system)
       var modes = ['light', 'dark', 'auto'];
 
       function resolveTheme(mode) {
-        if (mode === 'auto') {
+        if (mode === 'auto')
           return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-        }
         return mode;
       }
 
@@ -249,13 +247,13 @@
       }
 
       function updateIcons(mode) {
-        var resolved = resolveTheme(mode);
-        var lightIcon = toggle.querySelector('.theme-icon-light');
-        var darkIcon = toggle.querySelector('.theme-icon-dark');
-        var autoIcon = toggle.querySelector('.theme-icon-auto');
-        if (lightIcon) lightIcon.style.display = mode === 'light' ? '' : 'none';
-        if (darkIcon) darkIcon.style.display = mode === 'dark' ? '' : 'none';
-        if (autoIcon) autoIcon.style.display = mode === 'auto' ? '' : 'none';
+        var scope = toggle.parentElement || document;
+        var light = scope.querySelector('.theme-icon-light');
+        var dark = scope.querySelector('.theme-icon-dark');
+        var auto = scope.querySelector('.theme-icon-auto');
+        if (light) light.style.display = mode === 'light' ? '' : 'none';
+        if (dark) dark.style.display = mode === 'dark' ? '' : 'none';
+        if (auto) auto.style.display = mode === 'auto' ? '' : 'none';
       }
 
       function applyMode(mode) {
@@ -265,14 +263,14 @@
 
       applyMode(getMode());
 
-      toggle.addEventListener('click', function() {
+      toggle.addEventListener('click', function(e) {
+        e.preventDefault();
         var current = getMode();
         var next = modes[(modes.indexOf(current) + 1) % modes.length];
         localStorage.setItem('tabbycat-theme', next);
         applyMode(next);
       });
 
-      // React to OS theme changes when in auto mode
       window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function() {
         if (getMode() === 'auto') applyMode('auto');
       });

--- a/tabbycat/templates/base.html
+++ b/tabbycat/templates/base.html
@@ -38,7 +38,7 @@
   {% endblock %}
 
 
-  <link rel="preload" href="{% static 'fonts/Inter-Regular.woff2' %}" as="font" type="font/woff2">
+  <link rel="preload" href="{% static 'fonts/Inter-Regular.woff2' %}" as="font" type="font/woff2" crossorigin>
   <link rel="icon" type="image/png" href="{% static 'logo-32x32.png' %}" sizes="32x32" />
   <link rel="icon" type="image/png" href="{% static 'logo-16x16.png' %}" sizes="16x16" />
   <link rel="mask-icon" href="{% static 'safari-tab.svg' %}" color="rgb(102, 61, 160)">
@@ -47,7 +47,7 @@
   {% block extra-head %}{% endblock %}
 
   {% if not hmr %}
-  <link href="{% static 'vue/js/app.js' %}" rel=preload as=script>
+  <link rel="modulepreload" href="{% static 'vue/js/app.js' %}">
   {% endif %}
 
   {% if not debug %}<!-- Analytics -->

--- a/tabbycat/templates/components/alert.html
+++ b/tabbycat/templates/components/alert.html
@@ -2,11 +2,11 @@
 
   <div class="row align-items-center">
 
-    <div class="col-auto pr-1">
+    <div class="col-auto pe-1">
       <i data-feather="{{ icon|default:'bell' }}"></i>
     </div>
 
-    <div class="col pl-0 pr-0">
+    <div class="col ps-0 pe-0">
       {{ message|safe }}
       {% if extra %}
         <div class="mt-3">{{ extra|safe }}</div>

--- a/tabbycat/templates/components/form-field.html
+++ b/tabbycat/templates/components/form-field.html
@@ -1,6 +1,6 @@
 {% load add_field_css %}
 
-<div class="form-group {% if hide_label %}pt-2{% endif %}
+<div class="mb-3 {% if hide_label %}pt-2{% endif %}
             {% if double %}col-lg-6{% endif %}
             {% if triple %}col-lg-4{% endif %}
             {% if quadruple %}col-lg-3{% endif %}">
@@ -11,7 +11,11 @@
     </label>
   {% endif %}
 
-  {% if field|is_choice_widget %}
+  {% if field|is_checkbox %}
+    <div class="form-check form-switch">
+      {{ field|addcss:"form-check-input" }}
+    </div>
+  {% elif field|is_choice_widget %}
     {{ field }}
   {% else %}
     {{ field|addcss:"form-control" }}

--- a/tabbycat/templates/components/form-title.html
+++ b/tabbycat/templates/components/form-title.html
@@ -7,7 +7,7 @@
       {{ title|safe }}
     </h4>
     {% if subtitle %}
-      <h4 class="text-secondary float-right"><small>{{ subtitle }}</small></h4>
+      <h4 class="text-secondary float-end"><small>{{ subtitle }}</small></h4>
     {% endif %}
   {% endif %}
 

--- a/tabbycat/templates/components/item-action.html
+++ b/tabbycat/templates/components/item-action.html
@@ -1,7 +1,7 @@
 {% if alone %}<div class="list-group">{% endif %}
 
   <a href="{{ url }}" {% if blank %}target="_blank"{% endif %} {% if id %}id="{{ id }}"{% endif %}
-   {% if data_toggle %}data-toggle="{{ data_toggle }}"{% endif %} {% if data_target %}data-target="{{ data_target }}"{% endif %}
+   {% if data_toggle %}data-bs-toggle="{{ data_toggle }}"{% endif %} {% if data_target %}data-bs-target="{{ data_target }}"{% endif %}
    class="{% if not child %}list-group-item {% endif %}list-group-item-action
    {% if to_complete %}
     bg-{% if type %}{{ type }}{% else %}primary{% endif %} text-white
@@ -11,7 +11,7 @@
 
     <div class="row align-items-center">
 
-      <div class="col-auto pr-1">
+      <div class="col-auto pe-1">
         {% if icon %}
           <i data-feather="{{ icon }}"></i>
         {% elif to_complete %}
@@ -23,7 +23,7 @@
         {% endif %}
       </div>
 
-      <div class="col pl-0 pr-0">
+      <div class="col ps-0 pe-0">
 
         {% if extra %}
           <h5>{{ text|safe }}</h5>
@@ -38,7 +38,7 @@
 
       </div>
 
-      <div class="col-auto pr-1">
+      <div class="col-auto pe-1">
         <i data-feather="chevron-right"></i>
       </div>
 

--- a/tabbycat/templates/components/item-alert.html
+++ b/tabbycat/templates/components/item-alert.html
@@ -2,11 +2,11 @@
 
   <div class="row align-items-center">
 
-    <div class="col-auto pr-1">
+    <div class="col-auto pe-1">
       <i data-feather="alert-circle"></i>
     </div>
 
-    <div class="col pl-0 pr-0">
+    <div class="col ps-0 pe-0">
 
       {{ text|safe }}
 

--- a/tabbycat/templates/components/item-info.html
+++ b/tabbycat/templates/components/item-info.html
@@ -4,7 +4,7 @@
 
   <div class="row align-items-center">
 
-    <div class="col-auto pr-1">
+    <div class="col-auto pe-1">
       {% if icon %}
         <i data-feather="{{ icon }}"></i>
       {% elif emoji %}
@@ -14,7 +14,7 @@
       {% endif %}
     </div>
 
-    <div class="col pl-0 pr-0">
+    <div class="col ps-0 pe-0">
 
       {% if extra %}
         <h5>{{ text|safe }}</h5>

--- a/tabbycat/templates/components/item-submit.html
+++ b/tabbycat/templates/components/item-submit.html
@@ -3,7 +3,7 @@
    {% if to_complete %}
     bg-{% if type %}{{ type }}{% else %}primary{% endif %} text-white
    {% else %}
-    bg-white text-{% if type %}{{ type }}{% else %}primary{% endif %}
+    bg-body text-{% if type %}{{ type }}{% else %}primary{% endif %}
    {% endif %}">
 
     <div class="row align-items-center">

--- a/tabbycat/templates/components/item-submit.html
+++ b/tabbycat/templates/components/item-submit.html
@@ -1,5 +1,5 @@
   <button type="submit"
-   class="item-submit {% if not child %}list-group-item {% endif %} list-group-item-action border-0 rounded-0 w-100 text-left m-0
+   class="item-submit {% if not child %}list-group-item {% endif %} list-group-item-action border-0 rounded-0 w-100 text-start m-0
    {% if to_complete %}
     bg-{% if type %}{{ type }}{% else %}primary{% endif %} text-white
    {% else %}
@@ -8,7 +8,7 @@
 
     <div class="row align-items-center">
 
-      <div class="col-auto pr-1">
+      <div class="col-auto pe-1">
         {% if icon %}
           <i data-feather="{{ icon }}"></i>
         {% elif to_complete %}
@@ -20,7 +20,7 @@
         {% endif %}
       </div>
 
-      <div class="col pl-0 pr-0">
+      <div class="col ps-0 pe-0">
 
         {% if extra %}
           <h5>{{ text|safe }}</h5>
@@ -35,7 +35,7 @@
 
       </div>
 
-      <div class="col-auto pr-1">
+      <div class="col-auto pe-1">
         <i data-feather="chevron-right"></i>
       </div>
 

--- a/tabbycat/templates/composables/useModalAction.js
+++ b/tabbycat/templates/composables/useModalAction.js
@@ -21,7 +21,8 @@ export function useModalAction ({ modalRef = null, contextOfAction = null } = {}
 
   const resetModal = () => {
     if (modal.value) {
-      window.$?.(modal.value).modal('hide')
+      const instance = window.bootstrap?.Modal.getInstance(modal.value)
+      instance?.hide()
     }
   }
 

--- a/tabbycat/templates/composables/useModalError.js
+++ b/tabbycat/templates/composables/useModalError.js
@@ -1,31 +1,34 @@
 export function useModalError () {
   const showErrorAlert = (message, error, title,
     classOverride = false, titleOverride = false, messageOverride = false) => {
-    const $ = window.$ || window.jQuery
-    if (!$) {
-      throw new Error('jQuery is required for showErrorAlert')
-    }
+    const modalEl = document.getElementById('modalAlert')
+    if (!modalEl) return
 
-    $('#modalAlert').modal()
+    const bs = window.bootstrap
+    bs.Modal.getOrCreateInstance(modalEl).show()
+
+    const header = modalEl.querySelector('.modal-header')
+    const body = modalEl.querySelector('.modal-body')
+
     if (title === null) {
-      $('#modalAlert').find('.modal-header').text('Save Failed')
+      header.textContent = 'Save Failed'
     } else if (titleOverride) {
-      $('#modalAlert').find('.modal-header').text(title)
+      header.textContent = title
     } else {
-      $('#modalAlert').find('.modal-header').text(`Save Failed due to ${title}`)
+      header.textContent = `Save Failed due to ${title}`
     }
     if (classOverride) {
-      $('#modalAlert').find('.modal-header').removeClass('text-danger')
-      $('#modalAlert').find('.modal-header').addClass(classOverride)
+      header.classList.remove('text-danger')
+      header.classList.add(classOverride)
     } else {
-      $('#modalAlert').find('.modal-header').addClass('text-danger')
+      header.classList.add('text-danger')
     }
     if (messageOverride) {
-      $('#modalAlert').find('.modal-body').text(message)
+      body.textContent = message
     } else {
-      $('#modalAlert').find('.modal-body').text(`Failed to save a change to ${message} because
+      body.textContent = `Failed to save a change to ${message} because
           ${error}. You should now refresh this page to ensure the data is up to date and then
-          retry the action. If the problem persists please get in touch with the developers.`)
+          retry the action. If the problem persists please get in touch with the developers.`
     }
   }
 

--- a/tabbycat/templates/footer.html
+++ b/tabbycat/templates/footer.html
@@ -60,12 +60,13 @@
       <div class="col mt-2">
         <ul class="nav justify-content-center">
           <li class="nav-item p-2">
-            <button class="btn btn-link nav-link p-0 d-inline-block" id="theme-toggle" type="button"
-                    aria-label="{% trans 'Toggle theme' %}" title="{% trans 'Toggle theme' %}">
-              <i data-feather="sun" class="theme-icon-light" style="display:none"></i>
-              <i data-feather="moon" class="theme-icon-dark" style="display:none"></i>
-              <i data-feather="monitor" class="theme-icon-auto" style="display:none"></i>
-            </button>
+            <i data-feather="sun" class="theme-icon-light" style="display:none"></i>
+            <i data-feather="moon" class="theme-icon-dark" style="display:none"></i>
+            <i data-feather="monitor" class="theme-icon-auto" style="display:none"></i>
+            <a class="nav-link p-0 d-inline-block" href="#" id="theme-toggle"
+               role="button" aria-label="{% trans 'Toggle theme' %}" title="{% trans 'Toggle theme' %}">
+              {% trans "Theme" %}
+            </a>
           </li>
           <li class="nav-item p-2">
             <i data-feather="globe"></i>

--- a/tabbycat/templates/footer.html
+++ b/tabbycat/templates/footer.html
@@ -61,7 +61,7 @@
         <ul class="nav justify-content-center">
           <li class="nav-item p-2">
             <i data-feather="globe"></i>
-            <a class="nav-link p-0 d-inline-block" href="#" data-toggle="modal" data-target="#setLanguageModal">
+            <a class="nav-link p-0 d-inline-block" href="#" data-bs-toggle="modal" data-bs-target="#setLanguageModal">
               {% trans "Language" as local_language_label %}
               Language {% if LANGUAGE_CODE != 'en' and local_language_label != "Language" %} / {{ local_language_label }}{% endif %}
             </a>
@@ -108,14 +108,13 @@
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title">{% trans "Change Language" %}</h5>
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-          <span aria-hidden="true">&times;</span>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
         </button>
       </div>
       <div class="modal-body">
         <form action="{% url 'set_language' %}" method="post">{% csrf_token %}
           <input name="next" type="hidden" value="{{ redirect_to }}">
-          <select name="language" class="custom-select">
+          <select name="language" class="form-select">
               {% get_available_languages as LANGUAGES %}
               {% get_language_info_list for LANGUAGES as languages %}
               {% for language in languages %}

--- a/tabbycat/templates/footer.html
+++ b/tabbycat/templates/footer.html
@@ -60,6 +60,14 @@
       <div class="col mt-2">
         <ul class="nav justify-content-center">
           <li class="nav-item p-2">
+            <button class="btn btn-link nav-link p-0 d-inline-block" id="theme-toggle" type="button"
+                    aria-label="{% trans 'Toggle theme' %}" title="{% trans 'Toggle theme' %}">
+              <i data-feather="sun" class="theme-icon-light" style="display:none"></i>
+              <i data-feather="moon" class="theme-icon-dark" style="display:none"></i>
+              <i data-feather="monitor" class="theme-icon-auto" style="display:none"></i>
+            </button>
+          </li>
+          <li class="nav-item p-2">
             <i data-feather="globe"></i>
             <a class="nav-link p-0 d-inline-block" href="#" data-bs-toggle="modal" data-bs-target="#setLanguageModal">
               {% trans "Language" as local_language_label %}

--- a/tabbycat/templates/graphs/UpdatesList.vue
+++ b/tabbycat/templates/graphs/UpdatesList.vue
@@ -8,19 +8,19 @@ defineProps({
   <li class="list-group-item text-info d-flex justify-content-between align-items-center">
     <div>
       <strong
-        class="pr-1"
+        class="pe-1"
         v-html="item.user"
       />
       <span
         v-if="item.agent == 'a'"
-        class="badge badge-light mr-1"
+        class="badge text-bg-light me-1"
       >API</span>
       <span
-        class="pr-1"
+        class="pe-1"
         v-html="item.type"
       />
       <em v-html="item.param" />
     </div>
-    <span class="badge badge-light">{{ item.timestamp }}</span>
+    <span class="badge text-bg-light">{{ item.timestamp }}</span>
   </li>
 </template>

--- a/tabbycat/templates/js-bundles/main.js
+++ b/tabbycat/templates/js-bundles/main.js
@@ -3,8 +3,9 @@ import { createApp, defineAsyncComponent } from 'vue'
 import { createPinia } from 'pinia'
 import * as Sentry from '@sentry/vue';
 import feather from 'feather-icons'
-import 'bootstrap' // Import bootstrap javascript plugins
+import * as bootstrap from 'bootstrap'
 const $ = window.jQuery
+window.bootstrap = bootstrap
 
 // Generic Templates
 import CheckboxTablesContainer from '../tables/CheckboxTablesContainer.vue'
@@ -49,13 +50,13 @@ $.fn.extend({
   showAlert: function (alerttype, message, timeout) {
     $('#messages-container').prepend(`
       <div id='alertdiv' class='alert alert-${alerttype} fade show'>
-        <button type='button' class='close' data-dismiss='alert' aria-label='Close'>
-        <span aria-hidden='true'>&times;</span></button>${message}
+        <button type='button' class='btn-close' data-bs-dismiss='alert' aria-label='Close'>
+        </button>${message}
       </div>`)
     if (timeout && timeout !== 0) {
-      // this will automatically close the alert and remove this if the users don't within in 5s
       setTimeout(() => {
-        $('#alertdiv').alert('close')
+        const alertEl = document.getElementById('alertdiv')
+        if (alertEl) bootstrap.Alert.getOrCreateInstance(alertEl).close()
       }, timeout)
     }
   },
@@ -94,8 +95,8 @@ function disabledTriggeredForm (triggeredForm) {
 
 $(document).ready(() => {
   // Enable hover tooltips for all elements
-  $('[data-toggle=tooltip]').tooltip({
-    html: true,
+  document.querySelectorAll('[data-bs-toggle=tooltip]').forEach(el => {
+    new bootstrap.Tooltip(el, { html: true })
   })
 
   // Feather shim for icons

--- a/tabbycat/templates/modals/ModalForAllocating.vue
+++ b/tabbycat/templates/modals/ModalForAllocating.vue
@@ -61,7 +61,7 @@ const id = 'confirmAllocateModal'
     <div class="modal-dialog modal-lg">
       <div class="modal-content">
         <div class="modal-body text-center p-4 bg-bg">
-          <p class="font-italic small">
+          <p class="fst-italic small">
             {{ introText }}
           </p>
 
@@ -86,7 +86,7 @@ const id = 'confirmAllocateModal'
                 >
                   {{ loading ? gettext('Loading...') : gettext('Smart Allocate') }}
                 </button>
-                <p class="font-italic small mt-1 mb-1">
+                <p class="fst-italic small mt-1 mb-1">
                   {{ gettext(`Allocates preformed panels to debates of similar priority level, while avoiding conflicts.`) }}
                 </p>
               </div>
@@ -98,7 +98,7 @@ const id = 'confirmAllocateModal'
                 >
                   {{ loading ? gettext('Loading...') : gettext('Direct Allocate') }}
                 </button>
-                <p class="font-italic small mt-1 mb-1">
+                <p class="fst-italic small mt-1 mb-1">
                   {{ gettext(`Allocates panels in exact order going from top to bottom (ignoring debate priority and conflicts.)`) }}
                 </p>
               </div>
@@ -107,7 +107,7 @@ const id = 'confirmAllocateModal'
               v-if="!forPanels && !extra.hasPreformedPanels"
               class="list-group-item p-3"
             >
-              <p class="font-italic mb-0">
+              <p class="fst-italic mb-0">
                 {{ gettext(`No preformed panels exist for this round. You can create some by going to Setup, and then Preformed Panels.`) }}
               </p>
             </div>
@@ -138,7 +138,7 @@ const id = 'confirmAllocateModal'
                 The score required to be allocated as voting panellist ({{ settings.draw_rules__adj_min_voting_score }}) is
                 lower than the minimum  adjudicator score ({{ extra.adjMinScore }}).
               </div>
-              <div class="text-left py-3">
+              <div class="text-start py-3">
                 <div class="form-group row">
                   <div class="col-sm-3">
                     <input
@@ -222,7 +222,7 @@ const id = 'confirmAllocateModal'
               >
                 {{ loading ? gettext('Loading...') : gettext('Auto-Allocate Adjudicators') }}
               </button>
-              <p class="font-italic small">
+              <p class="fst-italic small">
                 {{ gettext(`The allocator creates stronger panels for debates that were given
                                   higher importances. If importances have not been set it will allocate
                                   stronger panels to debates in higher brackets.`) }}

--- a/tabbycat/templates/nav/admin_nav.html
+++ b/tabbycat/templates/nav/admin_nav.html
@@ -3,7 +3,7 @@
 <div class="list-group border-0 card text-center text-md-left" id="sidebar" data-children=".list-group-item">
 
   <div class="list-group-item d-inline-block main-menu-item">
-    <a href="#tlisth" data-toggle="collapse" data-parent="#sidebar" aria-expanded="false"
+    <a href="#tlisth" data-bs-toggle="collapse" data-bs-parent="#sidebar" aria-expanded="false"
        class="tournament-title d-flex justify-content-between align-items-center">
       <div class="mx-auto mx-md-0 text-center">
         {% blocktrans trimmed asvar logo_alt %}
@@ -15,7 +15,7 @@
           {% include "nav/logo.html" with width=18 height=18 alt=logo_alt %}
         {% endif %}
       </div>
-      <div class="mb-0 d-none d-md-inline h6 mr-auto pt-1 pl-2 pr-2">
+      <div class="mb-0 d-none d-md-inline h6 me-auto pt-1 ps-2 pe-2">
         {{ tournament }}
       </div>
       <div>
@@ -24,29 +24,29 @@
       </div>
     </a>
     <div class="collapse" id="tlisth">
-      <a href="/" class="list-group-item" data-parent="#titleh">
+      <a href="/" class="list-group-item" data-bs-parent="#titleh">
         <i data-feather="home"></i>{% trans "Site Home" %}
       </a>
-      <a href="{% url 'tournament-create' %}" class="list-group-item" data-parent="#titleh">
+      <a href="{% url 'tournament-create' %}" class="list-group-item" data-bs-parent="#titleh">
         <i data-feather="edit-2"></i>{% trans "New Tournament" %}
       </a>
-      <a href="{% url 'admin:index' %}" target="_blank" class="list-group-item" data-parent="#titleh">
+      <a href="{% url 'admin:index' %}" target="_blank" class="list-group-item" data-bs-parent="#titleh">
         <i data-feather="database"></i>{% trans "Edit Database" %}
       </a>
       {% for t in all_tournaments %}
-        <div class="list-group-item tournament-areas-title" data-parent="#titleh">
+        <div class="list-group-item tournament-areas-title" data-bs-parent="#titleh">
           {{ t }}
         </div>
         <a href="{% url 'tournament-admin-home' tournament_slug=t.slug %}"
-           class="list-group-item" data-parent="#titleh">
+           class="list-group-item" data-bs-parent="#titleh">
           <i data-feather="settings"></i>{% trans "Admin Area" %}
         </a>
         <a href="{% url 'tournament-assistant-home' tournament_slug=t.slug %}"
-           class="list-group-item" data-parent="#titleh">
+           class="list-group-item" data-bs-parent="#titleh">
           <i data-feather="pocket"></i>{% trans "Assistant Area" %}
         </a>
         <a href="{% url 'tournament-public-index' tournament_slug=t.slug %}"
-           class="list-group-item" data-parent="#titleh">
+           class="list-group-item" data-bs-parent="#titleh">
           <i data-feather="globe"></i>{% trans "Public Area" %}
         </a>
       {% endfor %}
@@ -54,7 +54,7 @@
   </div>
 
   <div class="list-group-item d-inline-block">
-    <a href="{% tournamenturl 'tournament-admin-home' %}" data-parent="#sidebar"
+    <a href="{% tournamenturl 'tournament-admin-home' %}" data-bs-parent="#sidebar"
        class="collapsed">
       <i data-feather="monitor"></i>
       <span class="d-none d-md-inline">{% trans "Overview" %}</span>
@@ -62,7 +62,7 @@
   </div>
 
   <div class="list-group-item d-inline-block">
-    <a href="#setuph" data-toggle="collapse" data-parent="#sidebar" aria-expanded="false">
+    <a href="#setuph" data-bs-toggle="collapse" data-bs-parent="#sidebar" aria-expanded="false">
        <i data-feather="briefcase"></i>
        <span class="d-none d-md-inline">{% trans "Setup" %}</span>
        <i data-feather="chevron-down" class="sidebar-expand d-none d-md-inline"></i>
@@ -70,34 +70,34 @@
     </a>
     <div class="collapse" id="setuph">
       <a href="{% tournamenturl 'options-tournament-index' %}"
-         class="list-group-item" data-parent="#setuph">
+         class="list-group-item" data-bs-parent="#setuph">
         <span class="circle-icon small-circle"></span><i data-feather="settings"></i>{% trans "Configuration" %}
       </a>
-      <a href="{% tournamenturl 'importer-simple-index' %}" class="list-group-item" data-parent="#setuph">
+      <a href="{% tournamenturl 'importer-simple-index' %}" class="list-group-item" data-bs-parent="#setuph">
         <span class="circle-icon small-circle"></span><i data-feather="download-cloud"></i>{% trans "Import Data" %}
       </a>
       <a href="{% tournamenturl 'participants-list' %}"
-         class="list-group-item" data-parent="#setuph">
+         class="list-group-item" data-bs-parent="#setuph">
         <span class="circle-icon small-circle"></span><i data-feather="book"></i>{% trans "Participants" %}
       </a>
       <a href="{% tournamenturl 'privateurls-list' %}"
-         class="list-group-item" data-parent="#setuph}">
+         class="list-group-item" data-bs-parent="#setuph}">
         <span class="circle-icon small-circle"></span><i data-feather="link"></i>{% trans "Private URLs" %}
       </a>
       <a href="{% tournamenturl 'tournament-set-schedule' %}"
-         class="list-group-item" data-parent="#setuph">
+         class="list-group-item" data-bs-parent="#setuph">
         <span class="circle-icon small-circle"></span><i data-feather="clock"></i>{% trans "Schedule" %}
       </a>
       <a href="{% tournamenturl 'notifications-status' %}"
-         class="list-group-item" data-parent="#setuph">
+         class="list-group-item" data-bs-parent="#setuph">
         <span class="circle-icon small-circle"></span><i data-feather="mail"></i>{% trans "Emails" %}
       </a>
       <a href="{% tournamenturl 'panel-adjudicators-index' %}"
-         class="list-group-item" data-parent="#setuph">
+         class="list-group-item" data-bs-parent="#setuph">
         <span class="circle-icon small-circle"></span><i data-feather="box"></i>{% trans "Preformed Panels" %}
       </a>
       <a href="{% tournamenturl 'exporter-xml-index' %}"
-          class="list-group-item" data-parent="#setuph">
+          class="list-group-item" data-bs-parent="#setuph">
         <span class="circle-icon small-circle"></span><i data-feather="archive"></i>{% trans "Export XML" %}
       </a>
     </div>
@@ -105,7 +105,7 @@
 
   {% if pref.draw_side_allocations == 'preallocated' %}
     <div class="list-group-item d-inline-block">
-      <a href="{% tournamenturl 'draw-side-allocations' %}" data-parent="#sidebar"
+      <a href="{% tournamenturl 'draw-side-allocations' %}" data-bs-parent="#sidebar"
         class="collapsed">
         <i data-feather="shuffle"></i>
         <span class="d-none d-md-inline">{% trans "Sides" %}</span>
@@ -114,7 +114,7 @@
   {% endif %}
 
   <div class="list-group-item d-inline-block">
-    <a href="#registrationh" data-toggle="collapse" data-parent="#sidebar" aria-expanded="false">
+    <a href="#registrationh" data-bs-toggle="collapse" data-bs-parent="#sidebar" aria-expanded="false">
        <i data-feather="pen-tool"></i>
        <span class="d-none d-md-inline">{% trans "Registration" %}</span>
        <i data-feather="chevron-down" class="sidebar-expand d-none d-md-inline"></i>
@@ -122,21 +122,21 @@
     </a>
     <div class="collapse" id="registrationh">
       <a href="{% tournamenturl 'reg-institution-list' %}"
-         class="list-group-item" data-parent="#registrationh">
+         class="list-group-item" data-bs-parent="#registrationh">
         <span class="circle-icon small-circle"></span><i data-feather="home"></i>{% trans "Institutions" %}
       </a>
-      <a href="{% tournamenturl 'reg-team-list' %}" class="list-group-item" data-parent="#registrationh">
+      <a href="{% tournamenturl 'reg-team-list' %}" class="list-group-item" data-bs-parent="#registrationh">
         <span class="circle-icon small-circle"></span><i data-feather="users"></i>{% trans "Teams" %}
       </a>
       <a href="{% tournamenturl 'reg-adjudicator-list' %}"
-         class="list-group-item" data-parent="#registrationh">
+         class="list-group-item" data-bs-parent="#registrationh">
         <span class="circle-icon small-circle"></span><i data-feather="columns"></i>{% trans "Adjudicators" %}
       </a>
     </div>
   </div>
 
   <div class="list-group-item d-inline-block">
-    <a href="#checkinh" data-toggle="collapse" data-parent="#sidebar" aria-expanded="false"
+    <a href="#checkinh" data-bs-toggle="collapse" data-bs-parent="#sidebar" aria-expanded="false"
        class="{% if checkins_nav %}active{% endif %}">
        <i data-feather="compass"></i>
        <span class="d-none d-md-inline">{% trans "Check-Ins" %}</span>
@@ -145,57 +145,57 @@
     </a>
     <div class="collapse {% if checkins_nav %}show{% endif %}" id="checkinh">
       <a href="{% tournamenturl 'admin-checkin-identifiers' %}"
-         class="list-group-item {% if checkins_ids %}active{% endif %}" data-parent="#checkinh">
+         class="list-group-item {% if checkins_ids %}active{% endif %}" data-bs-parent="#checkinh">
         <i data-feather="menu"></i>{% trans "Make Identifiers" %}
       </a>
       <a href="{% tournamenturl 'admin-checkin-prescan' %}"
-         class="list-group-item {% if checkins_scans %}active{% endif %}" data-parent="#checkinh">
+         class="list-group-item {% if checkins_scans %}active{% endif %}" data-bs-parent="#checkinh">
         <i data-feather="instagram"></i>{% trans "Scan Identifiers" %}
       </a>
       <a href="{% tournamenturl 'admin-people-statuses' %}"
-         class="list-group-item {% if checkins_people_statuses %}active{% endif %}" data-parent="#checkinh">
+         class="list-group-item {% if checkins_people_statuses %}active{% endif %}" data-bs-parent="#checkinh">
         <i data-feather="watch"></i>{% trans "People's Status" %}
       </a>
       <a href="{% tournamenturl 'admin-venues-statuses' %}"
-         class="list-group-item {% if checkins_venues_statuses %}active{% endif %}" data-parent="#checkinh">
+         class="list-group-item {% if checkins_venues_statuses %}active{% endif %}" data-bs-parent="#checkinh">
         <i data-feather="map"></i>{% trans "Rooms' Status" %}
       </a>
     </div>
   </div>
 
   <div class="list-group-item d-inline-block">
-    <a href="#feedh" data-toggle="collapse" data-parent="#sidebar" aria-expanded="false" class="collapsed">
+    <a href="#feedh" data-bs-toggle="collapse" data-bs-parent="#sidebar" aria-expanded="false" class="collapsed">
       <i data-feather="message-circle"></i>
       <span class="d-none d-md-inline">{% trans "Feedback" %}</span>
       <i data-feather="chevron-down" class="sidebar-expand d-none d-md-inline"></i>
       <i data-feather="chevron-up" class="sidebar-expand d-none d-md-inline"></i>
     </a>
     <div class="collapse" id="feedh">
-      <a class="list-group-item" href="{% tournamenturl 'adjfeedback-overview' %}" data-parent="#feedh">
+      <a class="list-group-item" href="{% tournamenturl 'adjfeedback-overview' %}" data-bs-parent="#feedh">
         <i data-feather="maximize"></i>{% trans "Overview" %}
       </a>
-        <a class="list-group-item" href="{% tournamenturl 'adjfeedback-view-latest' %}" data-parent="#feedh">
+        <a class="list-group-item" href="{% tournamenturl 'adjfeedback-view-latest' %}" data-bs-parent="#feedh">
         <i data-feather="clock"></i>{% trans "Latest" %}
       </a>
-      <a class="list-group-item" href="{% tournamenturl 'adjfeedback-view-important' %}" data-parent="#feedh">
+      <a class="list-group-item" href="{% tournamenturl 'adjfeedback-view-important' %}" data-bs-parent="#feedh">
         <i data-feather="star"></i>{% trans "Important" %}
       </a>
-      <a class="list-group-item" href="{% tournamenturl 'adjfeedback-view-comments' %}" data-parent="#feedh">
+      <a class="list-group-item" href="{% tournamenturl 'adjfeedback-view-comments' %}" data-bs-parent="#feedh">
         <i data-feather="message-square"></i>{% trans "Comments" %}
       </a>
-      <a class="list-group-item" href="{% tournamenturl 'adjfeedback-view-by-source' %}" data-parent="#feedh">
+      <a class="list-group-item" href="{% tournamenturl 'adjfeedback-view-by-source' %}" data-bs-parent="#feedh">
         <i data-feather="phone-outgoing"></i>{% trans "Find by Source" %}
       </a>
-      <a class="list-group-item" href="{% tournamenturl 'adjfeedback-view-by-target' %}" data-parent="#feedh">
+      <a class="list-group-item" href="{% tournamenturl 'adjfeedback-view-by-target' %}" data-bs-parent="#feedh">
         <i data-feather="phone-incoming"></i>{% trans "Find by Target" %}
       </a>
-      <a class="list-group-item" href="{% tournamenturl 'adjfeedback-progress' %}" data-parent="#feedh">
+      <a class="list-group-item" href="{% tournamenturl 'adjfeedback-progress' %}" data-bs-parent="#feedh">
         <i data-feather="x-circle"></i>{% trans "Unsubmitted" %}
       </a>
-      <a class="list-group-item" href="{% tournamenturl 'adjfeedback-edit-questions' %}" data-parent="#feedh">
+      <a class="list-group-item" href="{% tournamenturl 'adjfeedback-edit-questions' %}" data-bs-parent="#feedh">
         <i data-feather="paperclip"></i>{% trans "Feedback Questions" %}
       </a>
-      <a class="list-group-item" href="{% tournamenturl 'adjfeedback-add-index' %}" data-parent="#feedh">
+      <a class="list-group-item" href="{% tournamenturl 'adjfeedback-add-index' %}" data-bs-parent="#feedh">
         <i data-feather="plus-circle"></i>{% trans "Add Feedback" %}
       </a>
       <a class="list-group-item" href="{% tournamenturl 'adjfeedback-update-scores-bulk' %}">
@@ -205,8 +205,8 @@
   </div>
 
   <div class="list-group-item d-inline-block">
-    <a href="#standh" data-toggle="collapse" data-parent="#sidebar" aria-expanded="false"
-       data-parent="#sidebar" class="collapsed">
+    <a href="#standh" data-bs-toggle="collapse" data-bs-parent="#sidebar" aria-expanded="false"
+       data-bs-parent="#sidebar" class="collapsed">
       <i data-feather="bar-chart-2"></i>
       <span class="d-none d-md-inline">{% trans "Standings" %}</span>
       <i data-feather="chevron-down" class="sidebar-expand d-none d-md-inline"></i>
@@ -214,7 +214,7 @@
     </a>
     <div class="collapse" id="standh">
       <a href="{% roundurl 'standings-index' current_round %}"
-         class="list-group-item" data-parent="#setuph">
+         class="list-group-item" data-bs-parent="#setuph">
         <i data-feather="maximize"></i>{% trans "Overview" %}
       </a>
       <a class="list-group-item" href="{% roundurl 'standings-team' current_round %}">
@@ -265,7 +265,7 @@
       {% if r.stage == 'E' %}
 
         <div class="list-group-item d-inline-block">
-          <a href="#breakh" data-toggle="collapse" data-parent="#sidebar" aria-expanded="false"
+          <a href="#breakh" data-bs-toggle="collapse" data-bs-parent="#sidebar" aria-expanded="false"
              class="collapsed">
             <i data-feather="target"></i>
             <span class="d-none d-md-inline">{% trans "Breaks" %}</span>
@@ -300,7 +300,7 @@
   {% endfor %}
 
   <div class="list-group-item d-inline-block">
-    <form id="logout-form" action="{% url 'logout' %}" data-parent="#sidebar" method="post" class="collapsed">
+    <form id="logout-form" action="{% url 'logout' %}" data-bs-parent="#sidebar" method="post" class="collapsed">
       {% csrf_token %}
       <button type="submit" class="btn btn-link">
         <i data-feather="log-out"></i>

--- a/tabbycat/templates/nav/admin_nav.html
+++ b/tabbycat/templates/nav/admin_nav.html
@@ -1,6 +1,6 @@
 {% load debate_tags static i18n %}
 
-<div class="list-group border-0 card text-center text-md-left" id="sidebar" data-children=".list-group-item">
+<div class="list-group border-0 card text-center text-md-start" id="sidebar" data-children=".list-group-item">
 
   <div class="list-group-item d-inline-block main-menu-item">
     <a href="#tlisth" data-bs-toggle="collapse" data-bs-parent="#sidebar" aria-expanded="false"

--- a/tabbycat/templates/nav/assistant_nav.html
+++ b/tabbycat/templates/nav/assistant_nav.html
@@ -14,7 +14,7 @@
 
 <li class="nav-item dropdown {% if participants_nav or institutions_nav or code_names_nav %}active{% endif %}">
   <a class="nav-link dropdown-toggle" href="#" id="checkinsDrop"
-     data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+     data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     {% trans "Participants" %}
   </a>
   <div class="dropdown-menu" aria-labelledby="checkinsDrop">
@@ -34,7 +34,7 @@
 
 <li class="nav-item dropdown {% if checkins_nav %}active{% endif %}">
   <a class="nav-link dropdown-toggle" href="#" id="checkinsDrop"
-     data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+     data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     {% trans "Check-Ins" %}
   </a>
   <div class="dropdown-menu" aria-labelledby="checkinsDrop">

--- a/tabbycat/templates/nav/public_nav.html
+++ b/tabbycat/templates/nav/public_nav.html
@@ -49,7 +49,7 @@
   {% if pref.enable_motion_reuse %}
     <li class="nav-item dropdown {% if motions_nav %}active{% endif %}">
       <a class="nav-link dropdown-toggle" href="#" id="motionsDrop"
-         data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+         data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         {% trans "Motions Tab" %}
       </a>
       <div class="dropdown-menu" aria-labelledby="motionsDrop">
@@ -68,7 +68,7 @@
 {% if pref.public_draw == 'all-released' and not pref.team_tab_released %}
   <li class="nav-item dropdown {% if draw_nav %}active{% endif %}">
     <a class="nav-link dropdown-toggle" href="#" id="drawsDrop"
-       data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+       data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
       {% trans "Draws" %}
     </a>
     <div class="dropdown-menu draw-dropdown-menu" aria-labelledby="drawsDrop">
@@ -111,7 +111,7 @@
 {% if pref.public_results and tournament.rounds_with_released_results %}
   <li class="nav-item dropdown {% if results_nav %}active{% endif %}">
     <a class="nav-link dropdown-toggle" href="#" id="roundsDrop"
-       data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+       data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
        {% trans "Results" %}
     </a>
     <div class="dropdown-menu" aria-labelledby="roundsDrop">
@@ -129,7 +129,7 @@
 
   <li class="nav-item dropdown {% if break_nav %}active{% endif %}">
     <a class="nav-link dropdown-toggle" href="#" id="breakdrop"
-       data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+       data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
       {% trans "Break" %}
     </a>
     <div class="dropdown-menu" aria-labelledby="breakdrop">
@@ -198,7 +198,7 @@
   {% elif tournament.current_rounds|length > 1 %}
     <li class="nav-item dropdown {% if enter_ballots_nav %}active{% endif %}">
       <a class="nav-link dropdown-toggle" href="#" id="roundsDrop"
-         data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+         data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
          {% trans "Enter Ballot" %}
       </a>
       <div class="dropdown-menu" aria-labelledby="roundsDrop">

--- a/tabbycat/templates/nav/round_panel.html
+++ b/tabbycat/templates/nav/round_panel.html
@@ -2,7 +2,7 @@
 
 <div class="list-group-item d-inline-block">
 
-  <a href="#rh{{ r.id }}" data-toggle="collapse" data-parent="#sidebar" aria-expanded="false"
+  <a href="#rh{{ r.id }}" data-bs-toggle="collapse" data-bs-parent="#sidebar" aria-expanded="false"
      class="{% if round == r %}active{% endif %}">
     <i data-feather="circle" class="circle-icon
       {% if r.is_current %}circle-current
@@ -16,7 +16,7 @@
 
   <div class="collapse {% if r == round and round_nav %}show{% endif %}" id="rh{{ r.id }}">
 
-    <a href="{% roundurl 'availability-index' r %}" data-parent="#rh{{ r.id }}"
+    <a href="{% roundurl 'availability-index' r %}" data-bs-parent="#rh{{ r.id }}"
        class="list-group-item {% if availability_nav and round == r %}active{% endif %}">
       <i data-feather="circle" class="circle-icon
         {% if r.completed %} circle-done
@@ -25,7 +25,7 @@
         {% else %} circle-later{% endif %}"></i>{% trans "Availability" %}
     </a>
 
-    <a href="{% roundurl 'draw' r %}" data-parent="#rh{{ r.id }}"
+    <a href="{% roundurl 'draw' r %}" data-bs-parent="#rh{{ r.id }}"
        class="list-group-item {% if draw_nav and round == r %}active{% endif %}">
       <i data-feather="circle" class="circle-icon
         {% if r.completed %} circle-done
@@ -34,7 +34,7 @@
         {% else %} circle-todo{% endif %}"></i>{% trans "Draw" %}
     </a>
 
-    <a href="{% roundurl 'draw-display' r %}" data-parent="#rh{{ r.id }}"
+    <a href="{% roundurl 'draw-display' r %}" data-bs-parent="#rh{{ r.id }}"
       class="list-group-item {% if display_nav and round == r %}active{% endif %}">
       <i data-feather="circle" class="circle-icon
         {% if r.completed %} circle-done
@@ -44,7 +44,7 @@
         {% else %} circle-todo{% endif %}"></i>{% trans "Display" %}
     </a>
 
-    <a href="{% roundurl 'results-round-list' r %}" data-parent="#rh{{ r.id }}"
+    <a href="{% roundurl 'results-round-list' r %}" data-bs-parent="#rh{{ r.id }}"
        class="list-group-item {% if results_nav and round == r %}active{% endif %}">
       <i data-feather="circle" class="circle-icon
         {% if r.completed %} circle-done

--- a/tabbycat/templates/nav/top_nav_base.html
+++ b/tabbycat/templates/nav/top_nav_base.html
@@ -103,14 +103,6 @@
 
     <ul class="navbar-nav navbar-my-lg-0">
       <li class="nav-item">
-        <button class="btn btn-link nav-link" id="theme-toggle" type="button"
-                aria-label="{% trans 'Toggle dark mode' %}" title="{% trans 'Toggle theme' %}">
-          <i data-feather="sun" class="theme-icon-light" style="display:none"></i>
-          <i data-feather="moon" class="theme-icon-dark" style="display:none"></i>
-          <i data-feather="monitor" class="theme-icon-auto" style="display:none"></i>
-        </button>
-      </li>
-      <li class="nav-item">
         {% if user.is_authenticated %}
           <form id="logout-form" action="{% url 'logout' %}" method="post">
             {% csrf_token %}

--- a/tabbycat/templates/nav/top_nav_base.html
+++ b/tabbycat/templates/nav/top_nav_base.html
@@ -9,8 +9,8 @@
   {% if all_tournaments.count > 1 or user.is_authenticated %}
     <div class="nav-item dropdown">
 
-      <button class="btn btn-link mr-2 p-0 navbar-brand dropdown-toggle" id="tournamentdrop"
-              data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      <button class="btn btn-link me-2 p-0 navbar-brand dropdown-toggle" id="tournamentdrop"
+              data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         {% if on_local %}
           {% include "nav/logo_local.html" with width=33 height=33 alt=logo_alt %}
         {% else %}
@@ -85,13 +85,13 @@
     </div>
   {% endif %}
 
-  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#collapsed-main-nav" aria-controls="collapsed-main-nav" aria-expanded="false" aria-label="Toggle navigation">
+  <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#collapsed-main-nav" aria-controls="collapsed-main-nav" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
   </button>
 
   <div class="collapse navbar-collapse pt-3 pt-md-0 pb-2 pb-md-0" id="collapsed-main-nav">
 
-    <ul class="navbar-nav mr-auto">
+    <ul class="navbar-nav me-auto">
 
       {% if user_role == "assistant" %}
         {% include "nav/assistant_nav.html" %}

--- a/tabbycat/templates/nav/top_nav_base.html
+++ b/tabbycat/templates/nav/top_nav_base.html
@@ -103,6 +103,14 @@
 
     <ul class="navbar-nav navbar-my-lg-0">
       <li class="nav-item">
+        <button class="btn btn-link nav-link" id="theme-toggle" type="button"
+                aria-label="{% trans 'Toggle dark mode' %}" title="{% trans 'Toggle theme' %}">
+          <i data-feather="sun" class="theme-icon-light" style="display:none"></i>
+          <i data-feather="moon" class="theme-icon-dark" style="display:none"></i>
+          <i data-feather="monitor" class="theme-icon-auto" style="display:none"></i>
+        </button>
+      </li>
+      <li class="nav-item">
         {% if user.is_authenticated %}
           <form id="logout-form" action="{% url 'logout' %}" method="post">
             {% csrf_token %}

--- a/tabbycat/templates/registration/password_change_form.html
+++ b/tabbycat/templates/registration/password_change_form.html
@@ -10,7 +10,7 @@
 
 <div class="row">
 
-  <div class="col-lg-8 ml-lg-auto mr-md-auto">
+  <div class="col-lg-8 ms-lg-auto me-md-auto">
 
     {% if user and user.is_staff %}
       {% blocktrans trimmed asvar p1 with api_token=user.auth_token.key %}

--- a/tabbycat/templates/registration/password_reset_confirm.html
+++ b/tabbycat/templates/registration/password_reset_confirm.html
@@ -9,7 +9,7 @@
 {% block content %}
 
 <div class="row">
-  <div class="col-lg-8 ml-lg-auto mr-md-auto">
+  <div class="col-lg-8 ms-lg-auto me-md-auto">
 
     {% if validlink %}
       <div class="card">

--- a/tabbycat/templates/scss/components/allocation-highlights.scss
+++ b/tabbycat/templates/scss/components/allocation-highlights.scss
@@ -40,11 +40,11 @@
   }
 
   &.hover-histories-5-ago {
-    @include hover-highlights(lighten($conflict-history-base, 40%), theme-color('dark'));
+    @include hover-highlights(lighten($conflict-history-base, 40%), $dark);
   }
 
   &.hover-histories-6-ago {
-    @include hover-highlights(lighten($conflict-history-base, 44%), theme-color('dark'));
+    @include hover-highlights(lighten($conflict-history-base, 44%), $dark);
   }
 
   &.hover-histories-7-ago,
@@ -56,7 +56,7 @@
   &.hover-histories-13-ago,
   &.hover-histories-14-ago,
   &.hover-histories-15-ago {
-    @include hover-highlights(lighten($conflict-history-base, 46%), theme-color('dark'));
+    @include hover-highlights(lighten($conflict-history-base, 46%), $dark);
   }
 
   // Must be below histories (to take precedence)

--- a/tabbycat/templates/scss/components/allocations.scss
+++ b/tabbycat/templates/scss/components/allocations.scss
@@ -170,7 +170,7 @@
 
 .thead {
   border-bottom: 2px solid $table-border-color;
-  padding-bottom: $table-cell-padding;
+  padding-bottom: $table-cell-padding-y;
 }
 
 .flex-cell {

--- a/tabbycat/templates/scss/components/allocations.scss
+++ b/tabbycat/templates/scss/components/allocations.scss
@@ -4,14 +4,14 @@
 
 // For ModalForAllocating.vue
 .bg-bg {
-  background-color: $body-bg; // Need contrast with button sections, so can't use white
+  background-color: var(--bs-body-bg); // Need contrast with button sections, so can't use white
 }
 
 // For InlineAdjudicator.vue
 .inline-adjudicator {
   height: 100%;
   position: relative;
-  border: 5px solid $white;
+  border: 5px solid var(--bs-body-bg);
 
   &:hover { // Need to override conflict hovers
     background: $purple !important;
@@ -41,7 +41,7 @@
 .inline-team {
   height: 100%; // Need to fill space
   position: relative; // Need to allow for the seen marker
-  border: 5px solid $white; // Placeholder; so doesn't resize with highlights
+  border: 5px solid var(--bs-body-bg); // Placeholder; so doesn't resize with highlights
 
   &:hover { // Need to override conflict hovers
     background: $purple !important;
@@ -152,7 +152,7 @@
 .draw-row {
   @extend .flex-horizontal;
 
-  background: #fff; // Need to compensate for lack of table background
+  background: var(--bs-body-bg); // Need to compensate for lack of table background
   border-left: 1px solid $input-border-color;
   border-right: 1px solid $input-border-color;
 }
@@ -164,7 +164,7 @@
   border-bottom: 2px solid $table-border-color;
 
   &.droppable-cell {
-    border-bottom-color: #fff; // Have more contrast in drag/drop UIs
+    border-bottom-color: var(--bs-body-bg); // Have more contrast in drag/drop UIs
   }
 }
 
@@ -255,7 +255,7 @@
 
   > .conflictable {
     // Team cells need some border state for in panel conflicts
-    border-color: #fff;
+    border-color: var(--bs-body-bg);
     border-width: 4px;
     border-style: solid;
 

--- a/tabbycat/templates/scss/components/bootstrap-custom.scss
+++ b/tabbycat/templates/scss/components/bootstrap-custom.scss
@@ -2,16 +2,18 @@
 // Core variables and mixins
 @import "bootstrap/scss/functions";
 @import "bootstrap/scss/variables";
+@import "bootstrap/scss/variables-dark";
+@import "bootstrap/scss/maps";
 @import "bootstrap/scss/mixins";
+@import "bootstrap/scss/root";
 
 // Reset
-@import "bootstrap/scss/print";
 @import "bootstrap/scss/reboot";
 
 // Core CSS
 @import "bootstrap/scss/type";
 @import "bootstrap/scss/images";
-@import "bootstrap/scss/code";
+@import "bootstrap/scss/containers";
 @import "bootstrap/scss/grid";
 @import "bootstrap/scss/tables";
 @import "bootstrap/scss/forms";
@@ -20,7 +22,6 @@
 @import "bootstrap/scss/dropdown";
 @import "bootstrap/scss/button-group";
 @import "bootstrap/scss/input-group";
-@import "bootstrap/scss/custom-forms";
 
 // Components
 @import "bootstrap/scss/nav";
@@ -29,10 +30,8 @@
 // @import "bootstrap/scss/breadcrumb";
 // @import "bootstrap/scss/pagination";
 @import "bootstrap/scss/badge";
-// @import "bootstrap/scss/jumbotron";
 @import "bootstrap/scss/alert";
 @import "bootstrap/scss/progress";
-// @import "bootstrap/scss/media";
 @import "bootstrap/scss/list-group";
 @import "bootstrap/scss/close";
 
@@ -42,5 +41,7 @@
 @import "bootstrap/scss/popover";
 // @import "bootstrap/scss/carousel";
 
-// Utility classes
+// Helpers & Utilities
+@import "bootstrap/scss/helpers";
 @import "bootstrap/scss/utilities";
+@import "bootstrap/scss/utilities/api";

--- a/tabbycat/templates/scss/components/bootstrap-custom.scss
+++ b/tabbycat/templates/scss/components/bootstrap-custom.scss
@@ -1,16 +1,15 @@
 
-// Core variables and mixins
+// Configuration
 @import "bootstrap/scss/functions";
 @import "bootstrap/scss/variables";
 @import "bootstrap/scss/variables-dark";
 @import "bootstrap/scss/maps";
 @import "bootstrap/scss/mixins";
+@import "bootstrap/scss/utilities";
+
+// Layout & components
 @import "bootstrap/scss/root";
-
-// Reset
 @import "bootstrap/scss/reboot";
-
-// Core CSS
 @import "bootstrap/scss/type";
 @import "bootstrap/scss/images";
 @import "bootstrap/scss/containers";
@@ -21,9 +20,6 @@
 @import "bootstrap/scss/transitions";
 @import "bootstrap/scss/dropdown";
 @import "bootstrap/scss/button-group";
-@import "bootstrap/scss/input-group";
-
-// Components
 @import "bootstrap/scss/nav";
 @import "bootstrap/scss/navbar";
 @import "bootstrap/scss/card";
@@ -34,14 +30,13 @@
 @import "bootstrap/scss/progress";
 @import "bootstrap/scss/list-group";
 @import "bootstrap/scss/close";
-
-// Components w/ JavaScript
 @import "bootstrap/scss/modal";
 @import "bootstrap/scss/tooltip";
 @import "bootstrap/scss/popover";
 // @import "bootstrap/scss/carousel";
 
-// Helpers & Utilities
+// Helpers
 @import "bootstrap/scss/helpers";
-@import "bootstrap/scss/utilities";
+
+// Utilities
 @import "bootstrap/scss/utilities/api";

--- a/tabbycat/templates/scss/components/custom.scss
+++ b/tabbycat/templates/scss/components/custom.scss
@@ -97,19 +97,19 @@ $grid-gutter-width:         30px;
 $navbar-padding-x:          1rem;
 
 // List group items (BS4: .75rem 1.25rem, BS5: .5rem 1rem)
-$list-group-item-padding-y: .75rem;
+$list-group-item-padding-y: 0.75rem;
 $list-group-item-padding-x: 1.25rem;
 
 // Cards (BS4: .75rem/.1.25rem, BS5: 1rem/1rem)
-$card-spacer-y:             .75rem;
+$card-spacer-y:             0.75rem;
 $card-spacer-x:             1.25rem;
-$card-cap-padding-y:        .75rem;
+$card-cap-padding-y:        0.75rem;
 $card-cap-padding-x:        1.25rem;
 
 // Dropdowns (BS4: 1.5rem horizontal, BS5: 1rem)
 $dropdown-item-padding-x:   1.5rem;
 
 // Popovers (BS4: tighter padding, BS5: 1rem everywhere)
-$popover-header-padding-x:  .75rem;
-$popover-body-padding-y:    .5rem;
-$popover-body-padding-x:    .75rem;
+$popover-header-padding-x:  0.75rem;
+$popover-body-padding-y:    0.5rem;
+$popover-body-padding-x:    0.75rem;

--- a/tabbycat/templates/scss/components/custom.scss
+++ b/tabbycat/templates/scss/components/custom.scss
@@ -85,6 +85,15 @@ $link-color:                $purple;
 $link-decoration:           none;
 $link-hover-decoration:     underline;
 
+// Focus ring (BS5.3): tint focus highlight with the primary brand color
+$focus-ring-width:           0.2rem;
+$focus-ring-opacity:         0.25;
+$focus-ring-color:           rgba($purple, $focus-ring-opacity);
+$focus-ring-blur:            0;
+$input-btn-focus-color:      rgba($purple, $focus-ring-opacity);
+$input-btn-focus-width:      $focus-ring-width;
+$input-btn-focus-box-shadow: 0 0 0 $input-btn-focus-width $input-btn-focus-color;
+
 //------------------------------------------------------------------------------
 // BS4→BS5 spacing compatibility overrides
 // BS5 changed many default padding/margin values; restore BS4 defaults

--- a/tabbycat/templates/scss/components/custom.scss
+++ b/tabbycat/templates/scss/components/custom.scss
@@ -44,6 +44,14 @@ $gray-700: #495057 !default;
 $gray-800: #343a40 !default;
 $gray-900: #212529 !default;
 
+// Semantic color variables (must be set before bootstrap imports derive from them)
+$primary:                 $purple;
+$secondary:               $gray-600;
+$success:                 $green;
+$info:                    $blue;
+$warning:                 $orange;
+$danger:                  $red;
+
 // Key Colors
 $body-bg:                 #f8fafc;
 $body-color:              $gray-900; // Gray-900 equivalent; for body text
@@ -71,3 +79,37 @@ $input-btn-padding-y:       0.625rem;
 $input-btn-padding-y-sm:    0.3125rem;
 
 $navbar-light-hover-color:  $purple;
+
+// Restore BS4 link behavior (BS5 defaults to underline + derives color from $blue)
+$link-color:                $purple;
+$link-decoration:           none;
+$link-hover-decoration:     underline;
+
+//------------------------------------------------------------------------------
+// BS4→BS5 spacing compatibility overrides
+// BS5 changed many default padding/margin values; restore BS4 defaults
+//------------------------------------------------------------------------------
+
+// Grid gutter (BS4: 30px, BS5: 1.5rem/24px)
+$grid-gutter-width:         30px;
+
+// Navbar (BS4: 1rem horizontal padding, BS5: 0)
+$navbar-padding-x:          1rem;
+
+// List group items (BS4: .75rem 1.25rem, BS5: .5rem 1rem)
+$list-group-item-padding-y: .75rem;
+$list-group-item-padding-x: 1.25rem;
+
+// Cards (BS4: .75rem/.1.25rem, BS5: 1rem/1rem)
+$card-spacer-y:             .75rem;
+$card-spacer-x:             1.25rem;
+$card-cap-padding-y:        .75rem;
+$card-cap-padding-x:        1.25rem;
+
+// Dropdowns (BS4: 1.5rem horizontal, BS5: 1rem)
+$dropdown-item-padding-x:   1.5rem;
+
+// Popovers (BS4: tighter padding, BS5: 1rem everywhere)
+$popover-header-padding-x:  .75rem;
+$popover-body-padding-y:    .5rem;
+$popover-body-padding-x:    .75rem;

--- a/tabbycat/templates/scss/components/page-specific.scss
+++ b/tabbycat/templates/scss/components/page-specific.scss
@@ -43,7 +43,7 @@
 }
 
 .progress-empty span {
-  color: #000; // If its showing 0/x make the text visible and not flush
+  color: var(--bs-body-color); // If its showing 0/x make the text visible and not flush
   margin-left: 10px;
 }
 

--- a/tabbycat/templates/scss/components/variables.scss
+++ b/tabbycat/templates/scss/components/variables.scss
@@ -9,13 +9,11 @@
 //------------------------------------------------------------------------------
 
 // Layout Colors
-$alt-bg:                  #fff;     // For tables etc
 $table-bg-hover:          #e3e3e3;
 $sidebar-bg:              #333c47;  // Matches that of Jet
 $sidebar-muted-text:      $gray-400;
 $droppable-bg:            $gray-200;
-$navbar-light-bg:         $alt-bg; // Footer and Top Navbar
-$navbar-light-border:     $gray-200; // Footer and Top Navbar
+$navbar-light-border:     $gray-200; // Footer and Top Navbar border
 
 // Gender Highlights
 $male:                    #36b6c0;

--- a/tabbycat/templates/scss/components/variables.scss
+++ b/tabbycat/templates/scss/components/variables.scss
@@ -64,8 +64,8 @@ $alpha-ranking-8:           hsla(0, 0%, 50%, 1);
 $small-font-size: 80%;
 
 // Team Positions
-$aff:                     theme-color("info");
-$neg:                     theme-color("danger");
+$aff:                     $info;
+$neg:                     $danger;
 
 // BP colors designed according to a perceptual color wheel primaries as sides
 // i.e. red/green and yellow/blue opposites

--- a/tabbycat/templates/scss/components/variables.scss
+++ b/tabbycat/templates/scss/components/variables.scss
@@ -96,7 +96,7 @@ $footer-height: 175px;
 // For diversity and allocation highlights
 @mixin hover-highlights($baseColor, $textColor: #fff) {
   background-color: $baseColor;
-  border-color: darken($baseColor, 5);
+  border-color: darken($baseColor, 5%);
   color: $textColor;
 
   h4,

--- a/tabbycat/templates/scss/modules/dark-mode.scss
+++ b/tabbycat/templates/scss/modules/dark-mode.scss
@@ -26,7 +26,6 @@
   --bs-warning-rgb: #{red($dm-warning)}, #{green($dm-warning)}, #{blue($dm-warning)};
   --bs-danger: #{$dm-danger};
   --bs-danger-rgb: #{red($dm-danger)}, #{green($dm-danger)}, #{blue($dm-danger)};
-
   --bs-link-color: #{$dm-primary};
   --bs-link-color-rgb: #{red($dm-primary)}, #{green($dm-primary)}, #{blue($dm-primary)};
   --bs-link-hover-color: #{lighten($purple, 25%)};
@@ -196,7 +195,6 @@
   //----------------------------------------------------------------------------
   // Buttons with outline
   //----------------------------------------------------------------------------
-
   @each $color, $value in $theme-colors {
     .btn-outline-#{$color} {
       background-color: transparent;
@@ -241,6 +239,7 @@
   //----------------------------------------------------------------------------
 
   .d3-graph {
+
     .axis path,
     .axis line {
       stroke: var(--bs-border-color);
@@ -248,6 +247,7 @@
   }
 
   .d3-feedback-trend {
+
     .tick line,
     .axis line {
       stroke: var(--bs-border-color);

--- a/tabbycat/templates/scss/modules/dark-mode.scss
+++ b/tabbycat/templates/scss/modules/dark-mode.scss
@@ -6,10 +6,75 @@
 
 [data-bs-theme="dark"] {
 
-  // Layout
+  //----------------------------------------------------------------------------
+  // Lighter accent colors for dark backgrounds (~20% lighter, same hue)
+  //----------------------------------------------------------------------------
+
+  $dm-primary: lighten($purple, 20%);
+  $dm-success: lighten($green, 20%);
+  $dm-info: lighten($blue, 20%);
+  $dm-warning: lighten($orange, 20%);
+  $dm-danger: lighten($red, 20%);
+
+  --bs-primary: #{$dm-primary};
+  --bs-primary-rgb: #{red($dm-primary)}, #{green($dm-primary)}, #{blue($dm-primary)};
+  --bs-success: #{$dm-success};
+  --bs-success-rgb: #{red($dm-success)}, #{green($dm-success)}, #{blue($dm-success)};
+  --bs-info: #{$dm-info};
+  --bs-info-rgb: #{red($dm-info)}, #{green($dm-info)}, #{blue($dm-info)};
+  --bs-warning: #{$dm-warning};
+  --bs-warning-rgb: #{red($dm-warning)}, #{green($dm-warning)}, #{blue($dm-warning)};
+  --bs-danger: #{$dm-danger};
+  --bs-danger-rgb: #{red($dm-danger)}, #{green($dm-danger)}, #{blue($dm-danger)};
+
+  --bs-link-color: #{$dm-primary};
+  --bs-link-color-rgb: #{red($dm-primary)}, #{green($dm-primary)}, #{blue($dm-primary)};
+  --bs-link-hover-color: #{lighten($purple, 25%)};
+  --bs-link-hover-color-rgb: #{red(lighten($purple, 25%))}, #{green(lighten($purple, 25%))}, #{blue(lighten($purple, 25%))};
+
+  // Buttons
+  @each $name, $base in (primary: $purple, success: $green, info: $blue, warning: $orange, danger: $red) {
+    .btn-#{$name} {
+      --bs-btn-bg: #{lighten($base, 20%)};
+      --bs-btn-border-color: #{lighten($base, 20%)};
+      --bs-btn-hover-bg: #{lighten($base, 15%)};
+      --bs-btn-hover-border-color: #{lighten($base, 15%)};
+      --bs-btn-active-bg: #{lighten($base, 10%)};
+      --bs-btn-active-border-color: #{lighten($base, 10%)};
+    }
+
+    .text-bg-#{$name} {
+      background-color: #{lighten($base, 20%)} !important;
+    }
+
+    .alert-#{$name} {
+      --bs-alert-bg: #{rgba(lighten($base, 20%), 0.15)};
+      --bs-alert-color: #{lighten($base, 30%)};
+      --bs-alert-border-color: #{rgba(lighten($base, 20%), 0.3)};
+    }
+  }
+
+  //----------------------------------------------------------------------------
+  // Navbar & Footer
+  //----------------------------------------------------------------------------
+
   .navbar-light {
     background: var(--bs-body-bg);
     border-color: var(--bs-border-color);
+  }
+
+  .navbar .dropdown-menu .dropdown-item {
+    color: var(--bs-body-color);
+
+    &:hover {
+      color: var(--bs-primary);
+      background-color: var(--bs-tertiary-bg);
+    }
+
+    &.active,
+    &:focus {
+      color: var(--bs-body-color);
+    }
   }
 
   .footer a {
@@ -17,7 +82,10 @@
     color: var(--bs-body-color);
   }
 
+  //----------------------------------------------------------------------------
   // Sidebar (already dark; just ensure consistency)
+  //----------------------------------------------------------------------------
+
   .admin-sidebar > .list-group > .list-group-item {
     background: $sidebar-bg;
   }
@@ -26,7 +94,10 @@
     background: $sidebar-bg;
   }
 
+  //----------------------------------------------------------------------------
   // Tables
+  //----------------------------------------------------------------------------
+
   .table {
     background: var(--bs-body-bg);
   }
@@ -38,9 +109,52 @@
 
   .table > tbody > tr:hover td {
     background-color: var(--bs-tertiary-bg);
+
+    .hide-underline {
+      border-bottom-color: var(--bs-tertiary-bg);
+    }
   }
 
+  .table.hide-hover > tbody > tr:hover td .hide-underline {
+    border-bottom-color: var(--bs-border-color);
+  }
+
+  //----------------------------------------------------------------------------
+  // Allocations — hardcoded #fff borders
+  //----------------------------------------------------------------------------
+
+  .inline-adjudicator {
+    border-color: var(--bs-body-bg);
+  }
+
+  .inline-team {
+    border-color: var(--bs-body-bg);
+  }
+
+  .draw-row {
+    background: var(--bs-body-bg);
+  }
+
+  .draw-cell.droppable-cell {
+    border-bottom-color: var(--bs-body-bg);
+  }
+
+  .draw-team-cell > .conflictable {
+    border-color: var(--bs-body-bg);
+  }
+
+  .panel-incomplete .btn {
+    color: var(--bs-body-color);
+  }
+
+  .bg-bg {
+    background-color: var(--bs-body-bg);
+  }
+
+  //----------------------------------------------------------------------------
   // Drag and drop
+  //----------------------------------------------------------------------------
+
   .vue-draggable {
     background: var(--bs-body-bg);
   }
@@ -53,33 +167,162 @@
     background: var(--bs-body-bg);
   }
 
-  // Buttons with outline - remove white bg
+  .draggable-panel.vue-draggable {
+    border-color: var(--bs-border-color);
+
+    &:hover .panel-handle {
+      background: var(--bs-secondary-bg);
+
+      .feather {
+        color: var(--bs-body-color);
+      }
+    }
+
+    .panel-handle:hover {
+      background: var(--bs-primary);
+
+      .feather {
+        color: #fff;
+      }
+    }
+  }
+
+  .vue-draggable:hover .vc-title,
+  .vue-draggable:hover .vue-draggable:hover .vc-title,
+  .vue-draggable:hover .vue-draggable-dragging .vc-title {
+    color: #fff;
+  }
+
+  //----------------------------------------------------------------------------
+  // Buttons with outline
+  //----------------------------------------------------------------------------
+
   @each $color, $value in $theme-colors {
     .btn-outline-#{$color} {
       background-color: transparent;
     }
   }
 
-  // Form errors
+  //----------------------------------------------------------------------------
+  // Forms
+  //----------------------------------------------------------------------------
+
   .errorlist,
   label.error {
     color: var(--bs-danger);
   }
 
-  // Allocation panel colors survive dark mode (they're semantic)
+  .checkInForm {
+    border-color: var(--bs-border-color);
+  }
 
-  // Popover adjustments
+  //----------------------------------------------------------------------------
+  // Popovers & tooltips
+  //----------------------------------------------------------------------------
+
   .popover {
     --bs-popover-bg: var(--bs-body-bg);
   }
 
+  .tooltip-trigger {
+    border-bottom-color: var(--bs-border-color);
+  }
+
+  //----------------------------------------------------------------------------
   // Slideover info panel
+  //----------------------------------------------------------------------------
+
   .slideover-info {
     box-shadow: 0 0 10px rgba(255, 255, 255, 0.1);
   }
 
-  // Scrollbar hint for allocation droppables
-  .draggable-panel.vue-draggable {
-    border-color: var(--bs-border-color);
+  //----------------------------------------------------------------------------
+  // D3 graphs / datavis
+  //----------------------------------------------------------------------------
+
+  .d3-graph {
+    .axis path,
+    .axis line {
+      stroke: var(--bs-border-color);
+    }
+  }
+
+  .d3-feedback-trend {
+    .tick line,
+    .axis line {
+      stroke: var(--bs-border-color);
+    }
+  }
+
+  .d3-hover-black:hover {
+    fill: var(--bs-body-color);
+  }
+
+  //----------------------------------------------------------------------------
+  // Progress bars
+  //----------------------------------------------------------------------------
+
+  .progress-empty span {
+    color: var(--bs-body-color);
+  }
+
+  .progress-points-3 {
+    background: rgba(255, 255, 255, 0.9);
+    color: #000;
+  }
+
+  .progress-points-2 {
+    background: rgba(255, 255, 255, 0.7);
+    color: #000;
+  }
+
+  .progress-points-1 {
+    background: rgba(255, 255, 255, 0.5);
+    color: #000;
+  }
+
+  .progress-points-0 {
+    background: rgba(255, 255, 255, 0.3);
+    color: #000;
+  }
+
+  //----------------------------------------------------------------------------
+  // Interaction
+  //----------------------------------------------------------------------------
+
+  .item-submit:hover {
+    background-color: var(--bs-tertiary-bg) !important;
+  }
+
+  //----------------------------------------------------------------------------
+  // Active list-group items
+  //----------------------------------------------------------------------------
+
+  .list-group-item.active a {
+    color: var(--bs-body-bg);
+  }
+
+  //----------------------------------------------------------------------------
+  // Text color utilities (use lighter accents)
+  //----------------------------------------------------------------------------
+
+  .text-primary {
+    color: var(--bs-primary) !important;
+  }
+
+  .text-success {
+    color: var(--bs-success) !important;
+  }
+
+  .text-info {
+    color: var(--bs-info) !important;
+  }
+
+  .text-warning {
+    color: var(--bs-warning) !important;
+  }
+
+  .text-danger {
+    color: var(--bs-danger) !important;
   }
 }

--- a/tabbycat/templates/scss/modules/dark-mode.scss
+++ b/tabbycat/templates/scss/modules/dark-mode.scss
@@ -41,6 +41,18 @@
       --bs-btn-active-bg: #{lighten($base, 10%)};
       --bs-btn-active-border-color: #{lighten($base, 10%)};
     }
+  }
+
+  // In dark mode the lighter button bgs need dark text for legibility
+  .btn-success,
+  .btn-warning,
+  .btn-info {
+    --bs-btn-color: #000;
+    --bs-btn-hover-color: #000;
+    --bs-btn-active-color: #000;
+    --bs-btn-disabled-color: #000;
+  }
+  @each $name, $base in (primary: $purple, success: $green, info: $blue, warning: $orange, danger: $red) {
 
     .text-bg-#{$name} {
       background-color: #{lighten($base, 20%)} !important;

--- a/tabbycat/templates/scss/modules/dark-mode.scss
+++ b/tabbycat/templates/scss/modules/dark-mode.scss
@@ -1,0 +1,85 @@
+//------------------------------------------------------------------------------
+// Dark Mode Overrides
+// BS5.3 handles most components via data-bs-theme="dark".
+// These overrides cover Tabbycat-specific colors that BS5 doesn't know about.
+//------------------------------------------------------------------------------
+
+[data-bs-theme="dark"] {
+
+  // Layout
+  .navbar-light {
+    background: var(--bs-body-bg);
+    border-color: var(--bs-border-color);
+  }
+
+  .footer a {
+    border-bottom-color: var(--bs-border-color);
+    color: var(--bs-body-color);
+  }
+
+  // Sidebar (already dark; just ensure consistency)
+  .admin-sidebar > .list-group > .list-group-item {
+    background: $sidebar-bg;
+  }
+
+  .fake-sidebar .list-group-item {
+    background: $sidebar-bg;
+  }
+
+  // Tables
+  .table {
+    background: var(--bs-body-bg);
+  }
+
+  thead,
+  .thead {
+    background: var(--bs-body-bg);
+  }
+
+  .table > tbody > tr:hover td {
+    background-color: var(--bs-tertiary-bg);
+  }
+
+  // Drag and drop
+  .vue-draggable {
+    background: var(--bs-body-bg);
+  }
+
+  .vue-droppable {
+    background: var(--bs-secondary-bg);
+  }
+
+  .vue-droppable.vue-droppable-locked {
+    background: var(--bs-body-bg);
+  }
+
+  // Buttons with outline - remove white bg
+  @each $color, $value in $theme-colors {
+    .btn-outline-#{$color} {
+      background-color: transparent;
+    }
+  }
+
+  // Form errors
+  .errorlist,
+  label.error {
+    color: var(--bs-danger);
+  }
+
+  // Allocation panel colors survive dark mode (they're semantic)
+
+  // Popover adjustments
+  .popover {
+    --bs-popover-bg: var(--bs-body-bg);
+  }
+
+  // Slideover info panel
+  .slideover-info {
+    box-shadow: 0 0 10px rgba(255, 255, 255, 0.1);
+  }
+
+  // Scrollbar hint for allocation droppables
+  .draggable-panel.vue-draggable {
+    border-color: var(--bs-border-color);
+  }
+}

--- a/tabbycat/templates/scss/modules/dark-mode.scss
+++ b/tabbycat/templates/scss/modules/dark-mode.scss
@@ -131,51 +131,19 @@
   }
 
   //----------------------------------------------------------------------------
-  // Allocations — hardcoded #fff borders
+  // Allocations
   //----------------------------------------------------------------------------
-
-  .inline-adjudicator {
-    border-color: var(--bs-body-bg);
-  }
-
-  .inline-team {
-    border-color: var(--bs-body-bg);
-  }
-
-  .draw-row {
-    background: var(--bs-body-bg);
-  }
-
-  .draw-cell.droppable-cell {
-    border-bottom-color: var(--bs-body-bg);
-  }
-
-  .draw-team-cell > .conflictable {
-    border-color: var(--bs-body-bg);
-  }
 
   .panel-incomplete .btn {
     color: var(--bs-body-color);
-  }
-
-  .bg-bg {
-    background-color: var(--bs-body-bg);
   }
 
   //----------------------------------------------------------------------------
   // Drag and drop
   //----------------------------------------------------------------------------
 
-  .vue-draggable {
-    background: var(--bs-body-bg);
-  }
-
   .vue-droppable {
     background: var(--bs-secondary-bg);
-  }
-
-  .vue-droppable.vue-droppable-locked {
-    background: var(--bs-body-bg);
   }
 
   .draggable-panel.vue-draggable {

--- a/tabbycat/templates/scss/modules/dark-mode.scss
+++ b/tabbycat/templates/scss/modules/dark-mode.scss
@@ -7,14 +7,15 @@
 [data-bs-theme="dark"] {
 
   //----------------------------------------------------------------------------
-  // Lighter accent colors for dark backgrounds (~20% lighter, same hue)
+  // Softer accent colors for dark backgrounds (lightly lifted + desaturated)
   //----------------------------------------------------------------------------
 
-  $dm-primary: lighten($purple, 20%);
-  $dm-success: lighten($green, 20%);
-  $dm-info: lighten($blue, 20%);
-  $dm-warning: lighten($orange, 20%);
-  $dm-danger: lighten($red, 20%);
+  $dm-primary: desaturate(lighten($purple, 12%), 10%);
+  $dm-success: desaturate(lighten($green, 10%), 20%);
+  $dm-info: desaturate(lighten($blue, 10%), 15%);
+  $dm-warning: desaturate(lighten($orange, 8%), 15%);
+  $dm-danger: desaturate(lighten($red, 10%), 10%);
+  $dm-link-hover: lighten($dm-primary, 8%);
 
   --bs-primary: #{$dm-primary};
   --bs-primary-rgb: #{red($dm-primary)}, #{green($dm-primary)}, #{blue($dm-primary)};
@@ -28,40 +29,32 @@
   --bs-danger-rgb: #{red($dm-danger)}, #{green($dm-danger)}, #{blue($dm-danger)};
   --bs-link-color: #{$dm-primary};
   --bs-link-color-rgb: #{red($dm-primary)}, #{green($dm-primary)}, #{blue($dm-primary)};
-  --bs-link-hover-color: #{lighten($purple, 25%)};
-  --bs-link-hover-color-rgb: #{red(lighten($purple, 25%))}, #{green(lighten($purple, 25%))}, #{blue(lighten($purple, 25%))};
+  --bs-link-hover-color: #{$dm-link-hover};
+  --bs-link-hover-color-rgb: #{red($dm-link-hover)}, #{green($dm-link-hover)}, #{blue($dm-link-hover)};
 
-  // Buttons
-  @each $name, $base in (primary: $purple, success: $green, info: $blue, warning: $orange, danger: $red) {
+  // Buttons — use the softer dm-* palette
+  @each $name, $dm in (primary: $dm-primary, success: $dm-success, info: $dm-info, warning: $dm-warning, danger: $dm-danger) {
     .btn-#{$name} {
-      --bs-btn-bg: #{lighten($base, 20%)};
-      --bs-btn-border-color: #{lighten($base, 20%)};
-      --bs-btn-hover-bg: #{lighten($base, 15%)};
-      --bs-btn-hover-border-color: #{lighten($base, 15%)};
-      --bs-btn-active-bg: #{lighten($base, 10%)};
-      --bs-btn-active-border-color: #{lighten($base, 10%)};
+      --bs-btn-bg: #{$dm};
+      --bs-btn-border-color: #{$dm};
+      --bs-btn-hover-bg: #{darken($dm, 6%)};
+      --bs-btn-hover-border-color: #{darken($dm, 6%)};
+      --bs-btn-active-bg: #{darken($dm, 12%)};
+      --bs-btn-active-border-color: #{darken($dm, 12%)};
+      --bs-btn-color: #fff;
+      --bs-btn-hover-color: #fff;
+      --bs-btn-active-color: #fff;
     }
   }
-
-  // In dark mode the lighter button bgs need dark text for legibility
-  .btn-success,
-  .btn-warning,
-  .btn-info {
-    --bs-btn-color: #000;
-    --bs-btn-hover-color: #000;
-    --bs-btn-active-color: #000;
-    --bs-btn-disabled-color: #000;
-  }
-  @each $name, $base in (primary: $purple, success: $green, info: $blue, warning: $orange, danger: $red) {
-
+  @each $name, $dm in (primary: $dm-primary, success: $dm-success, info: $dm-info, warning: $dm-warning, danger: $dm-danger) {
     .text-bg-#{$name} {
-      background-color: #{lighten($base, 20%)} !important;
+      background-color: #{$dm} !important;
     }
 
     .alert-#{$name} {
-      --bs-alert-bg: #{rgba(lighten($base, 20%), 0.15)};
-      --bs-alert-color: #{lighten($base, 30%)};
-      --bs-alert-border-color: #{rgba(lighten($base, 20%), 0.3)};
+      --bs-alert-bg: #{rgba($dm, 0.15)};
+      --bs-alert-color: #{lighten($dm, 15%)};
+      --bs-alert-border-color: #{rgba($dm, 0.3)};
     }
   }
 

--- a/tabbycat/templates/scss/modules/drag-and-drop.scss
+++ b/tabbycat/templates/scss/modules/drag-and-drop.scss
@@ -136,7 +136,7 @@
 // Inheritance hack below to address double-hovering when using draggable panels
 .vue-droppable-enter,
 .vue-droppable-enter .panel-incomplete {
-  background: theme-color("success") !important;
+  background: $success !important;
 }
 
 //------------------------------------------------------------------------------

--- a/tabbycat/templates/scss/modules/drag-and-drop.scss
+++ b/tabbycat/templates/scss/modules/drag-and-drop.scss
@@ -3,7 +3,7 @@
 //------------------------------------------------------------------------------
 
 .vue-draggable {
-  background: #fff;
+  background: var(--bs-body-bg);
   border: 4px solid $gray-600;
   border-radius: $border-radius;
   overflow: hidden; // Need to cut off text (because it doesn't wrap)
@@ -63,7 +63,7 @@
   }
 
   &.vue-droppable-locked {
-    background: #fff;
+    background: var(--bs-body-bg);
     position: relative; // For the spinner
   }
 }
@@ -103,10 +103,10 @@
 
     .panel-handle {
       display: flex;
-      background: #fff;
+      background: var(--bs-body-bg);
 
       .feather {
-        color: #000; // for the icon
+        color: var(--bs-body-color); // for the icon
       }
     }
 

--- a/tabbycat/templates/scss/modules/footer.scss
+++ b/tabbycat/templates/scss/modules/footer.scss
@@ -20,8 +20,8 @@ body {
   height: $footer-height;
 
   a {
-    border-bottom: 1px solid theme-color("secondary");
-    color: theme-color("dark");
+    border-bottom: 1px solid $secondary;
+    color: $dark;
   }
 }
 

--- a/tabbycat/templates/scss/modules/forms.scss
+++ b/tabbycat/templates/scss/modules/forms.scss
@@ -35,7 +35,7 @@
   }
 }
 
-.btn[data-toggle='tooltip'] span {
+.btn[data-bs-toggle='tooltip'] span {
   border-bottom: 0; // Need to prevent dashed lines in glyphicons in btns
 }
 
@@ -84,7 +84,7 @@ input[type="range"] {
 // Inline form errors from django
 .errorlist,
 label.error {
-  color: theme-color("danger");
+  color: $danger;
   margin: 0;
   padding: 0;
   list-style-type: none;

--- a/tabbycat/templates/scss/modules/forms.scss
+++ b/tabbycat/templates/scss/modules/forms.scss
@@ -53,6 +53,92 @@
   align-items: center;
 }
 
+// BS5 dropped .btn-block; restore until template usages are migrated to .w-100
+.btn-block {
+  display: block;
+  width: 100%;
+}
+
+// BS5 picks .btn-* text color via color-contrast(). For Tabbycat's lighter
+// theme colors that flips to black; BS4 always rendered white. Restore white.
+.btn-success,
+.btn-warning,
+.btn-info {
+  --bs-btn-color: #fff;
+  --bs-btn-hover-color: #fff;
+  --bs-btn-active-color: #fff;
+  --bs-btn-disabled-color: #fff;
+}
+
+// BS5 sets .list-group-item padding/border/color via CSS vars declared only on
+// .list-group; orphan items (e.g. inside .card without .list-group) lose all of
+// these. Restore fallback values so orphan items render BS4-equivalent.
+.list-group-item {
+  padding: var(--bs-list-group-item-padding-y, 0.75rem) var(--bs-list-group-item-padding-x, 1.25rem);
+  color: var(--bs-list-group-color, var(--bs-body-color));
+  background-color: var(--bs-list-group-bg, var(--bs-body-bg));
+  border: var(--bs-list-group-border-width, var(--bs-border-width)) solid var(--bs-list-group-border-color, var(--bs-border-color));
+}
+
+// Restore the BS4 between-item separation: hide the leading border so consecutive
+// items share a single divider (BS5 normally handles this via .list-group rules).
+.card > .list-group-item:first-child,
+.card > form > .list-group-item:first-child {
+  border-top: 0;
+}
+
+.card > .list-group-item,
+.card > form > .list-group-item {
+  border-right: 0;
+  border-left: 0;
+}
+
+.card > .list-group-item:last-child,
+.card > form > .list-group-item:last-child {
+  border-bottom: 0;
+}
+
+// BS5 dropped .card-deck; replicate BS4 behavior (equal-width sibling cards)
+.card-deck {
+  display: flex;
+  flex-direction: column;
+
+  .card {
+    margin-bottom: 15px;
+  }
+  @include media-breakpoint-up(sm) {
+    flex-flow: row wrap;
+    margin-right: -15px;
+    margin-left: -15px;
+
+    .card {
+      flex: 1 0 0%;
+      margin-right: 15px;
+      margin-bottom: 0;
+      margin-left: 15px;
+    }
+  }
+}
+
+// BS5 dropped .card-columns; replicate BS4 masonry layout via CSS columns
+.card-columns {
+
+  .card {
+    margin-bottom: $card-spacer-y;
+  }
+  @include media-breakpoint-up(sm) {
+    column-count: 3;
+    column-gap: 1.25rem;
+    orphans: 1;
+    widows: 1;
+
+    .card {
+      display: inline-block;
+      width: 100%;
+    }
+  }
+}
+
 //------------------------------------------------------------------------------
 // Inputs (in general)
 //------------------------------------------------------------------------------
@@ -78,7 +164,7 @@ input[type="range"] {
 }
 
 // Choice widget labels (radios/checkboxes) don't need the extra padding
-.list-group-item {
+.list-group-item { // stylelint-disable-line no-duplicate-selectors
 
   .form-check label,
   label.form-check-label {

--- a/tabbycat/templates/scss/modules/forms.scss
+++ b/tabbycat/templates/scss/modules/forms.scss
@@ -40,6 +40,20 @@
 }
 
 //------------------------------------------------------------------------------
+// BS4 compatibility (classes removed in BS5)
+//------------------------------------------------------------------------------
+
+.form-group {
+  margin-bottom: 1rem;
+}
+
+.form-inline {
+  display: flex;
+  flex-flow: row wrap;
+  align-items: center;
+}
+
+//------------------------------------------------------------------------------
 // Inputs (in general)
 //------------------------------------------------------------------------------
 
@@ -69,6 +83,21 @@ input[type="range"] {
   .form-check label,
   label.form-check-label {
     padding-top: 0;
+  }
+
+  // Large centered toggle switches for preference forms
+  .form-check.form-switch {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 38px;
+    padding-left: 3.5em;
+
+    .form-check-input {
+      width: 3em;
+      height: 1.5em;
+      margin-top: 0;
+    }
   }
 }
 

--- a/tabbycat/templates/scss/modules/icons.scss
+++ b/tabbycat/templates/scss/modules/icons.scss
@@ -26,7 +26,7 @@ span.emoji {
 //------------------------------------------------------------------------------
 
 .adj-symbol {
-  @extend .text-monospace;
+  @extend .font-monospace;
 
   color: $gray-700; // not black; but not too gray
   font-style: normal;
@@ -44,23 +44,23 @@ span.emoji {
 
   // Icons should have brighter colors (using text-success is too dull)
   &.text-success {
-    color: theme-color("success");
+    color: $success;
   }
 
   &.text-danger {
-    color: theme-color("danger");
+    color: $danger;
   }
 
   &.text-warning {
-    color: theme-color("warning");
+    color: $warning;
   }
 
   &.text-info {
-    color: theme-color("info");
+    color: $info;
   }
 
   &.text-primary {
-    color: theme-color("primary");
+    color: $primary;
   }
 }
 

--- a/tabbycat/templates/scss/modules/interaction.scss
+++ b/tabbycat/templates/scss/modules/interaction.scss
@@ -57,10 +57,6 @@
     padding: 0.5rem 0.75rem;
   }
 
-  .bs-tether-element-attached-top::after,
-  .bs-tether-element-attached-top::before {
-    left: 25%;
-  }
 }
 @media (max-width: breakpoint-min(sm, $grid-breakpoints)) {
 

--- a/tabbycat/templates/scss/modules/interaction.scss
+++ b/tabbycat/templates/scss/modules/interaction.scss
@@ -11,14 +11,14 @@
 }
 
 // Specific styling for tooltips/popovers
-[data-toggle='tooltip'],
-[data-toggle="popover"],
+[data-bs-toggle='tooltip'],
+[data-bs-toggle="popover"],
 .hover-target {
 
   &:hover {
     cursor: help; // for tooltips
     span {
-      border-color: theme-color("primary");
+      border-color: $primary;
     }
   }
 
@@ -177,7 +177,7 @@
 
 .spinning {
   animation: spin 1s infinite linear;
-  color: theme-color("primary");
+  color: $primary;
 }
 @keyframes spin {
 
@@ -213,7 +213,7 @@
 @keyframes flash-animation {
 
   from {
-    color: theme-color("success");
+    color: $success;
   }
 
   to {

--- a/tabbycat/templates/scss/modules/interaction.scss
+++ b/tabbycat/templates/scss/modules/interaction.scss
@@ -56,7 +56,6 @@
   .list-group-item {
     padding: 0.5rem 0.75rem;
   }
-
 }
 @media (max-width: breakpoint-min(sm, $grid-breakpoints)) {
 

--- a/tabbycat/templates/scss/modules/layout.scss
+++ b/tabbycat/templates/scss/modules/layout.scss
@@ -13,7 +13,7 @@
 
   .main {
     @extend .col-12;
-    @extend .pl-3;
+    @extend .ps-3;
     // padding-right: 0;
   }
 }
@@ -22,19 +22,15 @@
 // Lists
 //------------------------------------------------------------------------------
 
-// Override some boostrap color defaults and automatically add color variations
+// Ensure links inside alerts and colored text are visually distinct
 @each $color, $value in $theme-colors {
 
-  .alert-#{$color},
-  .text-#{$color} {
-
-    a {
-      @include alert-variant(theme-color-level($color, -10), theme-color-level($color, -9), theme-color-level($color, 6));
-
-      text-decoration: underline;
-      background: none;
-      font-weight: bold;
-    }
+  .alert-#{$color} a,
+  .text-#{$color} a {
+    color: inherit;
+    text-decoration: underline;
+    background: none;
+    font-weight: bold;
   }
 }
 
@@ -57,6 +53,4 @@
   }
 }
 
-.gap-3 {
-  gap: $spacer;
-}
+// .gap-3 is now a built-in BS5 utility

--- a/tabbycat/templates/scss/modules/nav.scss
+++ b/tabbycat/templates/scss/modules/nav.scss
@@ -31,7 +31,7 @@
   background: none;
 
   &:hover {
-    color: theme-color("primary"); // Keep consistent with top level
+    color: $primary; // Keep consistent with top level
   }
   // Override standard dropdown highlights
   &.active,
@@ -84,7 +84,7 @@
     display: block;
 
     &:hover {
-      color: lighten(theme-color("primary"), 15%);
+      color: lighten($primary, 15%);
       text-decoration: none;
     }
 
@@ -158,23 +158,23 @@
 }
 
 .circle-done {
-  stroke: lighten(theme-color("success"), 20);
-  fill: theme-color("success");
+  stroke: lighten($success, 20%);
+  fill: $success;
 }
 
 .circle-todo {
-  stroke: lighten(theme-color("warning"), 20);
-  fill: theme-color("warning");
+  stroke: lighten($warning, 20%);
+  fill: $warning;
 }
 
 .circle-current {
-  stroke: lighten(theme-color("info"), 20);
-  fill: theme-color("info");
+  stroke: lighten($info, 20%);
+  fill: $info;
 }
 
 .circle-later {
-  stroke: lighten(theme-color("secondary"), 20);
-  fill: theme-color("secondary");
+  stroke: lighten($secondary, 20%);
+  fill: $secondary;
 }
 
 //------------------------------------------------------------------------------

--- a/tabbycat/templates/scss/modules/nav.scss
+++ b/tabbycat/templates/scss/modules/nav.scss
@@ -3,7 +3,7 @@
 //------------------------------------------------------------------------------
 
 .navbar-light {
-  background: $navbar-light-bg;
+  background: var(--bs-body-bg);
   border-bottom: 1px solid $navbar-light-border;
   border-top: 1px solid $navbar-light-border;
 

--- a/tabbycat/templates/scss/modules/nav.scss
+++ b/tabbycat/templates/scss/modules/nav.scss
@@ -76,6 +76,7 @@
   border-radius: 0;
   border-left: 0;
   border-right: 0;
+  border-color: darken($sidebar-bg, 5%);
   padding: 0;
 
   a,
@@ -308,7 +309,6 @@
     z-index: $z_2;
   }
 
-  .admin-sidebar .list-group .collapse.in,
   .admin-sidebar .list-group .collapsing,
   .admin-sidebar .list-group .collapse.show {
     z-index: $z_2;

--- a/tabbycat/templates/scss/modules/tables.scss
+++ b/tabbycat/templates/scss/modules/tables.scss
@@ -8,7 +8,7 @@
 
 .table {
   font-size: $font-size-sm;
-  background: $alt-bg; // For when tables blow out on mobile
+  background: var(--bs-body-bg); // For when tables blow out on mobile
   margin-bottom: 0; // Handled by the container elements
 
   th {
@@ -46,7 +46,7 @@ thead,
 
   font-size: $font-size-base;
   line-height: $font-size-base;
-  background: $alt-bg; // Fixed header needs a background while scrolling
+  background: var(--bs-body-bg); // Fixed header needs a background while scrolling
   min-height: 40px; // Must accomodate vue-sort key without resizing
   position: sticky;
   inset-block-start: 0;

--- a/tabbycat/templates/scss/modules/tables.scss
+++ b/tabbycat/templates/scss/modules/tables.scss
@@ -198,7 +198,7 @@ thead,
 
   // For highlighting bracket boundaries
   &.highlight-row {
-    border-top: 3px solid theme-color("info");
+    border-top: 3px solid $info;
   }
 
   // For highlighting boundaries between metrics in "draw with details"

--- a/tabbycat/templates/scss/modules/typography.scss
+++ b/tabbycat/templates/scss/modules/typography.scss
@@ -66,7 +66,7 @@ h6,
 }
 
 .list-group-item.active a {
-  color: $alt-bg; // If using a bg color; ensure the links aren't the same color
+  color: $white; // If using a bg color; ensure the links aren't the same color
   text-decoration: underline;
 }
 

--- a/tabbycat/templates/scss/modules/typography.scss
+++ b/tabbycat/templates/scss/modules/typography.scss
@@ -43,7 +43,7 @@ h6,
 
 // Mostly for hiding it in extra lines on table cells
 .hide-underline {
-  border-bottom: 2px solid #fff;
+  border-bottom: 2px solid var(--bs-body-bg);
 }
 
 .subtitle {
@@ -70,15 +70,4 @@ h6,
   text-decoration: underline;
 }
 
-// Bootstrap only displays up to .display-4; long motions need more options
-.display-5 {
-  @extend .display-4;
-
-  font-size: 3rem;
-}
-
-.display-6 {
-  @extend .display-4;
-
-  font-size: 2.5rem;
-}
+// BS5 natively provides .display-5 and .display-6

--- a/tabbycat/templates/scss/style.scss
+++ b/tabbycat/templates/scss/style.scss
@@ -28,6 +28,9 @@
 @import 'components/diversity-highlights';
 @import 'components/allocation-highlights';
 
+// Dark mode overrides (must come last)
+@import 'modules/dark-mode';
+
 //------------------------------------------------------------------------------
 // To Refactor
 //------------------------------------------------------------------------------

--- a/tabbycat/templates/tables/CellContent.vue
+++ b/tabbycat/templates/tables/CellContent.vue
@@ -38,7 +38,7 @@ const { getFeatherIcon } = useFeatherIcon(icon)
     <!-- Links and modals -->
     <div
       v-if="cellData.link || cellData.modal"
-      :data-toggle="cellData.tooltip ? tooltip : ''"
+      :data-bs-toggle="cellData.tooltip ? tooltip : ''"
       :title="cellData.tooltip"
     >
       <a
@@ -52,7 +52,7 @@ const { getFeatherIcon } = useFeatherIcon(icon)
       </a>
       <a
         v-if="cellData.modal"
-        :data-target="cellData.modal"
+        :data-bs-target="cellData.modal"
       >
         <span
           class="tooltip-trigger"
@@ -68,7 +68,7 @@ const { getFeatherIcon } = useFeatherIcon(icon)
     <!-- Standard -->
     <div
       v-else
-      :data-toggle="cellData.tooltip ? tooltip : ''"
+      :data-bs-toggle="cellData.tooltip ? tooltip : ''"
       :title="cellData.tooltip"
     >
       <span

--- a/tabbycat/templates/tables/CheckboxTablesContainer.vue
+++ b/tabbycat/templates/tables/CheckboxTablesContainer.vue
@@ -163,7 +163,7 @@ const massSelect = (state, type) => {
               v-if="roundInfo.prev"
               class="btn btn-primary"
               type="button"
-              data-toggle="tooltip"
+              data-bs-toggle="tooltip"
               :title="gettext(`Set all the availabilities to exactly match
                                      what they were in the previous round.`)"
               @click="copyFromPrevious"
@@ -173,7 +173,7 @@ const massSelect = (state, type) => {
             <button
               class="btn btn-primary"
               type="button"
-              data-toggle="tooltip"
+              data-bs-toggle="tooltip"
               :title="gettext('Set all availabilities to exactly match check-ins.')"
               @click="setFromCheckIns(true, true)"
             >
@@ -182,7 +182,7 @@ const massSelect = (state, type) => {
             <button
               class="btn btn-primary"
               type="button"
-              data-toggle="tooltip"
+              data-bs-toggle="tooltip"
               :title="gettext(`Set people who are checked in as available
                                      (leave people not checked in unchanged)`)"
               @click="setFromCheckIns(true, false)"
@@ -192,7 +192,7 @@ const massSelect = (state, type) => {
             <button
               class="btn btn-primary"
               type="button"
-              data-toggle="tooltip"
+              data-bs-toggle="tooltip"
               :title="gettext(`Set people who are not checked in as unavailable
                                      (leave people who are checked in unchanged)`)"
               @click="setFromCheckIns(false, true)"

--- a/tabbycat/templates/tables/SmartHeader.vue
+++ b/tabbycat/templates/tables/SmartHeader.vue
@@ -24,7 +24,7 @@ const showTooltip = (event) => {
   <th
     :class="['vue-sortable', 'sort-' + header.key]"
     :title="header.tooltip"
-    :data-toggle="header.tooltip ? 'tooltip' : null"
+    :data-bs-toggle="header.tooltip ? 'tooltip' : null"
     @click="resort(header.key)"
     @hover="header.tooltip ? showTooltip : null"
   >

--- a/tabbycat/templates/tables/SmartHeader.vue
+++ b/tabbycat/templates/tables/SmartHeader.vue
@@ -48,7 +48,7 @@ const showTooltip = (event) => {
         <span>{{ header.title }}</span>
       </div>
 
-      <div :class="['mr-auto', sortClasses(header['key'])]">
+      <div :class="['me-auto', sortClasses(header['key'])]">
         <i data-feather="chevrons-down" />
         <i data-feather="chevrons-up" />
       </div>

--- a/tabbycat/templates/tables/TablesContainer.vue
+++ b/tabbycat/templates/tables/TablesContainer.vue
@@ -55,9 +55,7 @@ const copyTableTrigger = (i) => {
           type="search"
           :placeholder="gettext('Find in Table')"
         >
-        <div class="input-group-append">
-          <span class="input-group-text"><i data-feather="search" /></span>
-        </div>
+        <span class="input-group-text"><i data-feather="search" /></span>
         <div
           v-for="(table, i) in tablesData"
           :key="i"

--- a/tabbycat/templates/tables/TablesContainer.vue
+++ b/tabbycat/templates/tables/TablesContainer.vue
@@ -63,8 +63,8 @@ const copyTableTrigger = (i) => {
           :key="i"
         >
           <button
-            class="btn btn-light border ml-2"
-            data-toggle="tooltip"
+            class="btn btn-light border ms-2"
+            data-bs-toggle="tooltip"
             title="Copy table data to clipboard in a CSV format"
             @click.prevent="copyTableTrigger(i)"
           >
@@ -82,9 +82,9 @@ const copyTableTrigger = (i) => {
     >
       <div
         :id="getTableId(i)"
-        class="card table-container pl-1"
+        class="card table-container ps-1"
       >
-        <div class="card-body pl-3 pr-0 py-2">
+        <div class="card-body ps-3 pe-0 py-2">
           <h4
             v-if="table.title"
             class="card-title mt-1 mb-2"

--- a/tabbycat/templates/tables/team.html
+++ b/tabbycat/templates/tables/team.html
@@ -1,6 +1,6 @@
 <span hidden>{{ team.short_name }}</span><!-- for sorting -->
 <span {% if pref.show_speakers_in_draw or 'admin/' in request.path %}
   title="{% if team.emoji %}<span class='emoji'>{{ team.emoji }}</span>{% endif %}{{ team.long_name }}"
-  data-toggle="popover"
+  data-bs-toggle="popover"
   id="team_speakers_{{ team.id }}"{% endif %}>
   {{ team.short_name }}</span>

--- a/tabbycat/tournaments/templates/blank_site_start.html
+++ b/tabbycat/tournaments/templates/blank_site_start.html
@@ -9,7 +9,7 @@
 {% block content %}
 
 <div class="row">
-  <div class="col-lg-8 ml-lg-auto mr-md-auto">
+  <div class="col-lg-8 ms-lg-auto me-md-auto">
 
     <div class="card">
 

--- a/tabbycat/tournaments/templates/round_complete_check.html
+++ b/tabbycat/tournaments/templates/round_complete_check.html
@@ -15,7 +15,7 @@
 
 
   {% if emails_sent %}
-    <a href="{% roundurl 'progress-email' %}" class="btn btn-outline-secondary" data-toggle="tooltip" title="{% trans "Emails have already been sent." %}">
+    <a href="{% roundurl 'progress-email' %}" class="btn btn-outline-secondary" data-bs-toggle="tooltip" title="{% trans "Emails have already been sent." %}">
   {% else %}
     <a href="{% roundurl 'progress-email' %}" class="btn btn-outline-primary active">
   {% endif %}

--- a/tabbycat/tournaments/templates/site_index.html
+++ b/tabbycat/tournaments/templates/site_index.html
@@ -80,15 +80,15 @@
       {% csrf_token %}
       <button type="submit" class="btn btn-link p-0 list-group-item-action text-primary">
         <div class="row align-items-center">
-          <div class="col-auto pr-1">
+          <div class="col-auto pe-1">
             <i data-feather="log-out"></i>
           </div>
 
-          <div class="col pl-0 pr-0">
+          <div class="col ps-0 pe-0">
             {% blocktrans %}Log Out ({{ user }}){% endblocktrans %}
           </div>
 
-          <div class="col-auto pr-1">
+          <div class="col-auto pe-1">
             <i data-feather="chevron-right"></i>
           </div>
         </div>

--- a/tabbycat/utils/tables.py
+++ b/tabbycat/utils/tables.py
@@ -299,7 +299,7 @@ class TabbycatTableBuilder(BaseTableBuilder):
         }
 
         if highlight:
-            cell['class'] += ' font-weight-bold table-secondary'
+            cell['class'] += ' fw-bold table-secondary'
         if subtext:
             cell['subtext'] = subtext
 

--- a/tabbycat/utils/templatetags/add_field_css.py
+++ b/tabbycat/utils/templatetags/add_field_css.py
@@ -1,11 +1,14 @@
 from django import template
-from django.forms import CheckboxSelectMultiple, RadioSelect
+from django.forms import CheckboxInput, CheckboxSelectMultiple, RadioSelect, Select
 
 register = template.Library()
 
 
 @register.filter(name='addcss')
 def addcss(field, css):
+    # BS5: selects need form-select, not form-control
+    if css == "form-control" and isinstance(field.field.widget, Select):
+        css = "form-select"
     return field.as_widget(attrs={"class": css})
 
 
@@ -13,6 +16,11 @@ def addcss(field, css):
 def is_choice_widget(field):
     widget = field.field.widget
     return isinstance(widget, (RadioSelect, CheckboxSelectMultiple))
+
+
+@register.filter(name='is_checkbox')
+def is_checkbox(field):
+    return isinstance(field.field.widget, CheckboxInput)
 
 
 @register.filter(name='addboundwidgetcss')

--- a/tabbycat/venues/templates/DraggableVenue.vue
+++ b/tabbycat/venues/templates/DraggableVenue.vue
@@ -93,7 +93,7 @@ const onVenueMouseLeave = () => {
   >
     <template #number>
       <span>
-        <small class="pl-2 vue-draggable-muted ">{{ item.priority }}</small>
+        <small class="ps-2 vue-draggable-muted ">{{ item.priority }}</small>
       </span>
     </template>
     <template #title>

--- a/tabbycat/venues/templates/EditDebateVenuesContainer.vue
+++ b/tabbycat/venues/templates/EditDebateVenuesContainer.vue
@@ -107,14 +107,14 @@ const unallocatedItems = container.unallocatedItems
         <template #default-highlights>
           <button
             class="btn conflictable conflicts-toolbar hover-adjudicator"
-            data-toggle="tooltip"
+            data-bs-toggle="tooltip"
             :title="gettext('This adjudicator or team has an unmet room constraint.')"
           >
             {{ gettext('Constraint') }}
           </button>
           <button
             class="btn panel-incomplete"
-            data-toggle="tooltip"
+            data-bs-toggle="tooltip"
             :title="gettext('Debate has no room.')"
           >
             {{ gettext('Incomplete') }}


### PR DESCRIPTION
Hey! 

Closes #2794.

This is a huge feature and in current state the PR is not ready, as many things should be reviewed due to BS5 breaking changes in style. 

### What was done

1. Bootstrap4 -> Bootstrap 5.3.x migration (mostly simple `sed` replacements), removed poppler.js from dep, now internal in BS5, removed jQuery for BS4 and wired native BS5 JavaScript API.
2. Implemented dark more and played with palette for decent result (see screenshots below)
3. Added Theme toggle in footer with Light/Auto/Dark modes and localStorage persistence so user choice is remembered. 
4. Removed several bugs and dead code

### What should be done 

- [ ] Fix all incorrect BS5 default settings which make UI worse (see settings panel for example)
- [ ] Decide on new UI look for some default elements (see checkbox to slider transition in setting as example)
- [ ] Enhance dark mode colors and verify no elements are left behind

Any help and reviews would be appreciated, more pages to be reviewed and improved.
<img width="3584" height="2192" alt="Screenshot 2026-04-29 at 01 51 53" src="https://github.com/user-attachments/assets/07443803-8a10-4b04-809d-0973029661ee" />
<img width="2478" height="1714" alt="Screenshot 2026-04-29 at 01 50 29" src="https://github.com/user-attachments/assets/da410b6f-cb23-403b-b229-d20782cb9d31" />
<img width="3584" height="2192" alt="Screenshot 2026-04-29 at 01 50 04" src="https://github.com/user-attachments/assets/0877cfe3-5503-47fc-8bf0-2c03ea620642" />
<img width="3584" height="2192" alt="Screenshot 2026-04-29 at 01 37 56" src="https://github.com/user-attachments/assets/208f7ee2-6c42-4c6d-aced-d777ed2f928f" />
<img width="3584" height="2274" alt="Screenshot 2026-04-29 at 01 37 04" src="https://github.com/user-attachments/assets/4b9a0856-7b81-4b6b-9b8e-09b8f48ee4c3" />
<img width="3584" height="2274" alt="Screenshot 2026-04-29 at 01 55 00" src="https://github.com/user-attachments/assets/11281bdb-2665-4a33-9271-29330cf78f3f" />
