### PR TITLE
Link teams on the elimination bracket to their record pages

### DIFF
--- a/tabbycat/breakqual/templates/EliminationBracketContainer.vue
+++ b/tabbycat/breakqual/templates/EliminationBracketContainer.vue
@@ -477,7 +477,10 @@ function connectorsForCol(idx) {
                   <span class="text-muted bracket-side-label">{{ sideLabel(t.side) }}</span>
                 </span>
                 <span class="bracket-col-name text-truncate">
-                  <template v-if="t.team">{{ t.team.short_name }}</template>
+                  <template v-if="t.team">
+                    <a v-if="t.team.url" :href="t.team.url">{{ t.team.short_name }}</a>
+                    <template v-else>{{ t.team.short_name }}</template>
+                  </template>
                   <span v-else class="text-muted">TBD</span>
                 </span>
               </div>

--- a/tabbycat/breakqual/views.py
+++ b/tabbycat/breakqual/views.py
@@ -411,10 +411,18 @@ class PublicEliminationBracketView(PublicTournamentPageMixin, SingleObjectFromTo
             break_rank__isnull=False,
         ).order_by('break_rank').select_related('team')
 
+        # Only link through to record pages if the tournament publishes them.
+        link_records = tournament.pref('public_record')
+
         breaking_teams_data = [
             {
                 'break_rank': bt.break_rank,
-                'team': {'id': bt.team_id, 'short_name': bt.team.short_name},
+                'team': {
+                    'id': bt.team_id,
+                    'short_name': bt.team.short_name,
+                    'url': reverse_tournament('participants-public-team-record', tournament,
+                        kwargs={'pk': bt.team_id}) if link_records else None,
+                },
             }
             for bt in breaking_teams
         ]


### PR DESCRIPTION
## Link teams on the elimination bracket to their record pages

Following on from the Facebook conversation with @tienne-B — making the bracket
page clickable through to each team's record.

### What it does

On the public elimination bracket, each team's name becomes a link to that team's
public record page. Everything else about the bracket is unchanged.

### The `public_record` gate

The link is only rendered when the tournament has `public_record` enabled. A
tournament that turns record pages off has decided spectators shouldn't reach
them, and the bracket shouldn't be a side door around that. When the preference
is off, `url` comes through as `null` and the name renders exactly as it does
today.

This mirrors what `TabbycatTableBuilder` already does for team columns
(`utils/tables.py`), so the bracket now behaves like the rest of the site.

### Implementation

The URL is reversed server-side in `PublicEliminationBracketView` and passed in
the existing `bracket_data` payload, rather than built in the component — the
component has no way to reverse Django URLs, and the preference check belongs on
the server anyway. Because `teamById` spreads the team object, the field is
available anywhere the component already uses a team.

### Tests

Two cases added to the existing `PublicEliminationBracketViewTest`:

- record pages enabled → every breaking team carries the reversed record URL
- record pages disabled → every breaking team carries `null`