### PR TITLE
Validate bulk email recipients and isolate failures

### DIFF
--- a/tabbycat/notifications/consumers.py
+++ b/tabbycat/notifications/consumers.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from dataclasses import asdict
 from email.utils import formataddr
 from time import time
@@ -19,6 +20,8 @@ from .utils import (AdjudicatorAssignmentEmailGenerator, BallotsEmailGenerator, 
                     MotionReleaseEmailGenerator, NotificationContextGenerator, RandomizedUrlEmailGenerator,
                     SlotsAllocatedEmailGenerator, StandingsEmailGenerator, TeamDrawEmailGenerator, TeamSpeakerEmailGenerator)
 
+logger = logging.getLogger(__name__)
+
 
 class NotificationQueueConsumer(SyncConsumer):
 
@@ -38,6 +41,8 @@ class NotificationQueueConsumer(SyncConsumer):
     @staticmethod
     def _send(messages: List[mail.EmailMultiAlternatives], records: List[SentMessage]) -> None:
         SentMessage.objects.bulk_create(records)
+        if not messages:
+            return
 
         connection = mail.get_connection(fail_silently=False)
         failed_events = []
@@ -103,23 +108,35 @@ class NotificationQueueConsumer(SyncConsumer):
         messages = []
         records = []
         for instance, recipient in contexts:
-            data = asdict(instance)
-            data['USER'] = recipient.name
-
             hook_id = str(bulk_notification.id) + "-" + str(recipient.id) + "-" + str(int(time()))[4:]
-            context = Context(data)
-            body = html_body.render(context)
-            email = mail.EmailMultiAlternatives(
-                subject=subject.render(context), body=html2text(body),
-                from_email=from_email, to=[formataddr((recipient.name.strip(), recipient.email))],
-                reply_to=reply_to, headers={
-                    'X-SMTPAPI': json.dumps({'unique_args': {'hook-id': hook_id}}),  # SendGrid-specific 'hook-id'
-                },
-            )
-            email.attach_alternative(body, "text/html")
-            messages.append(email)
+            data = None
+            try:
+                data = asdict(instance)
+                data['USER'] = recipient.name
 
