### PR TITLE
Add rounding for speaker scores in standings

### DIFF
--- a/tabbycat/standings/metrics.py
+++ b/tabbycat/standings/metrics.py
@@ -12,6 +12,10 @@ from django.db.models import Case, F, When
 
 logger = logging.getLogger(__name__)
 
+# Preserve differences from judge/round averages beyond the two displayed decimal
+# places, while removing floating-point noise before comparing standings metrics.
+SCORE_PRECISION = 6
+
 
 def metricgetter(items, negate=None):
     """Returns a callable object that fetches each item in `items` from its

--- a/tabbycat/standings/speakers.py
+++ b/tabbycat/standings/speakers.py
@@ -3,13 +3,13 @@
 import logging
 
 from django.db.models import Avg, Case, Count, F, FloatField, Max, Min, Q, StdDev, Sum, When
-from django.db.models.functions import Cast, NullIf
+from django.db.models.functions import Cast, NullIf, Round as RoundScore
 from django.utils.translation import gettext_lazy as _
 
 from tournaments.models import Round
 
 from .base import BaseStandingsGenerator
-from .metrics import QuerySetMetricAnnotator
+from .metrics import QuerySetMetricAnnotator, SCORE_PRECISION
 from .ranking import BasicRankAnnotator
 
 logger = logging.getLogger(__name__)
@@ -27,11 +27,16 @@ class SpeakerScoreQuerySetMetricAnnotator(QuerySetMetricAnnotator):
     replies = False
     field = 'speakerscore__score'
     where_value = None
+    round_value = True
 
     def get_annotation(self, round):
-        """Returns a QuerySet annotated with the metric given. All positional
-        arguments from the third onwards, and all keyword arguments, are passed
-        to get_annotation_metric_query_str()."""
+        annotation = self.get_aggregation(round)
+        if self.round_value:
+            return RoundScore(annotation, precision=SCORE_PRECISION)
+        return annotation
+
+    def get_aggregation(self, round):
+        """Build the unrounded aggregate so derived metrics round only once."""
 
         annotation_filter = Q(
             speakerscore__ballot_submission__confirmed=True,
@@ -50,6 +55,7 @@ class SpeakerScoreQuerySetMetricAnnotator(QuerySetMetricAnnotator):
 class TeamMetricQuerySetMetricAnnotator(SpeakerScoreQuerySetMetricAnnotator):
 
     combinable = False
+    round_value = False
 
     def get_annotation(self, round):
         """Returns a QuerySet annotated with the metric."""
@@ -171,6 +177,7 @@ class NumberOfSpeechesMetricAnnotator(SpeakerScoreQuerySetMetricAnnotator):
     name = _("number of speeches given")
     abbr = _("Num")
     function = Count
+    round_value = False
 
 
 class TotalReplyScoreMetricAnnotator(SpeakerScoreQuerySetMetricAnnotator):
@@ -210,6 +217,7 @@ class NumberOfRepliesMetricAnnotator(SpeakerScoreQuerySetMetricAnnotator):
     name = _("replies given")
     abbr = _("Num")
     function = Count
+    round_value = False
     replies = True
     listed = False
 
@@ -238,15 +246,15 @@ class TrimmedMeanSpeakerScoreMetricAnnotator(SpeakerScoreQuerySetMetricAnnotator
         return super().get_annotated_queryset(queryset, round=round)
 
     def get_annotation(self, round=None):
-        total = TotalSpeakerScoreMetricAnnotator().get_annotation(round)
-        highest = self.MaximumScore().get_annotation(round)
-        lowest = self.MinimumScore().get_annotation(round)
+        total = TotalSpeakerScoreMetricAnnotator().get_aggregation(round)
+        highest = self.MaximumScore().get_aggregation(round)
+        lowest = self.MinimumScore().get_aggregation(round)
 
-        return Case(
+        return RoundScore(Case(
             When(speech_count__gt=2, then=(total - highest - lowest) / (F('speech_count') - 2)),
             When(speech_count__gt=0, then=total / F('speech_count')),
             output_field=FloatField(),
-        )
+        ), precision=SCORE_PRECISION)
 
 
 class SpeakerScoreRankingsMetricAnnotator(SpeakerScoreQuerySetMetricAnnotator):
@@ -257,6 +265,7 @@ class SpeakerScoreRankingsMetricAnnotator(SpeakerScoreQuerySetMetricAnnotator):
     function = Sum
     ascending = True
     field = 'speakerscore__rank'
+    round_value = False
 
 
 # ==============================================================================

--- a/tabbycat/standings/teams.py
+++ b/tabbycat/standings/teams.py
@@ -1,18 +1,19 @@
 """Standings generator for teams."""
 
 import logging
+from builtins import round as builtins_round
 from statistics import mean
 
 from django.contrib.postgres.aggregates import ArrayAgg
 from django.db.models import Avg, Count, F, FloatField, PositiveIntegerField, Q, StdDev, Sum
-from django.db.models.functions import Cast, NullIf
+from django.db.models.functions import Cast, NullIf, Round as RoundScore
 from django.utils.translation import gettext_lazy as _
 
 from results.models import TeamScore
 from tournaments.models import Round
 
 from .base import BaseStandingsGenerator
-from .metrics import BaseMetricAnnotator, metricgetter, QuerySetMetricAnnotator, RepeatedMetricAnnotator
+from .metrics import BaseMetricAnnotator, metricgetter, QuerySetMetricAnnotator, RepeatedMetricAnnotator, SCORE_PRECISION
 from .ranking import BasicRankAnnotator, RankFromInstitutionAnnotator, SubrankAnnotator
 
 logger = logging.getLogger(__name__)
@@ -29,6 +30,7 @@ class TeamScoreQuerySetMetricAnnotator(QuerySetMetricAnnotator):
     function = None  # must be set by subclasses
     field = None  # must be set by subclasses
     output_field = None
+    round_value = False
 
     where_value = None
 
@@ -54,7 +56,10 @@ class TeamScoreQuerySetMetricAnnotator(QuerySetMetricAnnotator):
         return annotation_filter
 
     def get_annotation(self, round=None):
-        return self.function(self.get_field(), filter=self.get_annotation_filter(round), output_field=self.output_field)
+        annotation = self.function(self.get_field(), filter=self.get_annotation_filter(round), output_field=self.output_field)
+        if self.round_value:
+            return RoundScore(annotation, precision=SCORE_PRECISION)
+        return annotation
 
 
 class PointsMetricAnnotator(TeamScoreQuerySetMetricAnnotator):
@@ -90,6 +95,7 @@ class TotalSpeakerScoreMetricAnnotator(TeamScoreQuerySetMetricAnnotator):
 
     function = Sum
     field = "score"
+    round_value = True
 
 
 class AverageSpeakerScoreMetricAnnotator(TeamScoreQuerySetMetricAnnotator):
@@ -100,6 +106,7 @@ class AverageSpeakerScoreMetricAnnotator(TeamScoreQuerySetMetricAnnotator):
 
     function = Avg
     field = "score"
+    round_value = True
 
 
 class SpeakerScoreStandardDeviationMetricAnnotator(TeamScoreQuerySetMetricAnnotator):
@@ -111,6 +118,7 @@ class SpeakerScoreStandardDeviationMetricAnnotator(TeamScoreQuerySetMetricAnnota
 
     function = StdDev
     field = "score"
+    round_value = True
 
 
 class SumMarginMetricAnnotator(TeamScoreQuerySetMetricAnnotator):
@@ -121,6 +129,7 @@ class SumMarginMetricAnnotator(TeamScoreQuerySetMetricAnnotator):
 
     function = Sum
     field = "margin"
+    round_value = True
 
 
 class AverageMarginMetricAnnotator(TeamScoreQuerySetMetricAnnotator):
@@ -131,6 +140,7 @@ class AverageMarginMetricAnnotator(TeamScoreQuerySetMetricAnnotator):
 
     function = Avg
     field = "margin"
+    round_value = True
 
 
 class AverageIndividualScoreMetricAnnotator(TeamScoreQuerySetMetricAnnotator):
@@ -141,6 +151,7 @@ class AverageIndividualScoreMetricAnnotator(TeamScoreQuerySetMetricAnnotator):
 
     function = Avg
     combinable = False
+    round_value = True
 
     def get_field(self):
         return 'debateteam__speakerscore__score'
@@ -175,6 +186,7 @@ class AverageIndividualScoreMetricAnnotator(TeamScoreQuerySetMetricAnnotator):
 class BaseDrawStrengthMetricAnnotator(BaseMetricAnnotator):
 
     opponent_annotator = None
+    round_value = False
 
     def annotate(self, queryset, standings, round=None):
         if not queryset.exists():
@@ -193,7 +205,10 @@ class BaseDrawStrengthMetricAnnotator(BaseMetricAnnotator):
         teams_with_opponents = queryset.model.objects.annotate(opponent_ids=opponents_annotation)
         opponents_by_team = {team.id: team.opponent_ids or [] for team in teams_with_opponents}
 
-        opp_metric_queryset = self.opponent_annotator().get_annotated_queryset(
+        opponent_annotator = self.opponent_annotator()
+        # Round the final draw strength, not the individual opponents' totals.
+        opponent_annotator.round_value = False
+        opp_metric_queryset = opponent_annotator.get_annotated_queryset(
                 queryset[0].tournament.team_set.all(), round)
         opp_metric_queryset_teams = {team.id: team for team in opp_metric_queryset}
 
@@ -205,6 +220,8 @@ class BaseDrawStrengthMetricAnnotator(BaseMetricAnnotator):
                 opp_metric = getattr(opp_metric_queryset_teams[opponent_id], self.opponent_annotator.key)
                 if opp_metric is not None: # opp_metric is None when no debates have happened
                     draw_strength += opp_metric
+            if self.round_value:
+                draw_strength = builtins_round(draw_strength, SCORE_PRECISION)
             standings.add_metric(team, self.key, draw_strength)
 
 
@@ -262,6 +279,7 @@ class DrawStrengthBySpeakerScoreMetricAnnotator(BaseDrawStrengthMetricAnnotator)
     name = _("draw strength by total speaker score")
     abbr = _("DSS")
     opponent_annotator = TotalSpeakerScoreMetricAnnotator
+    round_value = True
 
 
 class TeamPullupsMetricAnnotator(TeamScoreQuerySetMetricAnnotator):

--- a/tabbycat/standings/tests/test_speakers.py
+++ b/tabbycat/standings/tests/test_speakers.py
@@ -1,0 +1,71 @@
+from django.test import TestCase
+
+from draw.models import Debate, DebateTeam
+from draw.types import DebateSide
+from participants.models import Speaker, Team
+from results.models import BallotSubmission, SpeakerScore
+from tournaments.models import Round, Tournament
+
+from ..speakers import SpeakerStandingsGenerator
+
+
+class TestSpeakerScoreRounding(TestCase):
+
+    def setUp(self):
+        self.tournament = Tournament.objects.create(slug='speaker-rounding', name='Speaker rounding')
+        self.speakers = []
+        for i in range(2):
+            team = Team.objects.create(tournament=self.tournament, reference=str(i))
+            self.speakers.append(Speaker.objects.create(team=team, name=str(i)))
+
+    def add_scores(self, scores, position=1):
+        for seq, pair in enumerate(zip(*scores), start=1):
+            rd = Round.objects.create(tournament=self.tournament, seq=seq, schedule_group=seq)
+            debate = Debate.objects.create(round=rd)
+            ballot = BallotSubmission.objects.create(debate=debate, confirmed=True)
+            for speaker, score, side in zip(self.speakers, pair, (DebateSide.AFF, DebateSide.NEG)):
+                dt = DebateTeam.objects.create(debate=debate, team=speaker.team, side=side)
+                SpeakerScore.objects.create(
+                    debate_team=dt, ballot_submission=ballot, speaker=speaker, position=position, score=score,
+                )
+
+    def standings(self, metric):
+        generator = SpeakerStandingsGenerator((metric,), ('rank',))
+        round = Round.objects.filter(tournament=self.tournament).select_related('tournament').order_by('-seq').first()
+        standings = generator.generate(Speaker.objects.filter(team__tournament=self.tournament), tournament=self.tournament, round=round)
+        return [standings.get_standing(speaker) for speaker in self.speakers]
+
+    def test_equal_averages_rank_together(self):
+        # The same three judge scores can produce different floats depending on
+        # their addition order, despite having exactly the same rational average.
+        first = (75.0 + 75.2 + 75.1) / 3
+        second = (75.2 + 75.1 + 75.0) / 3
+        self.assertNotEqual(first, second)
+        self.add_scores([[first] * 4, [second] * 4])
+        for metric in ('total', 'average', 'trimmed_mean', 'stdev'):
+            with self.subTest(metric=metric):
+                standings = self.standings(metric)
+                self.assertEqual(standings[0].metrics[metric], standings[1].metrics[metric])
+                for standing in standings:
+                    self.assertEqual(standing.rankings['rank'], (1, True))
+
+    def test_reply_averages_rank_together(self):
+        self.add_scores([[40.1, 40.1], [40.1 + 1e-12, 40.1 + 1e-12]],
+            position=self.tournament.reply_position)
+        for metric in ('replies_sum', 'replies_avg', 'replies_stddev'):
+            with self.subTest(metric=metric):
+                for standing in self.standings(metric):
+                    self.assertEqual(standing.rankings['rank'], (1, True))
+
+    def test_differences_smaller_than_display_precision_are_preserved(self):
+        self.add_scores([[75] * 10, [75] * 9 + [sum([75, 75, 75.1]) / 3]])
+        standings = self.standings('average')
+        self.assertEqual(format(standings[0].metrics['average'], '.2f'),
+            format(standings[1].metrics['average'], '.2f'))
+        self.assertEqual(standings[0].rankings['rank'], (2, False))
+        self.assertEqual(standings[1].rankings['rank'], (1, False))
+
+    def test_trimmed_mean_rounds_only_after_arithmetic(self):
+        self.add_scores([[70, 75 + 1/3, 76 + 1/3, 80], [70, 75, 76, 80]])
+        standings = self.standings('trimmed_mean')
+        self.assertEqual(standings[0].metrics['trimmed_mean'], 75.833333)

--- a/tabbycat/standings/tests/test_standings.py
+++ b/tabbycat/standings/tests/test_standings.py
@@ -112,6 +112,32 @@ class TestTrivialStandings(TestCase):
     def test_speaks_stddev(self):
         self._base_metric_test({'speaks_stddev': [.5, .5]})
 
+    def test_score_metrics_ignore_float_noise(self):
+        for team, score in ((self.team1, 75.1), (self.team2, 75.1 + 1e-12)):
+            TeamScore.objects.filter(debate_team__team=team).update(score=score, margin=score)
+        for metric in ('speaks_sum', 'speaks_avg', 'speaks_stddev', 'margin_sum', 'margin_avg', 'draw_strength_speaks'):
+            with self.subTest(metric=metric):
+                standings = self.get_standings(TeamStandingsGenerator((metric,), ('rank',)))
+                for team in (self.team1, self.team2):
+                    self.assertEqual(standings.get_standing(team).rankings['rank'], (1, True))
+
+    def test_individual_score_average_ignores_float_noise(self):
+        self.set_up_speaker_scores(1)
+        for team, score in ((self.team1, 75.1), (self.team2, 75.1 + 1e-12)):
+            SpeakerScore.objects.filter(debate_team__team=team).update(score=score)
+        standings = self.get_standings(TeamStandingsGenerator(('speaks_ind_avg',), ('rank',)))
+        for team in (self.team1, self.team2):
+            self.assertEqual(standings.get_standing(team).rankings['rank'], (1, True))
+
+    def test_score_average_preserves_sub_display_differences(self):
+        TeamScore.objects.filter(debate_team__team=self.team1).update(score=75)
+        TeamScore.objects.filter(debate_team__team=self.team2).update(score=75 + .1 / 30)
+        standings = self.get_standings(TeamStandingsGenerator(('speaks_avg',), ('rank',)))
+        first, second = [standings.get_standing(team) for team in (self.team1, self.team2)]
+        self.assertEqual(format(first.metrics['speaks_avg'], '.2f'), format(second.metrics['speaks_avg'], '.2f'))
+        self.assertEqual(first.rankings['rank'], (2, False))
+        self.assertEqual(second.rankings['rank'], (1, False))
+
     def test_draw_strength(self):
         # losing team has faced winning team twice, so draw strength is 2 * 2 = 4
         self._base_metric_test({'draw_strength': [0, 4]})


### PR DESCRIPTION
Adds rounding through SQL with 6 digits after the decimal point so that floating points don't affect the team or speaker standings. I chose 6 places to give some leeway with 0.1 score increments between many rounds.