### PR TITLE
Add pullup flag to lower-bracket team in intermediate brackets

### DIFF
--- a/tabbycat/draw/generator/common.py
+++ b/tabbycat/draw/generator/common.py
@@ -95,6 +95,15 @@ class BaseDrawGenerator:
         flags = self.team_flags.setdefault(team, list())
         flags.append(flag)
 
+    def remove_team_flag(self, team, flag):
+        """Removes a previously-attached flag from a team, if present.
+        Used when a team's bracket placement changes after a flag was
+        provisionally added (e.g. bubble down swaps a team out of the
+        pullup role in an intermediate bracket)."""
+        flags = self.team_flags.get(team)
+        if flags and flag in flags:
+            flags.remove(flag)
+
     def annotate_team_flags(self, pairings):
         """Applies the team flags to the pairings given.
         Child classes that use team flags should call this method as the last

--- a/tabbycat/draw/generator/powerpair.py
+++ b/tabbycat/draw/generator/powerpair.py
@@ -211,14 +211,15 @@ class BasePowerPairedDrawGenerator(BasePairDrawGenerator):
         if pullup_needed_for:
             raise DrawFatalError("Last bracket is still odd!\n" + repr(pullup_needed_for))
 
-    @classmethod
-    def _intermediate_brackets(cls, brackets):
+    def _intermediate_brackets(self, brackets):
         """Operates in-place."""
         new = OrderedDict()
         odd_team = None
         for points, teams in brackets.items():
             if odd_team:
-                new[points+0.5] = [odd_team, teams.pop(0)]
+                pullup_team = teams.pop(0)
+                new[points+0.5] = [odd_team, pullup_team]
+                self.add_team_flag(pullup_team, "pullup")
                 odd_team = None
             if len(teams) % 2 != 0:
                 odd_team = teams.pop()
@@ -276,6 +277,8 @@ class BasePowerPairedDrawGenerator(BasePairDrawGenerator):
                 if not _check_conflict(swap_team, teams[0]):
                     self.add_team_flag(teams[1], (conflict == 1) and "bub_dn_inst" or "bub_dn_hist")
                     self.add_team_flag(swap_team, "bub_dn_accom")
+                    self.remove_team_flag(teams[1], "pullup")
+                    self.add_team_flag(swap_team, "pullup")
                     teams[1], brackets[points-0.5][0] = swap_team, teams[1]
                     continue
 

--- a/tabbycat/draw/tests/test_generator.py
+++ b/tabbycat/draw/tests/test_generator.py
@@ -390,16 +390,16 @@ class TestPowerPairedDrawGenerator(unittest.TestCase):
 
     expected[2] = [dict(
         odd_bracket="intermediate_bubble_up_down", pairing_method="slide", avoid_conflicts="one_up_one_down", side_allocations="balance"),
-        [(12, 2, [], [], [], True),
+        [(12, 2, [], [], ['pullup'], True),
          (3, 17, [], [], [], True),  # institution conflict, but swapping
                              # would give history conflict
          (11, 14, ["1u1d_inst"], [], [], True),
          (6, 4, ["1u1d_other"], [], [], False),
-         (8, 7, [], [], [], True),
+         (8, 7, [], [], ['pullup'], True),
          (9, 22, [], [], [], True),
          (15, 23, [], [], [], True),
          (18, 24, [], [], [], False),
-         (1, 25, [], [], [], False),
+         (1, 25, [], ['pullup'], [], False),
          (5, 20, [], [], [], False),
          (10, 21, [], [], [], False),
          (16, 26, [], [], ["bub_up_hist"], True),

--- a/tabbycat/draw/tests/test_generator.py
+++ b/tabbycat/draw/tests/test_generator.py
@@ -121,8 +121,8 @@ class TestPowerPairedDrawGeneratorParts(unittest.TestCase):
         # Set up the brackets
         for p, b in b2.items():
             for i, x in enumerate(b):
-                if isinstance(x[-1], str) and len(x) > 2:
-                    flags = [x[-1]]
+                if isinstance(x[-1], (str, list)) and len(x) > 2:
+                    flags = [x[-1]] if isinstance(x[-1], str) else x[-1]
                     x = x[:-1]
                 else:
                     flags = None
@@ -150,8 +150,8 @@ class TestPowerPairedDrawGeneratorParts(unittest.TestCase):
     def test_intermediate_brackets_avoid_conflicts_1(self):
         brackets = OrderedDict([
             (4, [(1, 'A'), (2, 'B'), (3, 'C'), (4, 'A', 'bub_up_accom'), (5, 'C', 12, 'bub_up_inst')]),
-            (3, [(6, 'C'), (7, 'D'), (8, 'A', 10), (9, 'B', 10)]),
-            (2, [(10, 'D', 8, 9, 'bub_dn_hist'), (11, 'A', 'bub_dn_accom'), (12, 'C', 5), (13, 'B'), (14, 'C', 15)]),
+            (3, [(6, 'C', 'pullup'), (7, 'D'), (8, 'A', 10), (9, 'B', 10)]),
+            (2, [(10, 'D', 8, 9, 'bub_dn_hist'), (11, 'A', ['bub_dn_accom', 'pullup']), (12, 'C', 5), (13, 'B'), (14, 'C', 15)]),
             (1, [(15, 'C', 14), (16, 'C')]),
         ])
         expected = OrderedDict([
@@ -167,8 +167,8 @@ class TestPowerPairedDrawGeneratorParts(unittest.TestCase):
     def test_intermediate_brackets_avoid_conflicts_2(self):
         brackets = OrderedDict([
             (4, [(1, 'A'), (2, 'B'), (3, 'C'), (4, 'A', 'bub_up_accom'), (5, 'C', 12, 'bub_up_inst')]),
-            (3, [(6, 'C'), (7, 'D'), (8, 'A', 'bub_up_accom'), (9, 'B', 10, 'bub_up_hist')]),
-            (2, [(10, 'D', 9), (11, 'A'), (12, 'C', 5), (13, 'B'), (14, 'C', 15)]),
+            (3, [(6, 'C', 'pullup'), (7, 'D'), (8, 'A', 'bub_up_accom'), (9, 'B', 10, 'bub_up_hist')]),
+            (2, [(10, 'D', 9, 'pullup'), (11, 'A'), (12, 'C', 5), (13, 'B'), (14, 'C', 15)]),
             (1, [(15, 'C', 14), (16, 'C')]),
         ])
         expected = OrderedDict([
@@ -184,8 +184,8 @@ class TestPowerPairedDrawGeneratorParts(unittest.TestCase):
     def test_intermediate_brackets_avoid_conflicts_3(self):
         brackets = OrderedDict([
             (4, [(1, 'A'), (2, 'B'), (3, 'C'), (4, 'A', 'bub_up_accom'), (5, 'C', 12, 'bub_up_inst')]),
-            (3, [(6, 'C'), (7, 'D'), (8, 'D'), (9, 'B', 10)]),
-            (2, [(10, 'D', 9, 'bub_dn_hist'), (11, 'A', 'bub_dn_accom'), (12, 'C', 5), (13, 'B'), (14, 'C', 15)]),
+            (3, [(6, 'C', 'pullup'), (7, 'D'), (8, 'D'), (9, 'B', 10)]),
+            (2, [(10, 'D', 9, 'bub_dn_hist'), (11, 'A', ['bub_dn_accom', 'pullup']), (12, 'C', 5), (13, 'B'), (14, 'C', 15)]),
             (1, [(15, 'C', 14), (16, 'C')]),
         ])
         expected = OrderedDict([
@@ -201,8 +201,8 @@ class TestPowerPairedDrawGeneratorParts(unittest.TestCase):
     def test_intermediate_brackets_avoid_conflicts_none(self):
         brackets = OrderedDict([
             (4, [(1, 'A'), (2, 'B'), (3, 'C'), (4, 'A'), (5, 'C', 12)]),
-            (3, [(6, 'B'), (7, 'D'), (8, 'D'), (9, 'B')]),
-            (2, [(10, 'D'), (11, 'A'), (12, 'C', 5), (13, 'B'), (14, 'C', 15)]),
+            (3, [(6, 'B', 'pullup'), (7, 'D'), (8, 'D'), (9, 'B')]),
+            (2, [(10, 'D', 'pullup'), (11, 'A'), (12, 'C', 5), (13, 'B'), (14, 'C', 15)]),
             (1, [(15, 'C', 14), (16, 'C')]),
         ])
         expected = OrderedDict([
@@ -218,8 +218,8 @@ class TestPowerPairedDrawGeneratorParts(unittest.TestCase):
     def test_intermediate_brackets_avoid_conflicts_exhaust(self):
         brackets = OrderedDict([
             (4, [(1, 'A'), (2, 'B'), (3, 'C'), (4, 'A', 'bub_up_accom'), (5, 'C', 12, 'bub_up_inst')]),
-            (3, [(6, 'C'), (7, 'D'), (8, 'D'), (9, 'B', 10, 'no_bub_updn')]),
-            (2, [(10, 'D', 9), (11, 'B'), (12, 'C', 5), (13, 'B'), (14, 'C', 15)]),
+            (3, [(6, 'C', 'pullup'), (7, 'D'), (8, 'D'), (9, 'B', 10, 'no_bub_updn')]),
+            (2, [(10, 'D', 9, 'pullup'), (11, 'B'), (12, 'C', 5), (13, 'B'), (14, 'C', 15)]),
             (1, [(15, 'C', 14), (16, 'C')]),
         ])
         expected = OrderedDict([
@@ -403,7 +403,7 @@ class TestPowerPairedDrawGenerator(unittest.TestCase):
          (5, 20, [], [], [], False),
          (10, 21, [], [], [], False),
          (16, 26, [], [], ["bub_up_hist"], True),
-         (19, 13, [], ["bub_up_accom"], [], False)]]
+         (19, 13, [], ["bub_up_accom"], ['pullup'], False)]]
 
     expected[3] = [dict(
         odd_bracket="intermediate1", pairing_method="fold", avoid_conflicts="off", side_allocations="preallocated"),


### PR DESCRIPTION
## What

Adds `pullup` flag to the team that joins an intermediate bracket from the lower bracket. 

This adds the existing `pullup` flag to that team at the point when the intermediate bracket is formed, and correctly transfers the flag if that team is later swapped out via a bubble-down conflict resolution in `intermediate_brackets_with_bubble_up_down`.

## Why

Helpful for Tab Directors handling Asian Parliamentary debates as UADC's constitution (Section 20.10) proposes preventing multiple pull-ups of a team from the lower bracket to the intermediate bracket.

Tried and tested locally