### PR TITLE
Fix postgres:18 volume mount path in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - POSTGRES_USER=tabbycat
       - POSTGRES_DB=tabbycat
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - pgdata:/var/lib/postgresql
 
   redis:
     image: redis:6


### PR DESCRIPTION
postgres:18+ images use a pg_ctlcluster-style, version-specific data directory layout and refuse to start when a volume is mounted directly at `/var/lib/postgresql/data`, even if that volume is empty.

This mounts the parent `/var/lib/postgresql` directory instead, so Postgres manages the versioned subdirectory itself — matching the image's own suggested configuration for `pg_upgrade --link` support.

Tested against a real deployment migrating from `postgres:12` to `postgres:18`: the `db` container failed to start with the old mount path (`Error: ... there appears to be PostgreSQL data in: /var/lib/postgresql/data (unused mount/volume)`) and started cleanly once switched to the parent directory.
