### PR TITLE
Fix 500 when an anonymous private-URL ballot is confirmed

### DIFF
--- a/tabbycat/results/views.py
+++ b/tabbycat/results/views.py
@@ -343,7 +343,7 @@ class BaseBallotSetView(LogActionMixin, TournamentMixin, FormView):
     def form_valid(self, form):
         self.ballotsub = form.save()
         if self.ballotsub.confirmed:
-            self.ballotsub.confirmer = self.request.user
+            self.ballotsub.confirmer = self.request.user if self.request.user.is_authenticated else None
             self.ballotsub.confirm_timestamp = timezone.now()
             self.ballotsub.save()
 


### PR DESCRIPTION
BaseBallotSetView.form_valid() unconditionally assigned request.user to ballotsub.confirmer whenever the ballot is confirmed. For ballots submitted through a participant's private URL (no login, e.g. a sole chair confirming their own ballot), request.user is AnonymousUser, which isn't a valid value for the nullable confirmer FK and crashes with a 500.

Found via load-testing on a throwaway loadtest tournament (BP format, ballots_per_debate_prelim=per-debate): every private-URL ballot confirmation by a single chair reproduced this. Confirmed live on the running server that the fix resolves it (302 instead of 500, ballotsub saved with confirmer=None).