### PR TITLE
Add iCalendar exports for tournament schedules

### DIFF
--- a/tabbycat/tournaments/templates/public_tournament_schedule.html
+++ b/tabbycat/tournaments/templates/public_tournament_schedule.html
@@ -1,11 +1,22 @@
 {% extends 'tables/base_vue_table.html' %}
-{% load i18n %}
+{% load debate_tags i18n %}
 
 {% block content %}
 {% blocktrans trimmed asvar p1 %}
 Schedule is in time zone: {{ schedule_timezone_label }}
 {% endblocktrans %}
+{% tournamenturl 'tournament-public-schedule-ical' as calendar_url %}
+{% blocktrans trimmed asvar p2 %}
+Download the iCalendar file to add these events to your calendar app.
+{% endblocktrans %}
 {% include "components/explainer-card.html" with type="info" %}
+
+<p>
+  <a class="btn btn-outline-primary" href="{{ calendar_url }}">
+    <i data-feather="calendar"></i>
+    {% trans "Add schedule to calendar" %}
+  </a>
+</p>
 
 
 {{ block.super }}

--- a/tabbycat/tournaments/tests/test_schedule.py
+++ b/tabbycat/tournaments/tests/test_schedule.py
@@ -1,6 +1,8 @@
 import json
 from datetime import datetime
+from zoneinfo import ZoneInfo
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.utils import formats, timezone
@@ -221,3 +223,59 @@ class SetTournamentScheduleViewTest(TestCase):
         self.assertEqual(tables[0]['data'][0][1]['text'], formats.time_format(
             timezone.localtime(first.start_time), format='TIME_FORMAT', use_l10n=True,
         ))
+
+    def test_public_schedule_links_to_icalendar_export(self):
+        self.tournament.preferences['public_features__public_schedule'] = True
+
+        response = self.client.get(reverse_tournament('tournament-public-schedule', self.tournament))
+
+        export_url = reverse_tournament('tournament-public-schedule-ical', self.tournament)
+        self.assertContains(response, export_url)
+        self.assertContains(response, 'Add schedule to calendar')
+
+    def test_public_schedule_icalendar_export(self):
+        event = ScheduleEvent.objects.create(
+            tournament=self.tournament,
+            type=ScheduleEvent.Types.OTHER,
+            title='Lunch, networking; and Q&amp;A\\notes',
+            start_time=timezone.make_aware(datetime(2026, 8, 15, 9)),
+            end_time=timezone.make_aware(datetime(2026, 8, 15, 10, 30)),
+        )
+        self.tournament.preferences['public_features__public_schedule'] = True
+
+        response = self.client.get(reverse_tournament('tournament-public-schedule-ical', self.tournament))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-Type'], 'text/calendar; charset=utf-8')
+        self.assertEqual(
+            response['Content-Disposition'],
+            f'attachment; filename="{self.tournament.slug}-schedule.ics"',
+        )
+        content = response.content.decode('utf-8')
+        self.assertTrue(content.startswith('BEGIN:VCALENDAR\r\nVERSION:2.0\r\n'))
+        self.assertTrue(content.endswith('END:VCALENDAR\r\n'))
+        self.assertIn(f'UID:schedule-event-{event.pk}-{self.tournament.slug}@testserver\r\n', content)
+        self.assertIn(f'DTSTART;TZID={settings.TIME_ZONE}:', content)
+        self.assertIn(f'DTEND;TZID={settings.TIME_ZONE}:', content)
+        site_timezone = ZoneInfo(settings.TIME_ZONE)
+        expected_start = event.start_time.astimezone(site_timezone).strftime('%Y%m%dT%H%M%S')
+        expected_end = event.end_time.astimezone(site_timezone).strftime('%Y%m%dT%H%M%S')
+        self.assertIn(f'DTSTART;TZID={settings.TIME_ZONE}:{expected_start}\r\n', content)
+        self.assertIn(f'DTEND;TZID={settings.TIME_ZONE}:{expected_end}\r\n', content)
+        self.assertIn(f'X-WR-TIMEZONE:{settings.TIME_ZONE}\r\n', content)
+        self.assertIn(r'SUMMARY:Lunch\, networking\; and Q&amp\;A\\notes', content)
+
+    def test_public_schedule_icalendar_export_omits_missing_end_time(self):
+        self.create_event('Registration', 15, 9)
+        self.tournament.preferences['public_features__public_schedule'] = True
+
+        response = self.client.get(reverse_tournament('tournament-public-schedule-ical', self.tournament))
+
+        self.assertNotIn('DTEND:', response.content.decode('utf-8'))
+
+    def test_public_schedule_icalendar_export_obeys_public_preference(self):
+        self.tournament.preferences['public_features__public_schedule'] = False
+
+        response = self.client.get(reverse_tournament('tournament-public-schedule-ical', self.tournament))
+
+        self.assertEqual(response.status_code, 403)