-            raw_message = email.message()
+                context = Context(data)
+                body = html_body.render(context)
+                email = mail.EmailMultiAlternatives(
+                    subject=subject.render(context), body=html2text(body),
+                    from_email=from_email, to=[formataddr((recipient.name.strip(), recipient.email))],
+                    reply_to=reply_to, headers={
+                        'X-SMTPAPI': json.dumps({'unique_args': {'hook-id': hook_id}}),  # SendGrid-specific 'hook-id'
+                    },
+                )
+                email.attach_alternative(body, "text/html")
+                raw_message = email.message()
+            except Exception as e:
+                logger.warning("Failed to prepare email for recipient %s", recipient.id, exc_info=True)
+                failed_record = SentMessage.objects.create(
+                    recipient=recipient, email=recipient.email, method=SentMessage.METHOD_TYPE_EMAIL,
+                    context=data, hook_id=hook_id, notification=bulk_notification,
+                )
+                EmailStatus.objects.create(
+                    email=failed_record, event=EmailStatus.EventType.FAILED, data={'error': str(e)},
+                )
+                continue
+
+            messages.append(email)
             records.append(
                 SentMessage(recipient=recipient, email=recipient.email,
                             method=SentMessage.METHOD_TYPE_EMAIL,

--- a/tabbycat/notifications/tests/test_consumers.py
+++ b/tabbycat/notifications/tests/test_consumers.py
@@ -1,0 +1,57 @@
+from django.core import mail
+from django.test import override_settings, TestCase
+
+from notifications.consumers import NotificationQueueConsumer
+from notifications.models import BulkNotification, EmailStatus, SentMessage
+from participants.models import Adjudicator
+from tournaments.models import Tournament
+
+
+@override_settings(EMAIL_BACKEND='django.core.mail.backends.locmem.EmailBackend')
+class NotificationQueueConsumerTests(TestCase):
+
+    def setUp(self):
+        self.tournament = Tournament.objects.create(
+            name="Email Test Tournament", short_name="Email Test", slug="email-test",
+        )
+
+    def test_invalid_email_does_not_prevent_other_emails_sending(self):
+        valid_recipient = Adjudicator.objects.create(
+            tournament=self.tournament, name="Valid Recipient",
+            email="valid@example.com", url_key="valid-recipient",
+        )
+        invalid_recipient = Adjudicator.objects.create(
+            tournament=self.tournament, name="Invalid Recipient",
+            email="invalid@example.com\u200f", url_key="invalid-recipient",
+        )
+
+        NotificationQueueConsumer().email({
+            'type': 'email',
+            'message': BulkNotification.EventType.URL,
+            'extra': {
+                'tournament_id': self.tournament.id,
+                'url': 'https://example.com/private/',
+            },
+            'send_to': [valid_recipient.id, invalid_recipient.id],
+            'subject': 'Private URL for {{ USER }}',
+            'body': 'Your URL is {{ URL }}',
+        })
+
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].to, ['Valid Recipient <valid@example.com>'])
+
+        notification = BulkNotification.objects.get()
+        sent_messages = notification.sentmessage_set.order_by('recipient_id')
+        self.assertEqual(sent_messages.count(), 2)
+
+        valid_message = sent_messages.get(recipient=valid_recipient)
+        self.assertIsNotNone(valid_message.message_id)
+        self.assertFalse(valid_message.emailstatus_set.exists())
+
+        invalid_message = sent_messages.get(recipient=invalid_recipient)
+        self.assertIsNone(invalid_message.message_id)
+        failed_status = invalid_message.emailstatus_set.get()
+        self.assertEqual(failed_status.event, EmailStatus.EventType.FAILED)
+        self.assertTrue(failed_status.data['error'])
+
+        self.assertEqual(SentMessage.objects.count(), 2)

--- a/tabbycat/notifications/tests/test_views.py
+++ b/tabbycat/notifications/tests/test_views.py
@@ -1,0 +1,70 @@
+from unittest.mock import Mock, patch
+
+from django.contrib.messages import get_messages
+from django.contrib.messages.storage.fallback import FallbackStorage
+from django.test import RequestFactory, TestCase
+
+from notifications.forms import BasicEmailForm
+from notifications.models import BulkNotification
+from notifications.views import TemplateEmailCreateView
+from participants.models import Adjudicator
+from tournaments.models import Tournament
+
+
+class TemplateEmailCreateViewTests(TestCase):
+
+    def setUp(self):
+        self.tournament = Tournament.objects.create(
+            name="Email Test Tournament", short_name="Email Test", slug="email-test",
+        )
+        self.valid_recipient = Adjudicator.objects.create(
+            tournament=self.tournament, name="Valid Recipient", email="valid@example.com",
+        )
+        self.invalid_recipient = Adjudicator.objects.create(
+            tournament=self.tournament, name="Invalid Recipient", email="invalid@example.com\u200f",
+        )
+
+        self.request = RequestFactory().post('/')
+        self.request.session = {}
+        self.request._messages = FallbackStorage(self.request)
+
+        self.view = TemplateEmailCreateView()
+        self.view.request = self.request
+        self.view._tournament_from_url = self.tournament
+
+    def test_invalid_email_recipients_are_excluded_before_queueing(self):
+        recipient_ids = self.view.get_valid_email_recipient_ids([
+            self.valid_recipient.id, self.invalid_recipient.id,
+        ])
+
+        self.assertEqual(recipient_ids, [self.valid_recipient.id])
+        message = list(get_messages(self.request))[0]
+        self.assertIn(self.invalid_recipient.name, str(message))
+        self.assertIn("not queued", str(message))
+
+    @patch('notifications.views.get_channel_layer')
+    @patch('notifications.views.async_to_sync')
+    def test_form_only_queues_valid_email_recipients(self, mock_async_to_sync, mock_get_channel_layer):
+        self.request.POST = self.request.POST.copy()
+        self.request.POST.update({
+            'subject_line': 'Test subject',
+            'message_body': 'Test message',
+        })
+        self.request.POST.setlist('recipients', [
+            str(self.valid_recipient.id), str(self.invalid_recipient.id),
+        ])
+        form = BasicEmailForm(self.request.POST)
+        self.assertTrue(form.is_valid())
+
+        sender = Mock()
+        mock_async_to_sync.return_value = sender
+        self.view.event = BulkNotification.EventType.CUSTOM
+        self.view.get_extra = Mock(return_value={'tournament_id': self.tournament.id})
+        self.view.get_success_url = Mock(return_value='/')
+
+        self.view.form_valid(form)
+
+        mock_async_to_sync.assert_called_once_with(mock_get_channel_layer.return_value.send)
+        sender.assert_called_once()
+        event = sender.call_args.args[1]
+        self.assertEqual(event['send_to'], [self.valid_recipient.id])

