### PR TITLE
Add team column to speakers table on Private URL page

### DIFF
--- a/tabbycat/privateurls/views.py
+++ b/tabbycat/privateurls/views.py
@@ -93,14 +93,12 @@ class RandomisedUrlsView(RandomisedUrlsMixin, VueTableTemplateView):
         return table
 
     def get_speakers_table(self) -> TabbycatTableBuilder:
-        speakers = Speaker.objects.select_related('team').filter(team__tournament=self.tournament)
+        speakers = Speaker.objects.select_related('team').prefetch_related('team__speaker_set').filter(team__tournament=self.tournament)
         table = TabbycatTableBuilder(view=self, title=_("Speakers"), sort_key="name")
         table.add_speaker_columns(speakers, categories=False)
         table.add_column(
             {'key': 'team', 'tooltip': _("Team"), 'icon': 'users'},
-            [table._team_cell(speaker.team)
-                if not getattr(speaker.team, 'anonymise', False)
-                else table.BLANK_TEXT for speaker in speakers],
+            [table._team_cell(speaker.team, show_emoji=True) for speaker in speakers],
         )
         self.add_url_columns(table, speakers, self.request)
 

--- a/tabbycat/privateurls/views.py
+++ b/tabbycat/privateurls/views.py
@@ -93,9 +93,15 @@ class RandomisedUrlsView(RandomisedUrlsMixin, VueTableTemplateView):
         return table
 
     def get_speakers_table(self) -> TabbycatTableBuilder:
-        speakers = Speaker.objects.filter(team__tournament=self.tournament)
+        speakers = Speaker.objects.select_related('team').filter(team__tournament=self.tournament)
         table = TabbycatTableBuilder(view=self, title=_("Speakers"), sort_key="name")
         table.add_speaker_columns(speakers, categories=False)
+        table.add_column(
+            {'key': 'team', 'tooltip': _("Team"), 'icon': 'users'},
+            [table._team_cell(speaker.team)
+                if not getattr(speaker.team, 'anonymise', False)
+                else table.BLANK_TEXT for speaker in speakers],
+        )
         self.add_url_columns(table, speakers, self.request)
 
         return table


### PR DESCRIPTION
### What
Adds a "Team" column to the Speakers table on the Private URLs page, so tab staff can match a URL to its team without cross-referencing elsewhere.

### Why
With large speaker lists, the table currently only shows name + URL. No way to see the entire team's URLs at a glance. 

### Notes
- Reuses the existing `_team_cell` helper, so it respects `team_code_names` and anonymisation settings automatically, same as other admin tables.
- Added `select_related('team')` to avoid an N+1 query.

Tested locally with code names on and off.