### PR TITLE
Keep popovers open when they are opened by a tap

### DIFF
--- a/tabbycat/templates/tables/Popover.vue
+++ b/tabbycat/templates/tables/Popover.vue
@@ -23,6 +23,20 @@ const hoveringPopOver = ref(false)
 const popperInstance = ref(null)
 const uid = ref(Math.floor(Math.random() * 1000000))
 
+// Touch devices emit a compatibility mouse sequence after a tap
+// (mouseover/mouseenter, then mouseout/mouseleave). Letting those reach the
+// hover handlers closes a popover the tap has just opened, within a few
+// milliseconds, so a tap appears to do nothing at all.
+const lastPointerType = ref('mouse')
+
+const notePointerType = (event) => {
+  if (event?.pointerType) {
+    lastPointerType.value = event.pointerType
+  }
+}
+
+const isTouchPointer = () => ['touch', 'pen'].includes(lastPointerType.value)
+
 const setHoveringPopOver = (value) => {
   hoveringPopOver.value = value
 }
@@ -35,12 +49,16 @@ const hidePopOver = (force = false) => {
 }
 
 const togglePopOver = (event) => {
-  if (event && (event.pointerType === 'touch' || event.pointerType === 'pen')) {
-    if (showingPopOver.value) {
-      setTimeout(() => hidePopOver(), 150)
-    } else {
-      showingPopOver.value = true
-    }
+  notePointerType(event)
+  if (!isTouchPointer()) {
+    return
+  }
+  if (showingPopOver.value) {
+    setTimeout(() => hidePopOver(true), 150)
+  } else {
+    // Same path as hovering: register so other popovers close, and let the
+    // placement be recalculated, which cannot happen while it is hidden.
+    showPopOver()
   }
 }
 
@@ -48,6 +66,28 @@ const showPopOver = () => {
   registerPopover(uid.value)
   popperInstance.value?.setOptions?.({ placement: 'bottom' })
   showingPopOver.value = true
+}
+
+const onHoverEnter = () => {
+  if (isTouchPointer()) {
+    return
+  }
+  showPopOver()
+}
+
+const onHoverLeave = () => {
+  if (isTouchPointer()) {
+    return
+  }
+  hidePopOver()
+}
+
+const onPopOverLeave = () => {
+  if (isTouchPointer()) {
+    return
+  }
+  setHoveringPopOver(false)
+  hidePopOver()
 }
 
 watch(activePopoverUid, () => {
@@ -80,12 +120,14 @@ onBeforeUnmount(() => {
   <div
     ref="container"
     class="touch-target"
+    @pointerenter="notePointerType"
+    @pointerdown="notePointerType"
     @pointerup="togglePopOver"
   >
     <div
       class="hover-target"
-      @mouseenter="showPopOver"
-      @mouseleave="hidePopOver"
+      @mouseenter="onHoverEnter"
+      @mouseleave="onHoverLeave"
     >
       <slot>
         {{ cellData.content }}
@@ -97,7 +139,7 @@ onBeforeUnmount(() => {
         class="popover bs-popover-bottom"
         role="tooltip"
         @mouseenter="setHoveringPopOver(true)"
-        @mouseleave="setHoveringPopOver(false); hidePopOver()"
+        @mouseleave="onPopOverLeave"
       >
         <div class="popover-header d-flex">
           <h6


### PR DESCRIPTION
On a touch device, tapping a name in a table opens its popover and then closes
it again a few milliseconds later. The popover appears not to work at all, and
the record link inside it cannot be reached — you end up tapping repeatedly, or
zooming, until something sticks.

### Cause

Touch devices emit a compatibility mouse sequence after a tap: `mouseover` and
`mouseenter`, then `mouseout` and `mouseleave`. The popover opens on
`pointerup` and closes on `mouseleave`, so a single tap runs both. Measured on
a 390px viewport:

```
16ms  pointerdown (touch)   popover hidden
17ms  pointerup   (touch)   opens
21ms  mouseenter  (compat)
24ms  click       (touch)
25ms  mouseleave  (compat)  closes
```

Each path is correct on its own; the failure only exists because phones run
both.

### Changes

The component records the pointer type of the last interaction and skips the
hover handlers when it was a touch or a pen, so the synthesised mouse events
cannot dismiss a popover a tap has just opened. Hovering with a mouse is
unaffected.

The touch path also now goes through `showPopOver()` instead of setting
`showingPopOver` directly, which it arguably should always have done. That
does two things it was missing:

- `registerPopover()`, so opening one popover closes any other
- a Popper recalculation — popovers are created while hidden, so their
  position cannot be measured at mount. Without a recalculation a tapped
  popover was drawn from a stale position (`inset: 0px auto auto 0px`,
  `data-popper-reference-hidden`) with the mount-time `right-end` placement
  rather than below the name.

### Verification

There is no JS test harness in the project, so this was checked by hand in
Chromium.

On a 390px touch viewport, `/admin/participants/list/`:

| | before | after |
|---|---|---|
| popover after tap | closes in ~8ms | 