### PR TITLE
Load the compiled Vue component styles

### DIFF
--- a/tabbycat/templates/base.html
+++ b/tabbycat/templates/base.html
@@ -40,6 +40,7 @@
   {% block extra-head %}{% endblock %}
 
   {% if not hmr %}
+  <link rel="stylesheet" type="text/css" href="{% static 'vue/assets/app.css' %}" />
   <link href="{% static 'vue/js/app.js' %}" rel=preload as=script>
   {% endif %}
 


### PR DESCRIPTION
Vite compiles the `<style>` blocks of single-file components to
`static/vue/assets/app.css`, but `base.html` only ever linked `app.js`, so those
styles are never served outside HMR dev mode.

This had no visible effect until now, because `app.css` was empty. The
elimination bracket added in ab26b45e6 is the first component to ship a scoped
style block, and it does all of its layout there.

### What it looks like without this

The bracket rooms lose `position: absolute`, stack in normal document flow, and
overflow a column that still reports its computed height, so the page footer is
drawn on top of the last rooms and the final quarterfinal is unreachable.

Measured on the current `develop` build with a 16-team BP break:

| | column height | lowest room bottom | footer top |
|---|---|---|---|
| without `app.css` | 544px | 910px | 725px |
| with `app.css` | 544px | 691px | 825px |

### The change

One `<link>`, inside the existing `{% if not hmr %}` guard so HMR mode is
untouched and the dev server keeps injecting its own styles.

Found while running an 88-team British Parliamentary tournament through the new
bracket view