--- a/tabbycat/tournaments/urls.py
+++ b/tabbycat/tournaments/urls.py
@@ -28,7 +28,11 @@ urlpatterns = [
     path('registration/',           include('registration.urls_public')),
 
     # Public Schedule
-    path('schedule/',               views.PublicScheduleView.as_view(), name='tournament-public-schedule'),
+    path('schedule/', include([
+        path('', views.PublicScheduleView.as_view(), name='tournament-public-schedule'),
+        path('calendar.ics', views.PublicScheduleICalendarView.as_view(),
+            name='tournament-public-schedule-ical'),
+    ])),
 
     # Application URLs for admin pages
     path('admin/allocations/',      include('adjallocation.urls')),

--- a/tabbycat/tournaments/views.py
+++ b/tabbycat/tournaments/views.py
@@ -7,13 +7,14 @@ from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import get_user_model
 from django.db.models import Count, Q
-from django.http import HttpResponseRedirect
+from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import redirect, resolve_url
 from django.utils import formats, timezone
 from django.utils.encoding import force_str
 from django.utils.html import format_html_join
 from django.utils.timezone import get_current_timezone_name
 from django.utils.translation import gettext_lazy as _
+from django.views.generic import View
 from django.views.generic.base import TemplateView
 from django.views.generic.edit import FormView, UpdateView
 from formtools.wizard.views import SessionWizardView
@@ -28,6 +29,7 @@ from results.models import BallotSubmission
 from results.prefetch import populate_confirmed_ballots
 from tournaments.models import Round
 from users.permissions import has_permission, Permission
+from utils.ical import ICalendar
 from utils.misc import redirect_round, redirect_tournament, reverse_round, reverse_tournament
 from utils.mixins import (AdministratorMixin, AssistantMixin, CacheMixin, TabbycatPageTitlesMixin,
                           WarnAboutDatabaseUseMixin, WarnAboutLegacySendgridConfigVarsMixin)
@@ -602,3 +604,32 @@ class PublicScheduleView(PublicTournamentPageMixin, VueTableTemplateView):
         context = super().get_context_data(**kwargs)
         context['schedule_timezone_label'] = get_current_timezone_name()
         return context
+
+
+class PublicScheduleICalendarView(PublicTournamentPageMixin, View):
+    """Expose the public tournament schedule as an iCalendar feed."""
+
+    cache_timeout = settings.PUBLIC_SLOW_CACHE_TIMEOUT
+    public_page_preference = 'public_schedule'
+
+    def get(self, request, *args, **kwargs):
+        schedule_url = request.build_absolute_uri(
+            reverse_tournament('tournament-public-schedule', self.tournament),
+        )
+        calendar = ICalendar(
+            name=_("%(tournament)s Schedule") % {'tournament': self.tournament.name},
+            timezone_name=settings.TIME_ZONE,
+            prodid='-//Tabbycat//Tournament Schedule//EN',
+        )
+        for event in self.tournament.scheduleevent_set.select_related('round'):
+            calendar.add_event(
+                uid=f'schedule-event-{event.pk}-{self.tournament.slug}@{request.get_host()}',
+                start=event.start_time,
+                end=event.end_time,
+                summary=event.display_title,
+                url=schedule_url,
+            )
+
+        response = HttpResponse(calendar.to_ical(), content_type='text/calendar; charset=utf-8')
+        response['Content-Disposition'] = f'attachment; filename="{self.tournament.slug}-schedule.ics"'
+        return response

--- a/tabbycat/utils/ical.py
+++ b/tabbycat/utils/ical.py
@@ -1,0 +1,85 @@
+from datetime import UTC
+from zoneinfo import ZoneInfo
+
+from django.utils import timezone
+from django.utils.encoding import force_str
+
+
+def _escape_text(value):
+    """Escape a text value as required by RFC 5545."""
+    return (force_str(value).replace('\\', '\\\\').replace('\r\n', '\\n')
+            .replace('\r', '\\n').replace('\n', '\\n')
+            .replace(';', '\\;').replace(',', '\\,'))
+
+
+def _fold_line(line):
+    """Fold a content line without splitting UTF-8 characters."""
+    folded = []
+    current = ''
+    limit = 75
+    for character in line:
+        if current and len((current + character).encode('utf-8')) > limit:
+            folded.append(current)
+            current = character
+            limit = 74  # Continuation lines begin with one whitespace octet.
+        else:
+            current += character
+    folded.append(current)
+    return '\r\n '.join(folded)
+
+
+def _format_datetime(value, tz):
+    if timezone.is_naive(value):
+        value = timezone.make_aware(value, tz)
+    return value.astimezone(tz).strftime('%Y%m%dT%H%M%S')
+
+
+class ICalendar:
+    """A small iCalendar writer for calendars containing timed events."""
+
+    def __init__(self, name, timezone_name, prodid):
+        self.name = name
+        self.timezone_name = timezone_name
+        self.prodid = prodid
+        self.events = []
+
+    def add_event(self, uid, start, summary, url=None, end=None):
+        self.events.append({
+            'uid': uid,
+            'start': start,
+            'summary': summary,
+            'url': url,
+            'end': end,
+        })
+
+    def to_ical(self):
+        calendar_timezone = ZoneInfo(self.timezone_name)
+        timestamp = _format_datetime(timezone.now(), UTC) + 'Z'
+        lines = [
+            'BEGIN:VCALENDAR',
+            'VERSION:2.0',
+            f'PRODID:{self.prodid}',
+            'CALSCALE:GREGORIAN',
+            'METHOD:PUBLISH',
+            f'X-WR-CALNAME:{_escape_text(self.name)}',
+            f'X-WR-TIMEZONE:{self.timezone_name}',
+        ]
+
+        for event in self.events:
+            lines.extend([
+                'BEGIN:VEVENT',
+                f'UID:{event["uid"]}',
+                f'DTSTAMP:{timestamp}',
+                f'DTSTART;TZID={self.timezone_name}:{_format_datetime(event["start"], calendar_timezone)}',
+            ])
+            if event['end']:
+                lines.append(
+                    f'DTEND;TZID={self.timezone_name}:{_format_datetime(event["end"], calendar_timezone)}',
+                )
+            lines.append(f'SUMMARY:{_escape_text(event["summary"])}')
+            if event['url']:
+                lines.append(f'URL:{event["url"]}')
+            lines.append('END:VEVENT')
+
+        lines.append('END:VCALENDAR')
+        return '\r\n'.join(_fold_line(line) for line in lines) + '\r\n'


### PR DESCRIPTION
## Problem

Participants can view a structured public tournament schedule, but cannot add it to their calendar app without recreating each event manually. This is inconvenient and can introduce timezone mistakes.

Fixes #2424.

## Solution

Add a public `.ics` export alongside the existing schedule page. The feed identifies event times with the site’s IANA timezone and remains protected by the public schedule preference. The schedule page now links directly to the export.

The compact exporter handles iCalendar text escaping, UTF-8 line folding, and CRLF serialization without adding a runtime dependency.

## Testing

1. Enable the public tournament schedule and create events with and without end times.
2. Open the public schedule and select **Add schedule to calendar**.
3. Import the downloaded file into a calendar app and confirm event titles, site-local times, and optional end times are correct.
4. Disable the public schedule and confirm that both the schedule page and calendar export are unavailable.