### PR TITLE
BP Pullup Penalty Crash Fix

### DIFF
--- a/tabbycat/draw/tables.py
+++ b/tabbycat/draw/tables.py
@@ -238,6 +238,9 @@ class BasePositionBalanceReportTableBuilder(BaseDrawTableBuilder):
         return self.position_cost_func(pos, before) ** self.exponent
 
     def get_pullup_cost(self, team, bracket_level):
+        info = self.standings.get_standing(team)
+        team.points = next(info.itermetrics(), 0) or 0
+        team.npullups = info.metrics.get('npullups', 0)
         return BPHungarianDrawGenerator.get_pullup_cost(team, bracket_level, self.pullup_penalty)
 
     def get_assignment_cost(self, pos, team, bracket_level):

--- a/tabbycat/draw/views.py
+++ b/tabbycat/draw/views.py
@@ -460,7 +460,9 @@ class AdminDrawView(RoundMixin, AdministratorMixin, AdminDrawUtilitiesMixin, Vue
         side_histories_before = get_side_history(teams, self.tournament.sides, self.round.prev.seq)
         side_histories_now = get_side_history(teams, self.tournament.sides, self.round.seq)
         metrics = self.tournament.pref('team_standings_precedence')
-        generator = TeamStandingsGenerator(metrics[0:1], ())
+        pullup_penalty = self.tournament.pref('draw_pullup_penalty')
+        extra_metrics = ['npullups'] if pullup_penalty > 0 else []
+        generator = TeamStandingsGenerator(metrics[0:1], (), extra_metrics=extra_metrics)
         standings = generator.generate(teams, round=self.round.prev)
         draw_table = PositionBalanceReportDrawTableBuilder(view=self)
         draw_table.build(draw, teams, side_histories_before, side_histories_now, standings)


### PR DESCRIPTION
## Fix 500 crash on BP draw page when pullup penalty is enabled

### What
Setting a non-zero `draw_pullup_penalty` in Draw Rules breaks the draft draw page for BP tournaments. When one clicks on Generate Draw in Availability, the draw's draft status throws a 500. The draw itself is generated and saved fine (confirmed in the backend database), it was only the position-balance table on that page that failed. 

### Why 

`get_pullup_cost()` in `tables.py` expects `team.points` and `team.npullups` to already be set on the Team object, but nothing was actually setting them for the teams in this method. 