### PR TITLE
Remove dead Global Settings link from options index

### DIFF
--- a/tabbycat/options/templates/preferences_index.html
+++ b/tabbycat/options/templates/preferences_index.html
@@ -77,11 +77,6 @@
       {% trans "Configures sending notifications, such as emails confirming ballot submissions or team points" as description %}
       {% include "components/item-action.html" with type="primary" emoji="📧" text=title extra=description %}
 
-      {% tournamenturl 'options-tournament-section' section='global' as url %}
-      {% trans "Global Settings" as title %}
-      {% trans "Settings which can affect all tournaments on the site" as description %}
-      {% include "components/item-action.html" with type="primary" emoji="🌏" text=title extra=description %}
-
     </ul>
   </div>
 


### PR DESCRIPTION
The 'global' preferences section was removed in upstream #2761 (Remove ability to disable the API), along with global_preferences_registry from TournamentPreferenceFormView.possible_registries, but the tile linking to it was left in place, causing a 404 on every tournament.