### PR TITLE
Fix unwanted scrolling on draggable elements in Firefox

### DIFF
--- a/tabbycat/templates/allocations/DraggableItem.vue
+++ b/tabbycat/templates/allocations/DraggableItem.vue
@@ -61,7 +61,6 @@ const hideHovers = () => {
   <div
     draggable="true"
     :class="['d-flex m-1 align-items-center align-self-center', draggableClasses]"
-    @drag="drag"
     @dragstart="dragStart"
     @dragend="dragEnd"
     @mouseenter="showHovers"

--- a/tabbycat/templates/composables/useDraggable.js
+++ b/tabbycat/templates/composables/useDraggable.js
@@ -32,12 +32,15 @@ export function useDraggable (props) {
       event.dataTransfer.setData('text', JSON.stringify(props.dragPayload))
     }
     event.stopPropagation()
+    // Use 'dragover' on the window instead of 'drag' on the element because Firefox doesn't expose mouse position in 'drag'
+    window.addEventListener('dragover', drag)
   }
 
   const dragEnd = (event) => {
     isDragging.value = false
     scrollStop.value = true
     event.stopPropagation()
+    window.removeEventListener('dragover', drag)
   }
 
   const drag = (event) => {


### PR DESCRIPTION
In Firefox, the allocation screens scrolls up while you drag the judge/panel/room. This is due to Firefox not exposing mouse position in the drag event handler. It's a [very old bug](https://bugzilla.mozilla.org/show_bug.cgi?id=505521) that doesn't look like it's going to be fixed any time soon.

The fix is to subscribe to the `dragover` event on the whole window, which gives you [effectively the same result](https://bugzilla.mozilla.org/show_bug.cgi?id=505521#c95).

Tested on Linux+Wayland+KDE+(Firefox,Chromium) - I don't have anything else available at the moment, but I'll try to remember to test on some other platforms as soon as I'm back from the tournament.

Greetings from Prague Debate Spring!