### PR TITLE
Fixed Selenium testing

### DIFF
--- a/tabbycat/utils/tests.py
+++ b/tabbycat/utils/tests.py
@@ -6,7 +6,7 @@ from unittest import expectedFailure
 from django.contrib.auth import get_user, get_user_model
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from django.core.cache import cache
-from django.test import tag, TestCase
+from django.test import override_settings, tag, TestCase
 from django.urls import reverse
 from selenium.webdriver.chrome.webdriver import WebDriver
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
@@ -271,6 +271,13 @@ class BaseMinimalTournamentTestCase(TestCase):
 
 
 @tag('selenium') # Tagged so we can exclude from CI
+@override_settings( # StaticLiveServerTestCase uses debug static file paths
+    STORAGES={
+        "staticfiles": {
+            "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+        },
+    },
+)
 class SeleniumTestCase(StaticLiveServerTestCase):
     """Used to verify rendered html and javascript functionality on the site as
     rendered. Opens a Chrome window and checks for JS/DOM state on the fixture

--- a/tabbycat/utils/tests.py
+++ b/tabbycat/utils/tests.py
@@ -3,6 +3,7 @@ import logging
 from contextlib import contextmanager
 from unittest import expectedFailure
 
+from django.conf import settings
 from django.contrib.auth import get_user, get_user_model
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from django.core.cache import cache
@@ -272,7 +273,7 @@ class BaseMinimalTournamentTestCase(TestCase):
 
 @tag('selenium') # Tagged so we can exclude from CI
 @override_settings( # StaticLiveServerTestCase uses debug static file paths
-    STORAGES={
+    STORAGES=settings.STORAGES | {
         "staticfiles": {
             "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
         },


### PR DESCRIPTION
The SeleniumTestCase is a subclass of StaticLiveServerTestCase. StaticLiveServerTestCase starts a full Django server in the background that serves static files as though the server were running with Debug=True (e.g. serves from STATICFILES_DIRS instead of STATIC_ROOT) but templates HTML as though the server were running with Debug=False (e.g. uses paths to compressed static files in STATIC_ROOT instead of paths to uncompressed files in STATICFILES_DIRS). I have added a settings override for SeleniumTestCase that asks the server to template files with the paths to static files as they would be if Debug=True were set, and this fixes the discrepency without forcing the tester to run "dj collectstatic" with every test run.