--- a/tabbycat/notifications/views.py
+++ b/tabbycat/notifications/views.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from datetime import datetime, timezone
+from email.utils import formataddr
 from smtplib import SMTPException, SMTPResponseException
 from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
@@ -8,6 +9,8 @@ from asgiref.sync import async_to_sync
 from channels.layers import get_channel_layer
 from django.conf import settings
 from django.contrib import messages
+from django.core.exceptions import ValidationError
+from django.core.validators import validate_email
 from django.db.models import Prefetch, Q
 from django.http import HttpResponse
 from django.urls import reverse_lazy
@@ -252,7 +255,7 @@ class BaseSelectPeopleEmailView(AdministratorMixin, TournamentMixin, VueTableTem
         if email_count > 0:
             messages.success(self.request, text)
         else:
-            messages.warning(self.request, _("No emails were sent — likely because no recipients were selected."))
+            messages.warning(self.request, _("No emails were queued — likely because no valid recipients were selected."))
 
     def get_person_type(self, person: Person, **kwargs) -> str:
         return 'adj' if kwargs['mixed'] and hasattr(person, 'adjudicator') else 'spk'
@@ -316,20 +319,49 @@ class TemplateEmailCreateView(BaseSelectPeopleEmailView):
 
         return initial
 
+    def get_valid_email_recipient_ids(self, selected_ids: List[int]) -> List[int]:
+        recipients = self.get_queryset().in_bulk(selected_ids)
+        valid_ids = []
+        invalid_recipients = []
+
+        for recipient_id in selected_ids:
+            recipient = recipients.get(recipient_id)
+            if recipient is None:
+                continue
+            try:
+                validate_email(recipient.email)
+                formataddr((recipient.name.strip(), recipient.email))
+            except (ValidationError, UnicodeError, ValueError):
+                invalid_recipients.append(recipient)
+            else:
+                valid_ids.append(recipient_id)
+
+        if invalid_recipients:
+            recipient_names = ", ".join(recipient.name for recipient in invalid_recipients)
+            messages.warning(self.request, ngettext(
+                "The email to %(recipients)s was not queued because the email address is invalid.",
+                "Emails to %(recipients)s were not queued because their email addresses are invalid.",
+                len(invalid_recipients),
+            ) % {'recipients': recipient_names})
+
+        return valid_ids
+
     def form_valid(self, form: BasicEmailForm) -> 'HttpResponseRedirect':
         if hasattr(self, 'subject_template'):
             self.tournament.preferences[self.subject_template] = form.cleaned_data['subject_line']
             self.tournament.preferences[self.message_template] = form.cleaned_data['message_body']
-        email_recipients = list(map(int, self.request.POST.getlist('recipients')))
+        selected_ids = list(map(int, self.request.POST.getlist('recipients')))
+        email_recipients = self.get_valid_email_recipient_ids(selected_ids)
 
-        async_to_sync(get_channel_layer().send)("notifications", {
-            "type": "email",
-            "message": self.event,
-            "extra": self.get_extra(),
-            "send_to": email_recipients,
-            "subject": form.cleaned_data['subject_line'],
-            "body": form.cleaned_data['message_body'],
-        })
+        if email_recipients:
+            async_to_sync(get_channel_layer().send)("notifications", {
+                "type": "email",
+                "message": self.event,
+                "extra": self.get_extra(),
+                "send_to": email_recipients,
+                "subject": form.cleaned_data['subject_line'],
+                "body": form.cleaned_data['message_body'],
+            })
 
         self.add_sent_notification(len(email_recipients))
         return super().form_valid(form)


### PR DESCRIPTION
## Summary

This PR prevents malformed participant email addresses from disrupting bulk notifications by validating recipients before queueing and isolating unexpected failures during asynchronous processing.

**Problem:** Email recipient inputs bypass the Django form, and model saves do not automatically run field validators. A malformed stored address can therefore reach the notification consumer. If formatting one recipient's address raises an exception, the consumer exits before valid messages are persisted or sent, leaving an empty bulk notification with no indication of the problematic participant.

**Solution:** Preflight selected recipients synchronously using both Django email validation and the same address-header formatting used by the consumer. Invalid recipients are omitted from the queued event and named in an administrator warning, while valid recipients continue normally. The consumer also catches any remaining per-recipient preparation exception, records it as a failed message, and proceeds with the rest of the batch.

## Changes

### Modified Files

- **`tabbycat/notifications/views.py`**
  - Validates selected addresses before enqueueing notification events.
  - Uses `formataddr()` in addition to Django's validator because formatting characters such as a trailing `U+200F` pass `validate_email()` but cannot be encoded as an SMTP address.
  - Restricts submitted recipient IDs to the view's tournament-scoped queryset.
  - Warns administrators which participants were excluded and avoids queueing empty events.

- **`tabbycat/notifications/consumers.py`**
  - Isolates message construction and serialization errors per recipient.
  - Records preparation failures using the same failure-status model already used for SMTP-time errors.
  - Logs failed preparation using the recipient database ID and continues processing valid recipients.
  - Skips opening the email connection when no messages were successfully prepared.

### New Files

- **`tabbycat/notifications/tests/test_views.py`**
  - Verifies malformed recipients are rejected before queueing, administrators receive a warning, and queued events contain only valid tournament recipients.

- **`tabbycat/notifications/tests/test_consumers.py`**
  - Verifies a direct consumer event containing one valid recipient and one address with a trailing right-to-left mark still sends the valid email and records the malformed recipient as failed.

## Flow

1. Resolve submitted recipient IDs against the email view's permitted queryset.
2. Validate each stored address and confirm it can be formatted for an email header.
3. Warn about invalid recipients and queue only the valid IDs.
4. In the consumer, record any otherwise-unexpected preparation exception against that recipient and continue.
5. Send prepared messages through the existing per-message SMTP error handling.

## Security

- Submitted IDs are now resolved through the tournament-scoped queryset before queueing.
- Logs identify failed recipients by database ID rather than email address.
- Participant names in warnings remain plain template-escaped message content.
- Detailed exception data remains in existing administrator-facing email status records.

## Testing

- `python tabbycat/manage.py test notifications.tests -v 1`
- `flake8 tabbycat/notifications/consumers.py tabbycat/notifications/views.py tabbycat/notifications/tests/test_consumers.py tabbycat/notifications/tests/test_views.py` with the repository's configured plugins
- `git diff --check`

The full local suite was also attempted. It is blocked in this environment by the absent Selenium development dependency and two unrelated argparse message assertions under Python 3.13; the project declares Python 3.11.
